### PR TITLE
feat: Epoch Determinism Simulator + Cross-Node Replay

### DIFF
--- a/docs/security/epoch-determinism-simulator.md
+++ b/docs/security/epoch-determinism-simulator.md
@@ -1,0 +1,25 @@
+# Epoch Determinism Simulator + Cross-Node Replay
+
+Utility script for replaying per-node attestation event streams and comparing epoch digests.
+
+## What it checks
+- deterministic sorting/replay of events per node
+- digest equality across nodes for the same epoch input
+- explicit mismatch report when divergence appears
+
+## Run
+```bash
+python3 scripts/epoch_determinism_simulator.py --input replay.json
+```
+
+## Input format
+```json
+{
+  "nodes": [
+    {
+      "node_id": "n1",
+      "events": [{"epoch": 1, "height": 10, "txid": "abc"}]
+    }
+  ]
+}
+```

--- a/scripts/epoch_determinism_simulator.py
+++ b/scripts/epoch_determinism_simulator.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Epoch determinism simulator + cross-node replay checker."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+@dataclass(frozen=True)
+class NodeResult:
+    node_id: str
+    epoch_digest: str
+    event_count: int
+
+
+def _digest_events(events: List[Dict[str, Any]]) -> str:
+    h = hashlib.sha256()
+    for ev in events:
+        norm = json.dumps(ev, sort_keys=True, separators=(",", ":"))
+        h.update(norm.encode())
+    return h.hexdigest()
+
+
+def replay_for_node(node_id: str, events: List[Dict[str, Any]]) -> NodeResult:
+    # deterministic ordering by (epoch, height, txid)
+    ordered = sorted(
+        events,
+        key=lambda e: (
+            int(e.get("epoch", 0)),
+            int(e.get("height", 0)),
+            str(e.get("txid", "")),
+        ),
+    )
+    return NodeResult(node_id=node_id, epoch_digest=_digest_events(ordered), event_count=len(ordered))
+
+
+def run(payload: Dict[str, Any]) -> Dict[str, Any]:
+    nodes = payload.get("nodes", [])
+    if not nodes:
+        raise ValueError("payload.nodes is required")
+
+    results = []
+    for node in nodes:
+        res = replay_for_node(node["node_id"], node.get("events", []))
+        results.append(res)
+
+    baseline = results[0].epoch_digest
+    mismatches = [
+        {"node_id": r.node_id, "digest": r.epoch_digest, "reason": "digest_mismatch"}
+        for r in results
+        if r.epoch_digest != baseline
+    ]
+
+    return {
+        "deterministic": len(mismatches) == 0,
+        "baseline_digest": baseline,
+        "nodes": [r.__dict__ for r in results],
+        "mismatches": mismatches,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Epoch determinism simulator")
+    ap.add_argument("--input", required=True, help="JSON payload path")
+    ap.add_argument("--output", help="output path (default stdout)")
+    args = ap.parse_args()
+
+    payload = json.loads(Path(args.input).read_text())
+    report = run(payload)
+    out = json.dumps(report, indent=2)
+    if args.output:
+        Path(args.output).write_text(out + "\n")
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_epoch_determinism_simulator.py
+++ b/tests/test_epoch_determinism_simulator.py
@@ -1,0 +1,30 @@
+from scripts.epoch_determinism_simulator import run
+
+
+def test_cross_node_replay_deterministic_when_same_events_different_order():
+    evs_a = [
+        {"epoch": 3, "height": 10, "txid": "b"},
+        {"epoch": 3, "height": 9, "txid": "a"},
+    ]
+    evs_b = list(reversed(evs_a))
+    payload = {
+        "nodes": [
+            {"node_id": "n1", "events": evs_a},
+            {"node_id": "n2", "events": evs_b},
+        ]
+    }
+    report = run(payload)
+    assert report["deterministic"] is True
+    assert report["mismatches"] == []
+
+
+def test_cross_node_replay_detects_divergence():
+    payload = {
+        "nodes": [
+            {"node_id": "n1", "events": [{"epoch": 1, "height": 1, "txid": "x"}]},
+            {"node_id": "n2", "events": [{"epoch": 1, "height": 1, "txid": "y"}]},
+        ]
+    }
+    report = run(payload)
+    assert report["deterministic"] is False
+    assert len(report["mismatches"]) == 1


### PR DESCRIPTION
Implements an epoch determinism simulator with cross-node replay checks.

### Included
- script: scripts/epoch_determinism_simulator.py
- deterministic replay sorting + digesting
- mismatch reporting for node divergence
- tests for deterministic and divergence paths
- docs: docs/security/epoch-determinism-simulator.md

Closes #474