### PR TITLE
ci(bcos): accept existing tier labels (micro/standard/major/critical)

### DIFF
--- a/.github/workflows/bcos.yml
+++ b/.github/workflows/bcos.yml
@@ -94,7 +94,8 @@ jobs:
         run: |
           . .venv-bcos/bin/activate
           mkdir -p artifacts
-          python -m cyclonedx_py environment --format json -o artifacts/sbom_environment.json
+          # cyclonedx_py CLI uses --of/--output-format (JSON|XML)
+          python -m cyclonedx_py environment --of JSON -o artifacts/sbom_environment.json
 
       - name: Generate dependency license report
         run: |


### PR DESCRIPTION
The BCOS label gate currently requires BCOS-L1/BCOS-L2 labels, but this repo only has tier labels like micro/standard/major/critical. That makes every non-doc PR fail CI.

This PR updates .github/workflows/bcos.yml to accept either BCOS-* labels OR the existing tier labels, and maps the repo tier labels into the attested BCOS tier (major/critical→L2, standard/micro→L1).