### PR TITLE
triage: add issue #559 target and minimum-star threshold support

### DIFF
--- a/.github/workflows/auto-triage-claims.yml
+++ b/.github/workflows/auto-triage-claims.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   triage:
-    if: github.event_name != 'issue_comment' || contains(fromJson('[74,47,87,103,122,157,158]'), github.event.issue.number)
+    if: github.event_name != 'issue_comment' || contains(fromJson('[74,47,87,103,122,157,158,559]'), github.event.issue.number)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/AUTODEV_REPORT.md
+++ b/AUTODEV_REPORT.md
@@ -1,0 +1,30 @@
+# AUTODEV Report
+
+## Issue
+- Implemented support for issue #559: **[BOUNTY: 3 RTC] Follow Scottcjn on GitHub + Star Key Repos**
+
+## Changed Files
+- `.github/workflows/auto-triage-claims.yml`
+- `scripts/auto_triage_claims.py`
+- `tests/test_auto_triage_claims.py`
+
+## What Changed
+- Added issue `#559` to auto-triage workflow trigger gating.
+- Added issue `#559` to `DEFAULT_TARGETS` in `scripts/auto_triage_claims.py`.
+- Added configurable minimum-star threshold support via `_star_blockers(...)`:
+  - Default behavior remains unchanged (all configured stars required).
+  - New behavior supports “at least N stars from M repos” using `min_required_stars`.
+- Configured issue `#559` to require stars on the key repo set with `min_required_stars: 3`.
+- Added unit tests for star blocker logic (default full requirement, threshold pass, threshold fail).
+
+## Validation Commands
+- `python3 -m unittest tests.test_auto_triage_claims`
+- `python3 -m py_compile scripts/auto_triage_claims.py`
+
+## Validation Results
+- `python3 -m unittest tests.test_auto_triage_claims` ✅ Passed (10 tests).
+- `python3 -m py_compile scripts/auto_triage_claims.py` ✅ Passed (no syntax errors).
+
+## Risks / Notes
+- Follow-verification is not yet automated in triage logic; this change covers star-threshold triage behavior for issue `#559`.
+- `min_required_stars` counts stars only across repositories listed in `required_stars` for that target.

--- a/scripts/auto_triage_claims.py
+++ b/scripts/auto_triage_claims.py
@@ -112,6 +112,23 @@ DEFAULT_TARGETS = [
         "require_proof_link": True,
         "name": "BoTTube Star + Share Why",
     },
+    {
+        "owner": "Scottcjn",
+        "repo": "rustchain-bounties",
+        "issue": 559,
+        "min_account_age_days": 30,
+        "required_stars": [
+            "bottube",
+            "rustchain-bounties",
+            "legend-of-elya-n64",
+            "ram-coffers",
+        ],
+        "min_required_stars": 3,
+        "require_wallet": True,
+        "require_bottube_username": False,
+        "require_proof_link": False,
+        "name": "Follow + Star Key Repos",
+    },
 ]
 
 MARKER_START = "<!-- auto-triage-report:start -->"
@@ -281,6 +298,29 @@ def _status_label(blockers: List[str]) -> str:
     return "eligible" if not blockers else "needs-action"
 
 
+def _star_blockers(
+    user: str,
+    required_stars: List[str],
+    star_cache: Dict[str, Set[str]],
+    min_required_stars: Optional[int] = None,
+) -> List[str]:
+    repos = list(required_stars or [])
+    if not repos:
+        return []
+
+    if min_required_stars is None:
+        min_required_stars = len(repos)
+    min_required_stars = max(0, min(int(min_required_stars), len(repos)))
+
+    if min_required_stars >= len(repos):
+        return [f"missing_star:{repo}" for repo in repos if user not in star_cache.get(repo, set())]
+
+    starred_count = sum(1 for repo in repos if user in star_cache.get(repo, set()))
+    if starred_count < min_required_stars:
+        return [f"missing_star_count:{starred_count}/{min_required_stars}"]
+    return []
+
+
 @dataclass
 class ClaimResult:
     claim_id: str
@@ -444,6 +484,7 @@ def main() -> int:
         req_payout_target = bool(target.get("require_payout_target", False))
         req_proof = bool(target.get("require_proof_link", False))
         req_stars = list(target.get("required_stars", []))
+        min_required_stars = target.get("min_required_stars")
 
         issue_ref = f"{owner}/{repo}#{issue}"
         try:
@@ -523,9 +564,14 @@ def main() -> int:
             if req_proof and not _has_proof_link(merged_body):
                 blockers.append("missing_proof_link")
 
-            for star_repo in req_stars:
-                if user not in star_cache.get(star_repo, set()):
-                    blockers.append(f"missing_star:{star_repo}")
+            blockers.extend(
+                _star_blockers(
+                    user=user,
+                    required_stars=req_stars,
+                    star_cache=star_cache,
+                    min_required_stars=min_required_stars,
+                )
+            )
 
             rows.append(
                 ClaimResult(

--- a/tests/test_auto_triage_claims.py
+++ b/tests/test_auto_triage_claims.py
@@ -8,6 +8,7 @@ from scripts.auto_triage_claims import (
     _extract_wallet,
     _has_proof_link,
     _looks_like_claim,
+    _star_blockers,
 )
 
 
@@ -79,6 +80,42 @@ class AutoTriageClaimsTests(unittest.TestCase):
         self.assertIn("#### Suspicious Claims", report)
         self.assertIn("@fresh-bot", report)
         self.assertIn("ACCOUNT_AGE", report)
+
+    def test_star_blockers_requires_every_repo_by_default(self):
+        blockers = _star_blockers(
+            user="alice",
+            required_stars=["repo-a", "repo-b"],
+            star_cache={"repo-a": {"alice"}, "repo-b": set()},
+        )
+        self.assertEqual(blockers, ["missing_star:repo-b"])
+
+    def test_star_blockers_supports_minimum_threshold(self):
+        blockers = _star_blockers(
+            user="alice",
+            required_stars=["repo-a", "repo-b", "repo-c", "repo-d"],
+            star_cache={
+                "repo-a": {"alice"},
+                "repo-b": {"alice"},
+                "repo-c": {"alice"},
+                "repo-d": set(),
+            },
+            min_required_stars=3,
+        )
+        self.assertEqual(blockers, [])
+
+    def test_star_blockers_reports_shortfall_when_below_threshold(self):
+        blockers = _star_blockers(
+            user="alice",
+            required_stars=["repo-a", "repo-b", "repo-c", "repo-d"],
+            star_cache={
+                "repo-a": {"alice"},
+                "repo-b": {"alice"},
+                "repo-c": set(),
+                "repo-d": set(),
+            },
+            min_required_stars=3,
+        )
+        self.assertEqual(blockers, ["missing_star_count:2/3"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds auto-triage support for issue #559 ([BOUNTY: 3 RTC] Follow Scottcjn on GitHub + Star Key Repos) and introduces configurable minimum-star threshold logic so targets can require "at least N stars" instead of always requiring every listed repo.

## What changed
- Added issue `#559` to the `issue_comment` allowlist in `.github/workflows/auto-triage-claims.yml` so auto-triage runs for this bounty.
- Added a new `DEFAULT_TARGETS` entry for `Scottcjn/rustchain-bounties#559` in `scripts/auto_triage_claims.py`.
- Configured `required_stars` for the key repos and set `min_required_stars: 3` for issue `#559`.
- Extracted star validation into `_star_blockers(...)` with support for optional `min_required_stars`.
- Kept backward compatibility: when `min_required_stars` is unset, behavior remains "must star all configured repos".
- Replaced inline per-repo star checks in the main triage flow with `_star_blockers(...)`.
- Added unit tests for default full-star behavior, threshold pass, and threshold shortfall reporting.
- Added `AUTODEV_REPORT.md` documenting implementation, validation, and notes.

## Validation done
- `python3 -m unittest tests.test_auto_triage_claims` ✅ Passed (10 tests).
- `python3 -m py_compile scripts/auto_triage_claims.py` ✅ Passed (no syntax errors).

## Risks / notes
- Follow verification is not yet automated in triage logic; this change focuses on star-threshold gating for issue `#559`.
- `min_required_stars` is evaluated only against repos listed in `required_stars` for that target.