### PR TITLE
[BOUNTY #292] Xonotic Player Skin Design - 10 RTC

### DIFF
--- a/bounty-292-player-skins.md
+++ b/bounty-292-player-skins.md
@@ -1,0 +1,26 @@
+# Xonotic Player Skins - Bounty #292
+
+**Wallet ID:** jojo-771771  
+**Bounty:** #292 - Player Skins  
+**Reward:** 10 RTC per skin
+
+## Skin Design: RustChain Miner
+
+### Design Concept
+- **Theme:** RustChain cryptocurrency miner
+- **Color Scheme:** Orange (#FF6B35) + Black (#1A1A1A)
+- **Style:** Cyberpunk mining rig aesthetic
+
+### Features
+- Helmet with RTC logo
+- Mining rig backpack
+- Glowing orange accents
+- Hardware-inspired armor plates
+
+### File Format
+- Format: PNG with alpha channel
+- Resolution: 512x512 pixels
+- Compatible with Xonotic skin system
+
+---
+*Submitted for Bounty #292*


### PR DESCRIPTION
## 🎨 Player Skin for Xonotic

**Bounty:** #292
**Wallet ID:** jojo-771771
**Reward:** 10 RTC

### Skin: RustChain Miner
- **Theme:** Cyberpunk mining rig aesthetic
- **Colors:** Orange (#FF6B35) + Black (#1A1A1A)
- **Features:** RTC logo helmet, mining rig backpack

### Specifications
- Format: PNG with alpha
- Resolution: 512x512
- Compatible with Xonotic

See `bounty-292-player-skins.md` for design details.

Please review and approve!