### PR TITLE
fix: block RIP-201 bucket normalization spoofing

### DIFF
--- a/scripts/arch_validator.py
+++ b/scripts/arch_validator.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: MIT
+"""Server-side architecture validation for RustChain attestation.
+
+Fixes RIP-201: Prevents bucket normalization spoofing where a modern x86
+can claim device_arch=G4 and receive the 2.5x vintage_powerpc multiplier.
+
+Validation strategy:
+1. Cross-validate CPU brand string vs claimed device_arch
+2. Require SIMD evidence (AltiVec/vec_perm) for PowerPC claims
+3. Require cache timing profile matching architecture characteristics
+4. Classify miners into reward buckets from verified server-side features
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# --- Architecture Definitions ---
+
+ARCH_FAMILIES = {
+    "g4": "PowerPC",
+    "g5": "PowerPC",
+    "68k": "Motorola68K",
+    "486": "x86",
+    "pentium1": "x86",
+    "apple_silicon": "ARM64",
+    "modern_x86": "x86_64",
+}
+
+# CPU brand string patterns that MUST match for each family
+FAMILY_CPU_PATTERNS = {
+    "PowerPC": [
+        re.compile(r"(?i)power\s*pc"),
+        re.compile(r"(?i)power\s*mac"),
+        re.compile(r"(?i)7\d{3}"),  # 7400, 7447, 7450 etc.
+        re.compile(r"(?i)970"),  # G5
+        re.compile(r"(?i)ppc"),
+    ],
+    "Motorola68K": [
+        re.compile(r"(?i)680[0-4]0"),
+        re.compile(r"(?i)motorola"),
+        re.compile(r"(?i)68k"),
+    ],
+    "x86": [
+        re.compile(r"(?i)intel"),
+        re.compile(r"(?i)amd"),
+        re.compile(r"(?i)486"),
+        re.compile(r"(?i)pentium"),
+        re.compile(r"(?i)x86"),
+    ],
+    "x86_64": [
+        re.compile(r"(?i)intel"),
+        re.compile(r"(?i)amd"),
+        re.compile(r"(?i)ryzen"),
+        re.compile(r"(?i)xeon"),
+        re.compile(r"(?i)core\s*i[3579]"),
+        re.compile(r"(?i)x86.64"),
+    ],
+    "ARM64": [
+        re.compile(r"(?i)apple\s*m[0-9]"),
+        re.compile(r"(?i)arm"),
+        re.compile(r"(?i)aarch64"),
+    ],
+}
+
+# Patterns that MUST NOT match (anti-spoofing)
+FAMILY_REJECT_PATTERNS = {
+    "PowerPC": [
+        re.compile(r"(?i)intel"),
+        re.compile(r"(?i)amd"),
+        re.compile(r"(?i)ryzen"),
+        re.compile(r"(?i)xeon"),
+        re.compile(r"(?i)core\s*i[3579]"),
+        re.compile(r"(?i)apple\s*m[0-9]"),
+    ],
+    "Motorola68K": [
+        re.compile(r"(?i)intel"),
+        re.compile(r"(?i)amd"),
+        re.compile(r"(?i)power"),
+    ],
+    "ARM64": [
+        re.compile(r"(?i)intel"),
+        re.compile(r"(?i)amd"),
+        re.compile(r"(?i)power\s*pc"),
+    ],
+}
+
+# Required SIMD features per family
+REQUIRED_SIMD_FEATURES = {
+    "PowerPC": {"altivec", "vec_perm"},
+    "x86": {"mmx"},
+    "x86_64": {"sse2", "avx2"},
+    "ARM64": {"neon"},
+}
+
+# Cache timing profile ranges per family (p95 latency in ns)
+# PowerPC G4 has distinctly different cache characteristics than modern x86
+CACHE_TIMING_RANGES = {
+    "PowerPC": {"l1_min_ns": 1.5, "l1_max_ns": 8.0, "l2_min_ns": 10.0, "l2_max_ns": 60.0},
+    "Motorola68K": {"l1_min_ns": 5.0, "l1_max_ns": 30.0, "l2_min_ns": 30.0, "l2_max_ns": 200.0},
+    "x86": {"l1_min_ns": 1.0, "l1_max_ns": 5.0, "l2_min_ns": 5.0, "l2_max_ns": 30.0},
+    "x86_64": {"l1_min_ns": 0.5, "l1_max_ns": 4.0, "l2_min_ns": 3.0, "l2_max_ns": 20.0},
+    "ARM64": {"l1_min_ns": 0.5, "l1_max_ns": 4.0, "l2_min_ns": 3.0, "l2_max_ns": 25.0},
+}
+
+# Multipliers per arch bucket (from TOKENOMICS.md)
+ARCH_MULTIPLIERS = {
+    "g4": 2.5,
+    "g5": 2.0,
+    "68k": 3.0,
+    "486": 2.5,
+    "pentium1": 2.5,
+    "apple_silicon": 1.2,
+    "modern_x86": 1.0,
+}
+
+
+@dataclass
+class ValidationResult:
+    """Result of architecture validation."""
+    valid: bool
+    claimed_arch: str
+    verified_arch: Optional[str]
+    verified_family: Optional[str]
+    multiplier: float
+    checks: Dict[str, bool] = field(default_factory=dict)
+    reasons: List[str] = field(default_factory=list)
+
+
+def validate_cpu_brand(cpu_brand: str, claimed_family: str) -> Tuple[bool, List[str]]:
+    """Check 1: Cross-validate CPU brand string vs claimed architecture family.
+
+    Returns (passed, reasons).
+    """
+    if not cpu_brand or not cpu_brand.strip():
+        return False, ["cpu_brand is empty or missing"]
+
+    reasons = []
+    brand = cpu_brand.strip()
+
+    # Check reject patterns first — these are hard failures
+    reject_patterns = FAMILY_REJECT_PATTERNS.get(claimed_family, [])
+    for pattern in reject_patterns:
+        if pattern.search(brand):
+            reasons.append(
+                f"cpu_brand '{brand}' matches reject pattern '{pattern.pattern}' "
+                f"for family '{claimed_family}'"
+            )
+            return False, reasons
+
+    # Check that at least one positive pattern matches
+    accept_patterns = FAMILY_CPU_PATTERNS.get(claimed_family, [])
+    if accept_patterns:
+        matched = any(p.search(brand) for p in accept_patterns)
+        if not matched:
+            reasons.append(
+                f"cpu_brand '{brand}' does not match any known pattern "
+                f"for family '{claimed_family}'"
+            )
+            return False, reasons
+
+    return True, []
+
+
+def validate_simd_features(
+    reported_features: List[str],
+    claimed_family: str,
+) -> Tuple[bool, List[str]]:
+    """Check 2: Verify SIMD features match claimed architecture.
+
+    PowerPC must report AltiVec/vec_perm, not AVX2/SSE.
+    """
+    if not reported_features:
+        return False, [f"no SIMD features reported for family '{claimed_family}'"]
+
+    required = REQUIRED_SIMD_FEATURES.get(claimed_family)
+    if not required:
+        return True, []  # No specific requirement for this family
+
+    features_lower = {f.lower().strip() for f in reported_features}
+    missing = required - features_lower
+
+    if missing:
+        return False, [
+            f"missing required SIMD features for '{claimed_family}': {sorted(missing)}, "
+            f"reported: {sorted(features_lower)}"
+        ]
+
+    return True, []
+
+
+def validate_cache_timing(
+    cache_profile: Dict[str, Any],
+    claimed_family: str,
+) -> Tuple[bool, List[str]]:
+    """Check 3: Verify cache timing profile matches architecture characteristics.
+
+    PowerPC G4 has distinctly different L1/L2 latency than modern x86.
+    """
+    expected = CACHE_TIMING_RANGES.get(claimed_family)
+    if not expected:
+        return True, []  # No range defined
+
+    if not cache_profile:
+        return False, [f"no cache timing profile provided for family '{claimed_family}'"]
+
+    reasons = []
+    l1_ns = cache_profile.get("l1_latency_ns")
+    l2_ns = cache_profile.get("l2_latency_ns")
+
+    if l1_ns is not None:
+        if not (expected["l1_min_ns"] <= l1_ns <= expected["l1_max_ns"]):
+            reasons.append(
+                f"L1 latency {l1_ns}ns outside expected range "
+                f"[{expected['l1_min_ns']}, {expected['l1_max_ns']}] for '{claimed_family}'"
+            )
+
+    if l2_ns is not None:
+        if not (expected["l2_min_ns"] <= l2_ns <= expected["l2_max_ns"]):
+            reasons.append(
+                f"L2 latency {l2_ns}ns outside expected range "
+                f"[{expected['l2_min_ns']}, {expected['l2_max_ns']}] for '{claimed_family}'"
+            )
+
+    if l1_ns is None and l2_ns is None:
+        reasons.append(f"no L1/L2 latency data in cache profile for '{claimed_family}'")
+
+    return len(reasons) == 0, reasons
+
+
+def classify_arch_server_side(
+    attestation_payload: Dict[str, Any],
+) -> ValidationResult:
+    """Main entry point: classify a miner into a reward bucket from verified
+    server-side features, NOT from raw client-reported architecture strings.
+
+    This replaces the old trust-the-client approach that allowed spoofing.
+    """
+    device = attestation_payload.get("device", {})
+    fingerprint = attestation_payload.get("fingerprint", {})
+    checks_data = fingerprint.get("checks", {})
+
+    claimed_arch = device.get("arch", "").strip()
+    cpu_brand = device.get("cpu", "") or device.get("model", "")
+    claimed_family = ARCH_FAMILIES.get(claimed_arch)
+
+    # Unknown arch → reject with 1.0x
+    if not claimed_family:
+        return ValidationResult(
+            valid=False,
+            claimed_arch=claimed_arch,
+            verified_arch=None,
+            verified_family=None,
+            multiplier=1.0,
+            checks={},
+            reasons=[f"unknown architecture: '{claimed_arch}'"],
+        )
+
+    all_reasons: List[str] = []
+    check_results: Dict[str, bool] = {}
+
+    # Check 1: CPU brand vs claimed arch
+    brand_ok, brand_reasons = validate_cpu_brand(cpu_brand, claimed_family)
+    check_results["cpu_brand_match"] = brand_ok
+    all_reasons.extend(brand_reasons)
+
+    # Check 2: SIMD features
+    cpu_features = checks_data.get("cpu_features", {}).get("data", {}).get("flags", [])
+    simd_ok, simd_reasons = validate_simd_features(cpu_features, claimed_family)
+    check_results["simd_features"] = simd_ok
+    all_reasons.extend(simd_reasons)
+
+    # Check 3: Cache timing profile
+    cache_profile = checks_data.get("cache_timing", {}).get("data", {})
+    cache_ok, cache_reasons = validate_cache_timing(cache_profile, claimed_family)
+    check_results["cache_timing"] = cache_ok
+    all_reasons.extend(cache_reasons)
+
+    # Decision: ALL checks must pass for vintage multiplier
+    all_passed = brand_ok and simd_ok and cache_ok
+
+    if all_passed:
+        multiplier = ARCH_MULTIPLIERS.get(claimed_arch, 1.0)
+        return ValidationResult(
+            valid=True,
+            claimed_arch=claimed_arch,
+            verified_arch=claimed_arch,
+            verified_family=claimed_family,
+            multiplier=multiplier,
+            checks=check_results,
+            reasons=[],
+        )
+    else:
+        # Failed validation → fallback to 1.0x (no vintage bonus)
+        return ValidationResult(
+            valid=False,
+            claimed_arch=claimed_arch,
+            verified_arch=None,
+            verified_family=None,
+            multiplier=1.0,
+            checks=check_results,
+            reasons=all_reasons,
+        )

--- a/tests/test_arch_validator.py
+++ b/tests/test_arch_validator.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: MIT
+"""Tests for arch_validator — proves the spoofing vector from #551 is blocked.
+
+Key scenario: a modern x86 claims device_arch=G4 to get 2.5x multiplier.
+After the fix, this MUST be rejected and fall back to 1.0x.
+"""
+
+import unittest
+
+from scripts.arch_validator import (
+    classify_arch_server_side,
+    validate_cache_timing,
+    validate_cpu_brand,
+    validate_simd_features,
+    ValidationResult,
+)
+
+
+class TestCPUBrandValidation(unittest.TestCase):
+    """Check 1: Cross-validate CPU brand string vs claimed device_arch."""
+
+    def test_legit_g4_powerpc(self):
+        ok, reasons = validate_cpu_brand("PowerPC G4 (7447A)", "PowerPC")
+        self.assertTrue(ok)
+        self.assertEqual(reasons, [])
+
+    def test_legit_g5_powerpc(self):
+        ok, reasons = validate_cpu_brand("PowerPC G5 (970MP)", "PowerPC")
+        self.assertTrue(ok)
+
+    def test_spoofed_intel_xeon_claiming_powerpc(self):
+        """THE EXACT ATTACK FROM ISSUE #551."""
+        ok, reasons = validate_cpu_brand("Intel Xeon E5-2680", "PowerPC")
+        self.assertFalse(ok)
+        self.assertTrue(any("Intel" in r for r in reasons))
+
+    def test_spoofed_amd_ryzen_claiming_powerpc(self):
+        ok, reasons = validate_cpu_brand("AMD Ryzen 9 7950X", "PowerPC")
+        self.assertFalse(ok)
+
+    def test_spoofed_apple_silicon_claiming_powerpc(self):
+        ok, reasons = validate_cpu_brand("Apple M2 Max", "PowerPC")
+        self.assertFalse(ok)
+
+    def test_empty_cpu_brand(self):
+        ok, reasons = validate_cpu_brand("", "PowerPC")
+        self.assertFalse(ok)
+
+    def test_none_cpu_brand(self):
+        ok, reasons = validate_cpu_brand("   ", "PowerPC")
+        self.assertFalse(ok)
+
+    def test_legit_modern_x86(self):
+        ok, reasons = validate_cpu_brand("AMD Ryzen 9 7950X", "x86_64")
+        self.assertTrue(ok)
+
+    def test_legit_apple_silicon(self):
+        ok, reasons = validate_cpu_brand("Apple M2 Max", "ARM64")
+        self.assertTrue(ok)
+
+    def test_intel_claiming_arm(self):
+        ok, reasons = validate_cpu_brand("Intel Core i9-13900K", "ARM64")
+        self.assertFalse(ok)
+
+
+class TestSIMDValidation(unittest.TestCase):
+    """Check 2: SIMD features must match claimed architecture."""
+
+    def test_legit_powerpc_altivec(self):
+        ok, reasons = validate_simd_features(["altivec", "vec_perm"], "PowerPC")
+        self.assertTrue(ok)
+
+    def test_x86_avx2_claiming_powerpc(self):
+        """x86 reporting avx2 but missing altivec — must fail."""
+        ok, reasons = validate_simd_features(["avx2", "sse2"], "PowerPC")
+        self.assertFalse(ok)
+        self.assertTrue(any("altivec" in r or "vec_perm" in r for r in reasons))
+
+    def test_no_features_reported(self):
+        ok, reasons = validate_simd_features([], "PowerPC")
+        self.assertFalse(ok)
+
+    def test_none_features(self):
+        ok, reasons = validate_simd_features(None, "PowerPC")
+        self.assertFalse(ok)
+
+    def test_legit_x86_64_features(self):
+        ok, reasons = validate_simd_features(["sse2", "avx2"], "x86_64")
+        self.assertTrue(ok)
+
+    def test_legit_arm_neon(self):
+        ok, reasons = validate_simd_features(["neon"], "ARM64")
+        self.assertTrue(ok)
+
+
+class TestCacheTimingValidation(unittest.TestCase):
+    """Check 3: Cache timing must match architecture characteristics."""
+
+    def test_legit_powerpc_cache(self):
+        profile = {"l1_latency_ns": 3.0, "l2_latency_ns": 25.0}
+        ok, reasons = validate_cache_timing(profile, "PowerPC")
+        self.assertTrue(ok)
+
+    def test_modern_x86_cache_claiming_powerpc(self):
+        """Modern x86 has much faster L2 than PowerPC G4 — must fail."""
+        profile = {"l1_latency_ns": 1.0, "l2_latency_ns": 5.0}
+        ok, reasons = validate_cache_timing(profile, "PowerPC")
+        self.assertFalse(ok)
+
+    def test_no_cache_profile(self):
+        ok, reasons = validate_cache_timing({}, "PowerPC")
+        self.assertFalse(ok)
+
+    def test_none_cache_profile(self):
+        ok, reasons = validate_cache_timing(None, "PowerPC")
+        self.assertFalse(ok)
+
+    def test_legit_x86_64_cache(self):
+        profile = {"l1_latency_ns": 1.5, "l2_latency_ns": 8.0}
+        ok, reasons = validate_cache_timing(profile, "x86_64")
+        self.assertTrue(ok)
+
+
+class TestFullClassification(unittest.TestCase):
+    """End-to-end: classify_arch_server_side."""
+
+    def _make_payload(self, arch, cpu, simd_flags, cache_data=None):
+        """Helper to build attestation payloads."""
+        return {
+            "device": {
+                "family": "PowerPC" if arch in ("g4", "g5") else "x86_64",
+                "arch": arch,
+                "cpu": cpu,
+            },
+            "fingerprint": {
+                "all_passed": True,
+                "checks": {
+                    "cpu_features": {"passed": True, "data": {"flags": simd_flags}},
+                    "cache_timing": {"passed": True, "data": cache_data or {}},
+                },
+            },
+        }
+
+    def test_legit_g4_gets_2_5x(self):
+        """Legitimate PowerPC G4 should get 2.5x multiplier."""
+        payload = self._make_payload(
+            arch="g4",
+            cpu="PowerPC G4 (7447A)",
+            simd_flags=["altivec", "vec_perm"],
+            cache_data={"l1_latency_ns": 3.0, "l2_latency_ns": 25.0},
+        )
+        result = classify_arch_server_side(payload)
+        self.assertTrue(result.valid)
+        self.assertEqual(result.multiplier, 2.5)
+        self.assertEqual(result.verified_arch, "g4")
+
+    def test_spoofed_x86_as_g4_gets_1x(self):
+        """THE MAIN ATTACK: Intel Xeon claiming G4 must be rejected → 1.0x."""
+        payload = self._make_payload(
+            arch="g4",
+            cpu="Intel Xeon E5-2680 v4",
+            simd_flags=["avx2", "sse2"],
+            cache_data={"l1_latency_ns": 1.0, "l2_latency_ns": 5.0},
+        )
+        result = classify_arch_server_side(payload)
+        self.assertFalse(result.valid)
+        self.assertEqual(result.multiplier, 1.0)
+        self.assertFalse(result.checks["cpu_brand_match"])
+        self.assertFalse(result.checks["simd_features"])
+
+    def test_spoofed_ryzen_as_g4_gets_1x(self):
+        """AMD Ryzen claiming G4 must be rejected."""
+        payload = self._make_payload(
+            arch="g4",
+            cpu="AMD Ryzen 9 7950X",
+            simd_flags=["avx2", "sse2"],
+            cache_data={"l1_latency_ns": 0.8, "l2_latency_ns": 4.0},
+        )
+        result = classify_arch_server_side(payload)
+        self.assertFalse(result.valid)
+        self.assertEqual(result.multiplier, 1.0)
+
+    def test_partial_spoof_correct_brand_wrong_simd(self):
+        """Even with correct brand string, wrong SIMD → rejected."""
+        payload = self._make_payload(
+            arch="g4",
+            cpu="PowerPC G4 (7447A)",
+            simd_flags=["avx2"],  # Wrong! Should be altivec
+            cache_data={"l1_latency_ns": 3.0, "l2_latency_ns": 25.0},
+        )
+        result = classify_arch_server_side(payload)
+        self.assertFalse(result.valid)
+        self.assertEqual(result.multiplier, 1.0)
+
+    def test_partial_spoof_correct_brand_correct_simd_wrong_cache(self):
+        """Correct brand + SIMD but x86 cache timings → rejected."""
+        payload = self._make_payload(
+            arch="g4",
+            cpu="PowerPC G4 (7447A)",
+            simd_flags=["altivec", "vec_perm"],
+            cache_data={"l1_latency_ns": 0.5, "l2_latency_ns": 3.0},  # Too fast for G4
+        )
+        result = classify_arch_server_side(payload)
+        self.assertFalse(result.valid)
+        self.assertEqual(result.multiplier, 1.0)
+
+    def test_legit_modern_x86_gets_1x(self):
+        """Honest modern x86 should get 1.0x."""
+        payload = self._make_payload(
+            arch="modern_x86",
+            cpu="AMD Ryzen 9 7950X",
+            simd_flags=["sse2", "avx2"],
+            cache_data={"l1_latency_ns": 1.5, "l2_latency_ns": 8.0},
+        )
+        result = classify_arch_server_side(payload)
+        self.assertTrue(result.valid)
+        self.assertEqual(result.multiplier, 1.0)
+
+    def test_unknown_arch_gets_1x(self):
+        payload = self._make_payload(
+            arch="quantum_cpu",
+            cpu="QuantumChip",
+            simd_flags=[],
+        )
+        result = classify_arch_server_side(payload)
+        self.assertFalse(result.valid)
+        self.assertEqual(result.multiplier, 1.0)
+
+    def test_empty_payload(self):
+        result = classify_arch_server_side({})
+        self.assertFalse(result.valid)
+        self.assertEqual(result.multiplier, 1.0)
+
+    def test_legit_g5_gets_2x(self):
+        payload = self._make_payload(
+            arch="g5",
+            cpu="PowerPC G5 (970MP)",
+            simd_flags=["altivec", "vec_perm"],
+            cache_data={"l1_latency_ns": 2.5, "l2_latency_ns": 20.0},
+        )
+        result = classify_arch_server_side(payload)
+        self.assertTrue(result.valid)
+        self.assertEqual(result.multiplier, 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #554

## Changes
Server-side architecture validation module (`scripts/arch_validator.py`) that prevents bucket normalization spoofing (RIP-201).

### Three-layer validation:
1. **CPU brand cross-validation** — rejects `Intel Xeon` + `device_arch=G4`
2. **SIMD feature verification** — requires AltiVec/vec_perm for PowerPC claims
3. **Cache timing profile** — PowerPC L2 latency range differs from modern x86

Miners failing any check fall back to **1.0x multiplier** (no vintage bonus).

### Tests
30 unit tests in `tests/test_arch_validator.py`, including:
- The exact attack from #551 (Intel Xeon claiming G4 → **blocked**)
- AMD Ryzen claiming G4 → **blocked**
- Partial spoofs (correct brand but wrong SIMD) → **blocked**
- Legitimate G4/G5 → **2.5x/2.0x preserved**

```
30 passed in 0.09s
```

### Evidence
All existing tests still pass (189 passed, 10 pre-existing failures in unrelated xp_tracker module).

**BCOS-L2** (touches claim verification logic)

**Wallet:** will provide on acceptance