### PR TITLE
feat: expand dynamic badges with weekly growth and categories

### DIFF
--- a/.github/scripts/generate_dynamic_badges.py
+++ b/.github/scripts/generate_dynamic_badges.py
@@ -7,6 +7,11 @@ Outputs:
 - badges/active-hunters.json
 - badges/legendary-hunters.json
 - badges/updated-at.json
+- badges/weekly-growth.json (NEW)
+- badges/top-3-hunters.json (NEW)
+- badges/category-bug-slayers.json (NEW)
+- badges/category-tutorial-titans.json (NEW)
+- badges/category-outreach-pros.json (NEW)
 - badges/hunters/<hunter>.json (per hunter)
 """
 
@@ -17,7 +22,7 @@ import datetime as dt
 import json
 import re
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Set
 
 
 def parse_args() -> argparse.Namespace:
@@ -28,8 +33,30 @@ def parse_args() -> argparse.Namespace:
 
 
 def parse_int(value: str) -> int:
-    match = re.search(r"\d+", value or "")
-    return int(match.group(0)) if match else 0
+    match = re.search(r"(\d+)", value or "")
+    return int(match.group(1)) if match else 0
+
+
+def parse_xp_from_action(action_text: str) -> int:
+    # Example: "2026-02-20 13:44 UTC (+50 XP: tutorial bonus)"
+    match = re.search(r"\+(\d+)\s*XP", action_text)
+    return int(match.group(1)) if match else 0
+
+
+def parse_date_from_action(action_text: str) -> dt.datetime | None:
+    # Example: "2026-02-20" or "2026-02-20 13:44 UTC"
+    match = re.search(r"(\d{4}-\d{2}-\d{2})", action_text)
+    if match:
+        try:
+            return dt.datetime.strptime(match.group(1), "%Y-%m-%d").replace(tzinfo=dt.UTC)
+        except ValueError:
+            return None
+    return None
+
+
+def parse_badges(cell: str) -> Set[str]:
+    # Extract names from ![Name](url)
+    return set(re.findall(r"!\[([^\]]+)\]", cell or ""))
 
 
 def parse_rows(md_text: str) -> List[Dict[str, object]]:
@@ -52,7 +79,7 @@ def parse_rows(md_text: str) -> List[Dict[str, object]]:
             continue
 
         cells = [cell.strip() for cell in line.split("|")[1:-1]]
-        if len(cells) < 9:
+        if len(cells) < 8:
             i += 1
             continue
 
@@ -68,6 +95,8 @@ def parse_rows(md_text: str) -> List[Dict[str, object]]:
             "xp": parse_int(cells[3]),
             "level": parse_int(cells[4]),
             "title": cells[5],
+            "badges": parse_badges(cells[6]),
+            "last_action": cells[7],
         }
         rows.append(row)
         i += 1
@@ -90,11 +119,23 @@ def color_for_level(level: int) -> str:
     return "blue"
 
 
-def slugify_hunter(hunter: str) -> str:
+def slugify_hunter(hunter: str, existing_slugs: Set[str]) -> str:
     value = hunter.lstrip("@").strip().lower()
     value = re.sub(r"[^a-z0-9._-]+", "-", value)
     value = value.strip("-")
-    return value or "unknown"
+    base_slug = value or "unknown"
+    
+    slug = base_slug
+    counter = 2
+    while slug in existing_slugs:
+        slug = f"{base_slug}-{counter}"
+        counter += 1
+    return slug
+
+
+def validate_badge(payload: Dict[str, object]) -> bool:
+    required = {"schemaVersion", "label", "message", "color"}
+    return all(k in payload for k in required) and payload["schemaVersion"] == 1
 
 
 def write_badge(path: Path, label: str, message: str, color: str,
@@ -107,6 +148,10 @@ def write_badge(path: Path, label: str, message: str, color: str,
         "namedLogo": named_logo,
         "logoColor": logo_color,
     }
+    
+    if not validate_badge(payload):
+        print(f"Warning: Invalid badge payload for {path}")
+        
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
@@ -126,13 +171,30 @@ def main() -> None:
     active_hunters = len(rows)
     legendary = sum(1 for row in rows if int(row["level"]) >= 10)
 
+    # Weekly Growth Calculation
+    now = dt.datetime.now(dt.UTC)
+    seven_days_ago = now - dt.timedelta(days=7)
+    weekly_xp_gain = 0
+    for row in rows:
+        action_date = parse_date_from_action(str(row["last_action"]))
+        if action_date and action_date >= seven_days_ago:
+            weekly_xp_gain += parse_xp_from_action(str(row["last_action"]))
+
+    # Top 3 Hunters
     if rows:
-        top = rows[0]
-        top_name = str(top["hunter"]).lstrip("@")
-        top_msg = f"{top_name} ({top['xp']} XP)"
+        top_3 = rows[:3]
+        top_3_names = ", ".join(str(r["hunter"]).lstrip("@") for r in top_3)
+        top_msg = f"{str(rows[0]['hunter']).lstrip('@')} ({rows[0]['xp']} XP)"
     else:
+        top_3_names = "none"
         top_msg = "none yet"
 
+    # Category Badges
+    bug_slayers = sum(1 for row in rows if "Bug Slayer" in row["badges"])
+    tutorial_titans = sum(1 for row in rows if "Tutorial Titan" in row["badges"])
+    outreach_pros = sum(1 for row in rows if "Outreach Pro" in row["badges"])
+
+    # Write Standard Badges
     write_badge(
         out_dir / "hunter-stats.json",
         label="Bounty Hunter XP",
@@ -145,6 +207,14 @@ def main() -> None:
         out_dir / "top-hunter.json",
         label="Top Hunter",
         message=top_msg,
+        color="gold" if rows else "lightgrey",
+        named_logo="crown",
+        logo_color="black" if rows else "white",
+    )
+    write_badge(
+        out_dir / "top-3-hunters.json",
+        label="Top 3 Hunters",
+        message=top_3_names,
         color="gold" if rows else "lightgrey",
         named_logo="crown",
         logo_color="black" if rows else "white",
@@ -166,12 +236,43 @@ def main() -> None:
         logo_color="black" if legendary > 0 else "white",
     )
     write_badge(
+        out_dir / "weekly-growth.json",
+        label="Weekly XP",
+        message=f"+{weekly_xp_gain}",
+        color="brightgreen" if weekly_xp_gain > 0 else "blue",
+        named_logo="trending-up",
+        logo_color="white",
+    )
+    write_badge(
         out_dir / "updated-at.json",
         label="XP Updated",
-        message=dt.datetime.now(dt.UTC).strftime("%Y-%m-%d"),
+        message=now.strftime("%Y-%m-%d"),
         color="blue",
         named_logo="clockify",
         logo_color="white",
+    )
+
+    # Category Badges
+    write_badge(
+        out_dir / "category-bug-slayers.json",
+        label="Bug Slayers",
+        message=str(bug_slayers),
+        color="darkred",
+        named_logo="bug",
+    )
+    write_badge(
+        out_dir / "category-tutorial-titans.json",
+        label="Tutorial Titans",
+        message=str(tutorial_titans),
+        color="blue",
+        named_logo="book",
+    )
+    write_badge(
+        out_dir / "category-outreach-pros.json",
+        label="Outreach Pros",
+        message=str(outreach_pros),
+        color="teal",
+        named_logo="twitter",
     )
 
     # Reset per-hunter directory before writing fresh files.
@@ -180,12 +281,15 @@ def main() -> None:
     for old_file in hunters_dir.glob("*.json"):
         old_file.unlink()
 
+    used_slugs: Set[str] = set()
     for row in rows:
         hunter = str(row["hunter"])
         xp = int(row["xp"])
         level = int(row["level"])
         title = str(row["title"])
-        slug = slugify_hunter(hunter)
+        slug = slugify_hunter(hunter, used_slugs)
+        used_slugs.add(slug)
+        
         write_badge(
             hunters_dir / f"{slug}.json",
             label=f"{hunter} XP",
@@ -200,6 +304,8 @@ def main() -> None:
         "active_hunters": active_hunters,
         "legendary_hunters": legendary,
         "top_hunter": top_msg,
+        "weekly_growth": weekly_xp_gain,
+        "bug_slayers": bug_slayers,
         "generated_files": len(list(out_dir.glob("*.json"))) + len(list((out_dir / "hunters").glob("*.json"))),
     }))
 

--- a/.github/scripts/test_badges.py
+++ b/.github/scripts/test_badges.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Test suite for generate_dynamic_badges.py"""
+
+import unittest
+import json
+import tempfile
+from pathlib import Path
+from generate_dynamic_badges import parse_rows, slugify_hunter, validate_badge, parse_xp_from_action, parse_date_from_action
+
+class TestBadgeGenerator(unittest.TestCase):
+    def test_slugify(self):
+        used = set()
+        self.assertEqual(slugify_hunter("@Alice", used), "alice")
+        used.add("alice")
+        self.assertEqual(slugify_hunter("@Alice", used), "alice-2")
+        self.assertEqual(slugify_hunter("Bob!@#", set()), "bob")
+
+    def test_parse_xp(self):
+        self.assertEqual(parse_xp_from_action("2026-02-20: +50 XP (note)"), 50)
+        self.assertEqual(parse_xp_from_action("no xp here"), 0)
+
+    def test_parse_date(self):
+        dt_val = parse_date_from_action("2026-02-20: +50 XP")
+        self.assertIsNotNone(dt_val)
+        self.assertEqual(dt_val.year, 2026)
+        self.assertEqual(dt_val.month, 2)
+        self.assertEqual(dt_val.day, 20)
+
+    def test_validate_badge(self):
+        valid = {
+            "schemaVersion": 1,
+            "label": "test",
+            "message": "msg",
+            "color": "blue"
+        }
+        self.assertTrue(validate_badge(valid))
+        self.assertFalse(validate_badge({"schemaVersion": 2}))
+        self.assertFalse(validate_badge({}))
+
+    def test_parse_rows(self):
+        md = """
+| Rank | Hunter | Wallet | Total XP | Level | Title | Badges Earned | Last Action | Notes |
+|---:|:---|:---:|---:|---:|:---|:---|:---|:---|
+| 1 | @Hunter1 | 0x123 | 500 | 3 | Title | ![First Blood](url) | 2026-02-20: +100 XP | auto |
+"""
+        rows = parse_rows(md)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["hunter"], "@Hunter1")
+        self.assertEqual(rows[0]["xp"], 500)
+        self.assertIn("First Blood", rows[0]["badges"])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bounties/XP_TRACKER.md
+++ b/bounties/XP_TRACKER.md
@@ -96,7 +96,15 @@ Welcome to the Hall of Hunters. Contributors earn XP for meaningful work and unl
 
 - Total XP: `https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/rustchain-bounties/main/badges/hunter-stats.json`
 - Top Hunter: `https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/rustchain-bounties/main/badges/top-hunter.json`
+- Top 3 Hunters: `https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/rustchain-bounties/main/badges/top-3-hunters.json`
 - Active Hunters: `https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/rustchain-bounties/main/badges/active-hunters.json`
+- Legendary Hunters: `https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/rustchain-bounties/main/badges/legendary-hunters.json`
+- Weekly Growth: `https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/rustchain-bounties/main/badges/weekly-growth.json`
+
+### Category Badges
+- Bug Slayers: `https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/rustchain-bounties/main/badges/category-bug-slayers.json`
+- Tutorial Titans: `https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/rustchain-bounties/main/badges/category-tutorial-titans.json`
+- Outreach Pros: `https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/rustchain-bounties/main/badges/category-outreach-pros.json`
 
 Per-hunter dynamic badge pattern:
 `https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/rustchain-bounties/main/badges/hunters/<hunter-slug>.json`


### PR DESCRIPTION
Fixes #310. 

Changes:
- Extended generate_dynamic_badges.py to include weekly growth and top 3 hunters.
- Added category badges for Bug Slayers, Tutorial Titans, and Outreach Pros.
- Improved per-hunter slug mapping with collision safety.
- Added validation checks for badge JSON schema.
- Updated XP_TRACKER.md with new badge endpoint documentation.
- Added unit tests for the badge generator.