### PR TITLE
fix(badges): make weekly growth deterministic by tracker date

### DIFF
--- a/tests/test_badge_gen.py
+++ b/tests/test_badge_gen.py
@@ -3,10 +3,11 @@ import json
 import unittest
 from pathlib import Path
 import sys
-import os
+import datetime as dt
 
-# Mock dependencies
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Load badge script module from .github/scripts
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / ".github" / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
 import generate_dynamic_badges
 
 class TestBadgeGenerator(unittest.TestCase):
@@ -25,8 +26,10 @@ class TestBadgeGenerator(unittest.TestCase):
             {"last_action": "2026-01-01: +500 XP"}, # Old
             {"last_action": "Invalid date"},
         ]
-        growth = generate_dynamic_badges.calculate_weekly_growth(rows)
-        # Note: Depending on current date, 2026-02-22 should be within 7 days
+        growth = generate_dynamic_badges.calculate_weekly_growth(
+            rows,
+            reference_date=dt.date(2026, 2, 23),
+        )
         self.assertEqual(growth, 100)
 
     def test_color_for_level(self):


### PR DESCRIPTION
## Summary\n- parse last_updated from ounties/XP_TRACKER.md front matter\n- use that date as the reference date for weekly growth calculation\n- make updated-at.json use the same tracker reference date\n- add regression tests for metadata parsing + weekly growth window + updated-at behavior\n- fix 	ests/test_badge_gen.py import path and remove stale hardcoded-date assumption\n\n## Why\nIssue #310 discussion called out a remaining weekly-growth date bug. Current behavior depended on runtime wall-clock date, causing drift and non-deterministic badge outputs over time.\n\nThis patch anchors weekly growth and updated-at to tracker metadata, which is deterministic for a given tracker snapshot.\n\n## Validation\npy -3.12 -m pytest tests/test_generate_dynamic_badges.py tests/test_badge_gen.py\n- 45 passed\n\n## Bounty\n- Related issue: #310\n- Contributor: @liu971227-sys\n- Payout address: RTCa320f4334e7500987bce2fa0475f089ae9cd90e3