### PR TITLE
docs: add payout-ready checklist for faster bounty review

### DIFF
--- a/.github/workflows/bcos.yml
+++ b/.github/workflows/bcos.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           . .venv-bcos/bin/activate
           mkdir -p artifacts
-          python -m cyclonedx_py environment --format json -o artifacts/sbom_environment.json
+          python -m cyclonedx_py environment --of JSON -o artifacts/sbom_environment.json
 
       - name: Generate dependency license report
         run: |

--- a/.github/workflows/bcos.yml
+++ b/.github/workflows/bcos.yml
@@ -42,7 +42,6 @@ jobs:
               if (p.endsWith(".md")) return true;
               if (p.endsWith(".png") || p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".gif") || p.endsWith(".svg")) return true;
               if (p.endsWith(".pdf")) return true;
-              if (p.startsWith(".github/workflows/")) return true;
               return false;
             }
 

--- a/.github/workflows/bcos.yml
+++ b/.github/workflows/bcos.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           . .venv-bcos/bin/activate
           mkdir -p artifacts
-          python -m cyclonedx_py environment --of JSON -o artifacts/sbom_environment.json
+          python -m cyclonedx_py environment --format json -o artifacts/sbom_environment.json
 
       - name: Generate dependency license report
         run: |

--- a/.github/workflows/bcos.yml
+++ b/.github/workflows/bcos.yml
@@ -42,6 +42,7 @@ jobs:
               if (p.endsWith(".md")) return true;
               if (p.endsWith(".png") || p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".gif") || p.endsWith(".svg")) return true;
               if (p.endsWith(".pdf")) return true;
+              if (p.startsWith(".github/workflows/")) return true;
               return false;
             }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,18 @@ When to pick a tier:
 - Include proof for bounty-related automation (sample output or test run).
 - Avoid adding vendored blobs; prefer pulling via package managers.
 
+## Fast Claim Checklist (for paid bounties)
+
+Before opening your PR, make sure your submission is payout-ready:
+
+1. Link the bounty issue in the PR body (`Closes #<issue>` or `Refs #<issue>`).
+2. Keep the change scoped to one bounty objective.
+3. Attach evidence (logs/screenshots/CLI output) when the task is not self-evident from diff alone.
+4. Confirm CI is green (or explain any unrelated flaky failures).
+5. Add your RustChain wallet/handle exactly as requested in the issue template.
+
+This short checklist helps reviewers verify work quickly and reduces payout delays.
+
 ## Maintainer Yes/No Checkpoint (Issue #87)
 
 Before asking for payout or merge review, include this five-line packet:


### PR DESCRIPTION
## Summary
- add a short payout-ready checklist to `CONTRIBUTING.md`
- clarify minimum evidence + linking requirements for bounty PRs
- help reviewers process claims faster and reduce payout back-and-forth

## Why
Contributors frequently ask what makes a bounty PR review-ready. This checklist standardizes that expectation and speeds up claim verification.

Refs #255