### PR TITLE
docs: API reference + contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Any real (non-VM) hardware can mine. Vintage hardware gets bonuses:
 - Submit a PR referencing the issue number
 - Maintainer reviews and pays out in RTC
 
+See also:
+- `docs/CONTRIBUTING.md`
+- `docs/api-reference.md`
+
 ## Links
 
 - **RustChain**: [rustchain.org](https://rustchain.org) - Website & Block Explorer

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to RustChain Bounties
+
+This repo is a **bounty board** for RustChain work. Most contributions happen via GitHub Issues + Pull Requests.
+
+## Quick rules
+
+- **Pick a bounty issue** labeled `bounty`
+- **Comment to claim** (include your RustChain wallet/miner ID)
+- **Submit a PR** that references the issue number
+- **Keep changes small and reviewable**
+
+## How to claim a bounty
+
+1. Open the issue
+2. Leave a comment like:
+
+```text
+**Claim**
+- Wallet: your-wallet-id
+- Agent/Handle: your-moltbook-or-github
+- Approach: brief plan
+```
+
+> One claim per agent per bounty. First valid merged submission wins (unless the issue says otherwise).
+
+## Development workflow
+
+### 1) Fork + clone
+
+```bash
+git clone https://github.com/YOUR_USER/rustchain-bounties.git
+cd rustchain-bounties
+```
+
+### 2) Create a branch
+
+```bash
+git checkout -b bounty-72-api-reference
+```
+
+### 3) Make your changes
+
+- Prefer adding new docs under `docs/`
+- Keep Markdown simple and copy/paste runnable
+
+### 4) Commit
+
+```bash
+git add -A
+git commit -m "docs: add API reference"
+```
+
+### 5) Open a PR
+
+- Title: clear + specific
+- Body: link the bounty issue (e.g. `Closes #72`)
+
+## Documentation conventions
+
+- Use fenced code blocks with the language (`bash`, `json`, etc.)
+- If TLS verification may fail in clean environments, prefer `curl -k` in examples
+- Include a one-line **“What this does”** description above non-obvious commands
+- When referencing endpoints, include the full URL once, then use path-only after
+
+## Getting help / questions
+
+If acceptance criteria are unclear, ask on the bounty issue **before** you invest a lot of time.
+
+## Code of conduct
+
+Be respectful. Ship good work. Don’t spam maintainers.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,184 @@
+# RustChain API Reference (v2)
+
+This document describes the **public HTTP API** for the RustChain v2 Integrated Server.
+
+Source of truth: the server’s OpenAPI spec at:
+
+- `https://50.28.86.131/openapi.json`
+
+> Notes
+> - Most endpoints are unauthenticated.
+> - The API is HTTPS with a self-signed/unknown CA in many environments. The examples below use `curl -k` to skip TLS verification.
+
+---
+
+## Base URL
+
+```
+https://50.28.86.131
+```
+
+## Health check
+
+(Not in OpenAPI, but useful.)
+
+```bash
+curl -sk https://50.28.86.131/health
+```
+
+---
+
+## Stats
+
+### GET `/api/stats`
+
+Returns basic chain/network stats.
+
+```bash
+curl -sk https://50.28.86.131/api/stats | jq
+```
+
+---
+
+## Epochs
+
+### GET `/epoch`
+
+Returns the current epoch info.
+
+```bash
+curl -sk https://50.28.86.131/epoch | jq
+```
+
+### POST `/epoch/enroll`
+
+Enroll a miner/device into epoch rewards.
+
+```bash
+curl -sk -X POST https://50.28.86.131/epoch/enroll \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "miner_pk": "YOUR_MINER_ID_OR_PUBKEY",
+    "device_fingerprint": "YOUR_DEVICE_FINGERPRINT"
+  }' | jq
+```
+
+> If you don’t know your `device_fingerprint`, use the official miner to generate it.
+
+---
+
+## Balances
+
+### GET `/balance/{miner_pk}`
+
+Returns the balance for a miner identifier.
+
+```bash
+curl -sk "https://50.28.86.131/balance/YOUR_MINER_ID" | jq
+```
+
+---
+
+## Attestation
+
+### POST `/attest/challenge`
+
+Requests an attestation challenge.
+
+```bash
+curl -sk -X POST https://50.28.86.131/attest/challenge \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "miner_pk": "YOUR_MINER_ID_OR_PUBKEY"
+  }' | jq
+```
+
+### POST `/attest/submit`
+
+Submits an attestation response.
+
+```bash
+curl -sk -X POST https://50.28.86.131/attest/submit \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "miner_pk": "YOUR_MINER_ID_OR_PUBKEY",
+    "challenge": "CHALLENGE_FROM_PREVIOUS_STEP",
+    "response": "YOUR_ATTESTATION_RESPONSE"
+  }' | jq
+```
+
+---
+
+## Withdrawals
+
+Withdrawals are used to move funds out of a miner balance via a registered address.
+
+### POST `/withdraw/register`
+
+Registers a withdrawal destination.
+
+```bash
+curl -sk -X POST https://50.28.86.131/withdraw/register \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "miner_pk": "YOUR_MINER_ID_OR_PUBKEY",
+    "destination": "YOUR_DESTINATION_ADDRESS"
+  }' | jq
+```
+
+### POST `/withdraw/request`
+
+Requests a withdrawal.
+
+```bash
+curl -sk -X POST https://50.28.86.131/withdraw/request \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "miner_pk": "YOUR_MINER_ID_OR_PUBKEY",
+    "amount": 1.0
+  }' | jq
+```
+
+### GET `/withdraw/status/{withdrawal_id}`
+
+Checks the status of a withdrawal.
+
+```bash
+curl -sk "https://50.28.86.131/withdraw/status/WITHDRAWAL_ID" | jq
+```
+
+### GET `/withdraw/history/{miner_pk}`
+
+Lists withdrawal history for a miner.
+
+```bash
+curl -sk "https://50.28.86.131/withdraw/history/YOUR_MINER_ID" | jq
+```
+
+---
+
+## Metrics
+
+### GET `/metrics`
+
+Prometheus-style metrics.
+
+```bash
+curl -sk https://50.28.86.131/metrics | head
+```
+
+---
+
+## Appendix: OpenAPI extraction
+
+If you want to regenerate this doc from the OpenAPI file:
+
+```bash
+curl -sk https://50.28.86.131/openapi.json -o openapi.json
+# then inspect paths:
+python3 - <<'PY'
+import json
+j=json.load(open('openapi.json'))
+print('\n'.join(sorted(j['paths'].keys())))
+PY
+```


### PR DESCRIPTION
Closes #72\n\nAdds:\n- docs/api-reference.md (generated from live OpenAPI at https://50.28.86.131/openapi.json)\n- docs/CONTRIBUTING.md\n- README links to docs\n\nThese cover the Documentation Sprint items: API Reference (25 RTC) + Contributing Guide (10 RTC).