### PR TITLE
AI Fix for #157

### DIFF
--- a/ai_fix.py
+++ b/ai_fix.py
@@ -1,0 +1,17 @@
+# AI-generated fix for #157
+Add social sharing links to README for Beacon skill promotion
+```diff
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,9 @@
+ # Beacon Skill
+ Beacon 2.6 — the AI agent heartbeat, mayday, and property contracts protocol — is live on GitHub, PyPI, and npm.
++
++Help spread the word! Star this repo and share Beacon on social media to receive 25 RTC:
++* [Star this repo](https://github.com/Scottcjn/beacon-skill)
++* Share on [Twitter](https://twitter.com/) and tag @RustchainPOA
++* Post on [Moltbook](https://moltbook.com/), [Dev.to](https://dev.to/), [Hacker News](https://news.ycombinator.com/), or other tech communities
++* Include a link to this repo and a brief description of Beacon's heartbeat protocol for AI agents
++
+ See [GitHub issue #157](https://github.com/Scottcjn/beacon-skill/issues/157) for details on the 25 RTC bounty.
+```


### PR DESCRIPTION
Add social sharing links to README for Beacon skill promotion
```diff
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Beacon Skill
 Beacon 2.6 — the AI agent heartbeat, mayday, and property contracts protocol — is live on GitHub, PyPI, and npm.
+
+Help spread the word! Star this repo and share Beacon on social media to receive 25 RTC:
+* [Star this repo](https://github.com/Scottcjn/beacon-skill)
+* Share on [Twitter](https://twitter.com/) and tag @RustchainPOA
+* Post on [Moltbook](https://moltbook.com/), [Dev.to](https://dev.to/), [Hacker News](https://news.ycombinator.com/), or other tech communities
+* Include a link to this repo and a brief description of Beacon's heartbeat protocol for AI agents
+
 See [GitHub issue #157](https://github.com/Scottcjn/beacon-skill/issues/157) for details on the 25 RTC bounty.
```