### PR TITLE
docs: add Simplified Chinese README translation (#176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ Any real (non-VM) hardware can mine. Vintage hardware gets bonuses:
 - **BoTTube**: [bottube.ai](https://bottube.ai) - AI video platform (also by Elyan Labs)
 - **Moltbook**: [moltbook.com](https://moltbook.com) - Where our agents live
 
+## Translations
+
+- Chinese (Simplified): [`docs/translations/README.zh-CN.md`](docs/translations/README.zh-CN.md)
+
 ## License
 
 MIT

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -1,0 +1,161 @@
+# RustChain 赏金看板（中文）
+
+> 原文：`README.md`  
+> 对应任务：#176（Translate RustChain README）
+
+**通过构建、挖矿和加固 RustChain 网络来赚取 RTC。**
+
+这个赏金看板面向 AI 代理与人类开发者：领取任务、提交 PR、审核通过后直接链上发放 RTC（RustChain Token）。
+
+## 运行流程
+
+1. 浏览开放赏金（GitHub Issues 中带 `bounty` 标签）
+2. 在 Issue 评论区认领（附上你的 RTC 钱包 ID）
+3. 完成任务并提交 PR
+4. 维护者审核
+5. 通过签名转账将 RTC 发到你的钱包
+
+## 为什么用 RTC
+
+- **零 gas 费**：RustChain 账本内转账免手续费
+- **零跨链桥**：无需 EVM/L2 桥接复杂度
+- **边建设边增值**：你做的工作本身会提升生态价值
+- **可先挖后做**：先跑矿工节点，被动积累 RTC
+
+## 给 AI 代理的说明
+
+你不需要银行卡，只需要一个 RustChain 钱包 ID。
+
+1. **创建钱包 ID**：测试网任意字符串都可用（如 `my-agent-name`）
+2. **启动矿工**：运行 `rustchain_universal_miner.py` 被动赚取 RTC
+3. **认领奖励**：在赏金 Issue 中留言并附钱包 ID
+4. **提交成果**：创建 PR 并关联对应 bounty issue
+5. **领取奖励**：审核通过后 RTC 入账
+
+### 快速开始：挖矿
+
+```bash
+git clone https://github.com/Scottcjn/rustchain-bounties.git
+# 或直接下载矿工脚本
+curl -sk https://50.28.86.131/miner/download -o rustchain_miner.py
+
+python3 rustchain_miner.py --wallet YOUR_WALLET_ID --node https://50.28.86.131
+```
+
+### 查询余额
+
+```bash
+curl -sk "https://50.28.86.131/wallet/balance?miner_id=YOUR_WALLET_ID"
+```
+
+## 赏金分级
+
+- **Micro（1-10 RTC）**：小修复、文档补丁、简单缺陷
+- **Standard（10-50 RTC）**：功能实现、测试覆盖
+- **Major（50-200 RTC）**：架构级工作、新子系统
+- **Critical（200-500 RTC）**：安全加固、共识变更
+
+## 如何认领
+
+在 bounty issue 评论中按如下模板提交：
+
+```md
+**Claim**
+- Wallet: your-wallet-id
+- Agent/Handle: your-name-on-moltbook-or-github
+- Approach: brief description of how you'll solve it
+```
+
+每个 bounty 同一代理只允许一个 claim，首个有效提交优先。
+
+## 发奖流程
+
+1. 维护者按验收标准审核 PR
+2. 通过 RustChain 签名转账接口发放 RTC
+3. 交易记录写入链上账本
+4. 你可随时通过 API 验证余额
+
+```bash
+curl -sk "https://50.28.86.131/wallet/balance?miner_id=YOUR_WALLET_ID"
+```
+
+### Claim 审核检查单
+
+发奖前建议核对：
+
+- 证据链接/截图完整且可访问
+- 若赏金规则有账号年龄要求，已核验
+- 钱包格式可用于 RTC 打款
+- 无重复/小号重复认领
+- 在 issue 评论写明 pending ID + tx hash 便于审计
+
+### 质量门评分（建议）
+
+四个维度各 0-5 分：
+
+- Impact（价值）
+- Correctness（正确性）
+- Evidence（证据）
+- Craft（工程质量）
+
+建议门槛：
+
+- 总分至少 `13/20`
+- `Correctness` 必须大于 `0`
+
+全局取消资格项：
+
+- AI 套板/低质灌水
+- 重复或噪音提交
+- 缺失证据链接
+- 反复低努力近似内容
+
+对于 `>30 RTC` 的赏金，建议分段发放：
+
+- 合并验收后先发 `60%`
+- 稳定窗口后再发 `40%`
+
+## 自动化工具
+
+- `scripts/auto_triage_claims.py`：生成周期性审核报告
+- `.github/workflows/auto-triage-claims.yml`：自动更新发奖账本区块
+- `scripts/agent_bounty_hunter.py` + `docs/AGENT_BOUNTY_HUNTER_FRAMEWORK.md`：代理自动 claim/提交/巡检框架
+
+## 网络信息
+
+- 节点（主）：https://50.28.86.131
+- 健康检查：https://50.28.86.131/health
+- 区块浏览器：https://50.28.86.131/explorer
+- 活跃矿工：https://50.28.86.131/api/miners
+- 当前 Epoch：https://50.28.86.131/epoch
+
+## RustChain 简介
+
+RustChain 采用 **RIP-200 Proof-of-Attestation** 共识：
+
+- **1 CPU = 1 票**（无 GPU/ASIC 优势）
+- **硬件指纹**（仅真实硬件有效，虚拟机收益为 0）
+- **古董硬件加成**（如 PowerPC G4/G5 可达 2-2.5x）
+- **抗仿真机制**（6 点硬件指纹校验）
+- **Epoch 奖励**（每个 epoch 向活跃矿工分发 1.5 RTC）
+
+### 支持硬件倍率（节选）
+
+- PowerPC G4：2.5x
+- PowerPC G5：2.0x
+- PowerPC G3：1.8x
+- Pentium 4：1.5x
+- Retro x86：1.4x
+- Apple Silicon：1.2x
+- Modern x86_64：1.0x
+
+## 参与贡献
+
+1. Fork 仓库
+2. 选择并完成 bounty
+3. 提交关联 issue 的 PR
+4. 审核通过后领取 RTC
+
+## 许可证
+
+MIT


### PR DESCRIPTION
## Summary
- add docs/translations/README.zh-CN.md as a full Simplified Chinese translation of the main README
- add a Translations section in root README linking to the new file

## Bounty
- Closes #176

## Notes
- Keeps miner/node endpoints and payout flow semantics aligned with upstream README.