### PR TITLE
process: add quality gate scorecard to bounty workflow templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -69,3 +69,45 @@ body:
         - File: /root/rustchain/...
         - Docs: ...
         - Related issue: #...
+
+  - type: textarea
+    id: quality_gate
+    attributes:
+      label: Quality Gate Scorecard (0-5 each)
+      description: Used by maintainers during payout review.
+      placeholder: |
+        Scoring dimensions:
+        - Impact (0-5):
+        - Correctness (0-5):
+        - Evidence (0-5):
+        - Craft (0-5):
+
+        Suggested gate:
+        - Minimum total: 13/20
+        - Correctness must be > 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: disqualifiers
+    attributes:
+      label: Global Disqualifiers
+      description: Submissions matching these can be rejected with no payout.
+      placeholder: |
+        - AI slop / template-only output
+        - Duplicate or noisy submissions
+        - Missing proof links or validation evidence
+        - Repeated low-effort near-identical content
+    validations:
+      required: true
+
+  - type: dropdown
+    id: payout_mode
+    attributes:
+      label: Payout Mode
+      description: For higher-value bounties, staged payout is recommended.
+      options:
+        - "Single payout on merge"
+        - "Staged payout (60% on merge, 40% after stability window)"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,8 +12,26 @@
 - [ ] `npm test` / `python -m pytest` / manual verification passes
 - [ ] Demo or reproduction steps provided
 
+## Evidence
+
+- Proof links (screenshots/logs/metrics):
+- Before vs after summary:
+- Validation method:
+
+## Quality Gate Self-Score (0-5)
+
+| Dimension | Score | Notes |
+|---|---:|---|
+| Impact |  |  |
+| Correctness |  |  |
+| Evidence |  |  |
+| Craft |  |  |
+
+Suggested gate for maintainers: >=13/20 total and Correctness > 0.
+
 ## Checklist
 
 - [ ] All acceptance criteria from the bounty issue are met
 - [ ] Code is tested
 - [ ] No secrets or credentials committed
+- [ ] Submission does not match any global disqualifier

--- a/README.md
+++ b/README.md
@@ -102,6 +102,31 @@ Before queueing payout:
 - Verify no duplicate/alt claims for the same action.
 - Post pending ID + tx hash in an issue comment for auditability.
 
+### Quality Gate Scorecard
+
+For consistent payout decisions, maintainers should score accepted submissions:
+
+| Dimension | Description | Range |
+|---|---|---|
+| Impact | Meaningful user/network value | 0-5 |
+| Correctness | Works as intended, no regressions | 0-5 |
+| Evidence | Proof links, logs, before/after data | 0-5 |
+| Craft | Readable changes, tests/docs where relevant | 0-5 |
+
+Suggested payout gate:
+- minimum total: `13/20`
+- `Correctness` must be greater than `0`
+
+Global disqualifiers:
+- AI slop or template-only output
+- duplicate/noise submissions
+- missing proof links
+- repeated low-effort near-identical content
+
+For bounties over `30 RTC`, staged payout is recommended:
+- `60%` on merge acceptance
+- `40%` after a short stability window (no rollback/regression)
+
 Automation:
 - `scripts/auto_triage_claims.py` builds a recurring triage report.
 - `.github/workflows/auto-triage-claims.yml` updates the payout ledger issue block.


### PR DESCRIPTION
Implements issue #134 scorecard/disqualifier process in templates and docs.\n\n- add required scorecard + disqualifiers + payout mode to bounty issue template\n- add evidence + self-score table to PR template\n- add scoring rubric and staged payout guidance to README\n\nLead for discovery track #133.