### PR TITLE
triage: accept miner id wallet labels and add parser tests (English resubmission)

### DIFF
--- a/scripts/auto_triage_claims.py
+++ b/scripts/auto_triage_claims.py
@@ -194,7 +194,7 @@ def _extract_wallet(body: str) -> Optional[str]:
             continue
 
         # English label with value on next line.
-        if re.search(r"(?i)\b(?:rtc\s*)?(?:wallet|miner_id|address)\b.*[:：\-]\s*$", s):
+        if re.search(r"(?i)\b(?:rtc\s*)?(?:wallet|miner[_\-\s]?id|address)\b.*[:：\-]\s*$", s):
             expect_next = True
             continue
 
@@ -202,7 +202,7 @@ def _extract_wallet(body: str) -> Optional[str]:
         m = re.search(
             r"(?i)\b(?:payout\s*target\s*)?"
             r"(?:rtc\s*)?"
-            r"(wallet|miner_id|address)\s*"
+            r"(wallet|miner[_\-\s]?id|address)\s*"
             r"(?:\((?:miner_?id|id|address)\))?\s*[:：\-]\s*"
             r"([A-Za-z0-9_\-]{4,80})\b",
             s,

--- a/tests/test_auto_triage_claims.py
+++ b/tests/test_auto_triage_claims.py
@@ -1,0 +1,33 @@
+import unittest
+
+from scripts.auto_triage_claims import _extract_wallet, _extract_bottube_user, _has_proof_link, _looks_like_claim
+
+
+class AutoTriageClaimsTests(unittest.TestCase):
+    def test_extract_wallet_supports_miner_id_space(self):
+        body = "Claim\nMiner id: abc_123_wallet\nProof: https://example.com/proof"
+        self.assertEqual(_extract_wallet(body), "abc_123_wallet")
+
+    def test_extract_wallet_supports_miner_id_hyphen(self):
+        body = "Payout target miner-id: zk_worker_007"
+        self.assertEqual(_extract_wallet(body), "zk_worker_007")
+
+    def test_extract_wallet_supports_chinese_label(self):
+        body = "钱包地址： zh_wallet_01"
+        self.assertEqual(_extract_wallet(body), "zh_wallet_01")
+
+    def test_extract_bottube_user_from_profile_link(self):
+        body = "BoTTube profile: https://bottube.ai/@energypantry"
+        self.assertEqual(_extract_bottube_user(body), "energypantry")
+
+    def test_has_proof_link(self):
+        self.assertTrue(_has_proof_link("Demo: https://github.com/foo/bar/pull/1"))
+        self.assertFalse(_has_proof_link("No links included"))
+
+    def test_looks_like_claim(self):
+        self.assertTrue(_looks_like_claim("Claiming this bounty. Wallet: abc_123"))
+        self.assertFalse(_looks_like_claim("General discussion about roadmap and release timing."))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend wallet label parsing in `scripts/auto_triage_claims.py` to accept `miner id` and `miner-id` (in addition to `miner_id`)
- add focused unit tests in `tests/test_auto_triage_claims.py` covering wallet extraction, BoTTube user extraction, proof links, and claim detection

## Why
This is an English-only resubmission to replace a prior thread that contained non-English issue comments.

## Validation
- `python3 -m unittest tests/test_auto_triage_claims.py`
- `python3 -m unittest tests/test_agent_bounty_hunter.py`

## Supersedes
- supersedes #265
