### PR TITLE
feat:Prometheus Metrics Exporter — Observable RustChain

### DIFF
--- a/docs/PROMETHEUS_METRICS.md
+++ b/docs/PROMETHEUS_METRICS.md
@@ -1,0 +1,208 @@
+# Prometheus Metrics for RustChain
+
+A standalone Prometheus exporter that polls your RustChain node's JSON APIs and re-exposes them as Prometheus-compatible metrics on `GET /metrics`.
+
+**Bounty:** [#765 — Prometheus Metrics Exporter — Observable RustChain](https://github.com/RustChainOrg/rustchain-bounties/issues/765)
+
+---
+
+## Architecture
+
+```mermaid
+graph LR
+    subgraph RustChain Node
+        A["/health"] 
+        B["/epoch"]
+        C["/api/miners"]
+        D["/wallet/balance"]
+    end
+
+    E["prometheus_exporter.py<br/>:9120"] -->|polls on scrape| A
+    E -->|polls on scrape| B
+    E -->|polls on scrape| C
+    E -->|polls on scrape| D
+
+    F["Prometheus<br/>Server"] -->|scrapes /metrics| E
+    G["Grafana"] -->|queries| F
+    H["Alertmanager"] -->|alerts from| F
+```
+
+The exporter uses a **custom collector** — it fetches fresh data from the node on every Prometheus scrape.  No background threads, no stale data.
+
+---
+
+## Quick Start
+
+### 1. Install
+
+```bash
+pip install -r scripts/requirements-metrics.txt
+```
+
+### 2. Run
+
+```bash
+python scripts/prometheus_exporter.py \
+    --node-url https://50.28.86.131 \
+    --port 9120 \
+    --poll-timeout 15
+```
+
+### 3. Verify
+
+```bash
+curl http://localhost:9120/metrics
+```
+
+You should see output like:
+
+```
+# HELP rustchain_node_up Whether the RustChain node is reachable and healthy
+# TYPE rustchain_node_up gauge
+rustchain_node_up 1.0
+# HELP rustchain_node_uptime_seconds Node uptime in seconds
+# TYPE rustchain_node_uptime_seconds gauge
+rustchain_node_uptime_seconds 97760.0
+...
+```
+
+### 4. Docker (optional)
+
+```bash
+cd scripts
+docker build -f Dockerfile.metrics -t rustchain-exporter .
+docker run -d -p 9120:9120 rustchain-exporter --node-url https://50.28.86.131
+```
+
+---
+
+## CLI Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--node-url` | `https://50.28.86.131` | Base URL of the RustChain node |
+| `--port` | `9120` | Port to serve `/metrics` on |
+| `--poll-timeout` | `15` | HTTP timeout per API call (seconds) |
+| `--tracked-wallets` | `""` | Comma-separated wallet IDs to track |
+| `--verify-tls` | `false` | Verify TLS certs |
+| `--log-level` | `INFO` | Logging level |
+
+---
+
+## Exported Metrics
+
+### Node Health (from `/health`)
+
+| Metric | Type | Description |
+|---|---|---|
+| `rustchain_node_up` | gauge | 1 if node healthy, 0 otherwise |
+| `rustchain_node_uptime_seconds` | gauge | Node uptime |
+| `rustchain_node_version_info{version="..."}` | gauge | Always 1, version in label |
+| `rustchain_db_rw` | gauge | 1 if DB read-write, 0 if read-only |
+| `rustchain_backup_age_hours` | gauge | Backup age in hours |
+| `rustchain_tip_age_slots` | gauge | Tip age in slots (0 = synced) |
+
+### Epoch (from `/epoch`)
+
+| Metric | Type | Description |
+|---|---|---|
+| `rustchain_epoch_current` | gauge | Current epoch number |
+| `rustchain_epoch_slot` | gauge | Current slot in epoch |
+| `rustchain_epoch_blocks_per_epoch` | gauge | Blocks per epoch |
+| `rustchain_epoch_enrolled_miners` | gauge | Enrolled miners count |
+| `rustchain_epoch_pot_rtc` | gauge | Epoch reward pot (RTC) |
+
+### Miners (from `/api/miners`)
+
+| Metric | Type | Description |
+|---|---|---|
+| `rustchain_miners_active` | gauge | Active miner count |
+| `rustchain_miners_total` | gauge | Total miners in API response |
+| `rustchain_attestation_age_seconds{miner="..."}` | gauge | Per-miner attestation age |
+| `rustchain_miner_entropy_score{miner="..."}` | gauge | Per-miner entropy score |
+| `rustchain_miner_antiquity_multiplier{miner="..."}` | gauge | Per-miner antiquity multiplier |
+
+### Wallets (from `/wallet/balance`)
+
+| Metric | Type | Description |
+|---|---|---|
+| `rustchain_wallet_balance_rtc{wallet="..."}` | gauge | Wallet balance (RTC) |
+
+### Internal
+
+| Metric | Type | Description |
+|---|---|---|
+| `rustchain_api_request_duration_seconds` | histogram | Exporter poll latency |
+| `rustchain_scrape_errors_total{endpoint="..."}` | counter | Failed polls per endpoint |
+
+---
+
+## Prometheus Setup
+
+Add to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: "rustchain"
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["localhost:9120"]
+```
+
+A complete example config is at [`docs/prometheus/prometheus.yml`](prometheus/prometheus.yml).
+
+---
+
+## Alert Rules
+
+Import [`docs/prometheus/alert_rules.yml`](prometheus/alert_rules.yml) into your Prometheus `rule_files`:
+
+| Alert | Condition | Severity |
+|---|---|---|
+| `RustChainNodeDown` | Node unreachable for 2m | critical |
+| `RustChainDBReadOnly` | DB read-only for 1m | critical |
+| `RustChainNoActiveMiners` | Zero miners for 5m | critical |
+| `RustChainEpochStuck` | Epoch unchanged for 30m | warning |
+| `RustChainBackupStale` | Backup > 6 hours old | warning |
+| `RustChainHighAPILatency` | p95 latency > 2s for 5m | warning |
+
+---
+
+## Grafana Dashboard
+
+Import [`docs/grafana/rustchain-dashboard.json`](grafana/rustchain-dashboard.json) via Grafana → Dashboards → Import.
+
+**Panels included (10):**
+
+1. Node Status (stat)
+2. Node Uptime (stat)
+3. Current Epoch (stat)
+4. Epoch Progress (gauge)
+5. Epoch Pot RTC (stat)
+6. Enrolled Miners (stat)
+7. Active Miners Over Time (timeseries)
+8. API Latency p50/p95/p99 (timeseries)
+9. Per-Miner Attestation Age (table)
+10. Scrape Errors Rate (timeseries)
+
+---
+
+## Running Tests
+
+```bash
+python -m pytest tests/test_prometheus_metrics_exporter.py -v
+```
+
+All tests use mocked HTTP — no live node required.
+
+---
+
+## Troubleshooting
+
+| Issue | Fix |
+|---|---|
+| `Connection refused` on `:9120` | Ensure the exporter is running |
+| All metrics zero | Check `--node-url` is correct and node is reachable |
+| TLS errors | Use `--verify-tls` only if node has valid certs (default: off) |
+| Wallet metrics empty | Pass `--tracked-wallets wallet1,wallet2` |
+| High scrape latency | Increase `--poll-timeout` or check node performance |

--- a/docs/grafana/rustchain-dashboard.json
+++ b/docs/grafana/rustchain-dashboard.json
@@ -1,0 +1,768 @@
+{
+    "__inputs": [
+        {
+            "name": "DS_PROMETHEUS",
+            "label": "Prometheus",
+            "description": "Prometheus data source for RustChain metrics",
+            "type": "datasource",
+            "pluginId": "prometheus",
+            "pluginName": "Prometheus"
+        }
+    ],
+    "__requires": [
+        {
+            "type": "grafana",
+            "id": "grafana",
+            "name": "Grafana",
+            "version": "9.0.0"
+        },
+        {
+            "type": "datasource",
+            "id": "prometheus",
+            "name": "Prometheus",
+            "version": "1.0.0"
+        }
+    ],
+    "annotations": {
+        "list": []
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 1,
+    "id": null,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "id": 1,
+            "title": "Node Status",
+            "type": "stat",
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 0,
+                "y": 0
+            },
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "targets": [
+                {
+                    "expr": "rustchain_node_up",
+                    "legendFormat": "Node Up",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "mappings": [
+                        {
+                            "options": {
+                                "0": {
+                                    "text": "DOWN",
+                                    "color": "red"
+                                }
+                            },
+                            "type": "value"
+                        },
+                        {
+                            "options": {
+                                "1": {
+                                    "text": "UP",
+                                    "color": "green"
+                                }
+                            },
+                            "type": "value"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "red",
+                                "value": null
+                            },
+                            {
+                                "color": "green",
+                                "value": 1
+                            }
+                        ]
+                    },
+                    "color": {
+                        "mode": "thresholds"
+                    }
+                },
+                "overrides": []
+            },
+            "options": {
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "orientation": "auto",
+                "textMode": "auto",
+                "colorMode": "background",
+                "graphMode": "none"
+            }
+        },
+        {
+            "id": 2,
+            "title": "Node Uptime",
+            "type": "stat",
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 4,
+                "y": 0
+            },
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "targets": [
+                {
+                    "expr": "rustchain_node_uptime_seconds / 3600",
+                    "legendFormat": "Hours",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "h",
+                    "decimals": 1,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "yellow",
+                                "value": null
+                            },
+                            {
+                                "color": "green",
+                                "value": 24
+                            }
+                        ]
+                    },
+                    "color": {
+                        "mode": "thresholds"
+                    }
+                },
+                "overrides": []
+            },
+            "options": {
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "orientation": "auto",
+                "textMode": "auto",
+                "colorMode": "value",
+                "graphMode": "area"
+            }
+        },
+        {
+            "id": 3,
+            "title": "Current Epoch",
+            "type": "stat",
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 8,
+                "y": 0
+            },
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "targets": [
+                {
+                    "expr": "rustchain_epoch_current",
+                    "legendFormat": "Epoch",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "decimals": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "blue",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "color": {
+                        "mode": "thresholds"
+                    }
+                },
+                "overrides": []
+            },
+            "options": {
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "orientation": "auto",
+                "textMode": "auto",
+                "colorMode": "value",
+                "graphMode": "none"
+            }
+        },
+        {
+            "id": 4,
+            "title": "Epoch Progress",
+            "type": "gauge",
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 12,
+                "y": 0
+            },
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "targets": [
+                {
+                    "expr": "rustchain_epoch_slot / rustchain_epoch_blocks_per_epoch",
+                    "legendFormat": "Progress",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "percentunit",
+                    "min": 0,
+                    "max": 1,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "blue",
+                                "value": null
+                            },
+                            {
+                                "color": "green",
+                                "value": 0.5
+                            },
+                            {
+                                "color": "orange",
+                                "value": 0.9
+                            }
+                        ]
+                    },
+                    "color": {
+                        "mode": "thresholds"
+                    }
+                },
+                "overrides": []
+            },
+            "options": {
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "orientation": "auto",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            }
+        },
+        {
+            "id": 5,
+            "title": "Epoch Pot (RTC)",
+            "type": "stat",
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 16,
+                "y": 0
+            },
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "targets": [
+                {
+                    "expr": "rustchain_epoch_pot_rtc",
+                    "legendFormat": "Pot",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "short",
+                    "decimals": 2,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "purple",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "color": {
+                        "mode": "thresholds"
+                    }
+                },
+                "overrides": []
+            },
+            "options": {
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "orientation": "auto",
+                "textMode": "auto",
+                "colorMode": "value",
+                "graphMode": "none"
+            }
+        },
+        {
+            "id": 6,
+            "title": "Enrolled Miners",
+            "type": "stat",
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 20,
+                "y": 0
+            },
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "targets": [
+                {
+                    "expr": "rustchain_epoch_enrolled_miners",
+                    "legendFormat": "Enrolled",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "decimals": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "color": {
+                        "mode": "thresholds"
+                    }
+                },
+                "overrides": []
+            },
+            "options": {
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "orientation": "auto",
+                "textMode": "auto",
+                "colorMode": "value",
+                "graphMode": "area"
+            }
+        },
+        {
+            "id": 7,
+            "title": "Active Miners Over Time",
+            "type": "timeseries",
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 4
+            },
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "targets": [
+                {
+                    "expr": "rustchain_miners_active",
+                    "legendFormat": "Active Miners",
+                    "refId": "A"
+                },
+                {
+                    "expr": "rustchain_epoch_enrolled_miners",
+                    "legendFormat": "Enrolled Miners",
+                    "refId": "B"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "drawStyle": "line",
+                        "lineInterpolation": "smooth",
+                        "lineWidth": 2,
+                        "fillOpacity": 15,
+                        "gradientMode": "scheme",
+                        "spanNulls": true,
+                        "showPoints": "auto",
+                        "pointSize": 5,
+                        "stacking": {
+                            "mode": "none",
+                            "group": "A"
+                        },
+                        "axisPlacement": "auto",
+                        "scaleDistribution": {
+                            "type": "linear"
+                        }
+                    },
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "options": {
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                },
+                "legend": {
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "calcs": []
+                }
+            }
+        },
+        {
+            "id": 8,
+            "title": "API Request Latency (p50 / p95 / p99)",
+            "type": "timeseries",
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 4
+            },
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.50, rate(rustchain_api_request_duration_seconds_bucket[5m]))",
+                    "legendFormat": "p50",
+                    "refId": "A"
+                },
+                {
+                    "expr": "histogram_quantile(0.95, rate(rustchain_api_request_duration_seconds_bucket[5m]))",
+                    "legendFormat": "p95",
+                    "refId": "B"
+                },
+                {
+                    "expr": "histogram_quantile(0.99, rate(rustchain_api_request_duration_seconds_bucket[5m]))",
+                    "legendFormat": "p99",
+                    "refId": "C"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "s",
+                    "custom": {
+                        "drawStyle": "line",
+                        "lineInterpolation": "smooth",
+                        "lineWidth": 2,
+                        "fillOpacity": 10,
+                        "gradientMode": "scheme",
+                        "spanNulls": true,
+                        "showPoints": "never",
+                        "stacking": {
+                            "mode": "none",
+                            "group": "A"
+                        },
+                        "axisPlacement": "auto",
+                        "scaleDistribution": {
+                            "type": "linear"
+                        }
+                    },
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "yellow",
+                                "value": 1
+                            },
+                            {
+                                "color": "red",
+                                "value": 2
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "options": {
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                },
+                "legend": {
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "calcs": [
+                        "mean",
+                        "max"
+                    ]
+                }
+            }
+        },
+        {
+            "id": 9,
+            "title": "Per-Miner Attestation Age",
+            "type": "table",
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 12
+            },
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "targets": [
+                {
+                    "expr": "rustchain_attestation_age_seconds",
+                    "legendFormat": "{{ miner }}",
+                    "refId": "A",
+                    "format": "table",
+                    "instant": true
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": "auto",
+                        "displayMode": "auto"
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value"
+                        },
+                        "properties": [
+                            {
+                                "id": "unit",
+                                "value": "s"
+                            },
+                            {
+                                "id": "displayName",
+                                "value": "Attestation Age"
+                            },
+                            {
+                                "id": "thresholds",
+                                "value": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "yellow",
+                                            "value": 300
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 600
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "custom.displayMode",
+                                "value": "color-background"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "miner"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "Miner ID"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Time"
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.hidden",
+                                "value": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            "options": {
+                "showHeader": true,
+                "sortBy": [
+                    {
+                        "displayName": "Attestation Age",
+                        "desc": true
+                    }
+                ]
+            },
+            "transformations": [
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {
+                            "__name__": true,
+                            "instance": true,
+                            "job": true
+                        },
+                        "indexByName": {},
+                        "renameByName": {}
+                    }
+                }
+            ]
+        },
+        {
+            "id": 10,
+            "title": "Scrape Errors Rate",
+            "type": "timeseries",
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 12
+            },
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "targets": [
+                {
+                    "expr": "rate(rustchain_scrape_errors_total[5m])",
+                    "legendFormat": "{{ endpoint }}",
+                    "refId": "A"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "ops",
+                    "custom": {
+                        "drawStyle": "bars",
+                        "lineWidth": 1,
+                        "fillOpacity": 50,
+                        "gradientMode": "scheme",
+                        "spanNulls": false,
+                        "showPoints": "never",
+                        "stacking": {
+                            "mode": "normal",
+                            "group": "A"
+                        },
+                        "axisPlacement": "auto",
+                        "scaleDistribution": {
+                            "type": "linear"
+                        }
+                    },
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 0.1
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "options": {
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                },
+                "legend": {
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "calcs": []
+                }
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 37,
+    "style": "dark",
+    "tags": [
+        "rustchain",
+        "blockchain",
+        "monitoring"
+    ],
+    "templating": {
+        "list": []
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "RustChain Network Dashboard",
+    "uid": "rustchain-network-overview",
+    "version": 1,
+    "weekStart": ""
+}

--- a/docs/prometheus/alert_rules.yml
+++ b/docs/prometheus/alert_rules.yml
@@ -1,0 +1,78 @@
+# RustChain Prometheus Alert Rules
+# Bounty #765 — Observable RustChain
+#
+# Import these into your Prometheus server's rule_files configuration.
+# See docs/PROMETHEUS_METRICS.md for setup instructions.
+
+groups:
+  - name: rustchain_alerts
+    rules:
+      # ── Critical ──────────────────────────────────────────────────────
+
+      - alert: RustChainNodeDown
+        expr: rustchain_node_up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "RustChain node is unreachable"
+          description: >-
+            The RustChain node has been down for more than 2 minutes.
+            Check the node process and network connectivity.
+
+      - alert: RustChainDBReadOnly
+        expr: rustchain_db_rw == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "RustChain database is read-only"
+          description: >-
+            The node's database has been in read-only mode for over 1 minute.
+            This typically indicates a disk full condition or filesystem error.
+
+      - alert: RustChainNoActiveMiners
+        expr: rustchain_miners_active == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No active miners on the network"
+          description: >-
+            Zero miners have been active for over 5 minutes.
+            This may indicate a network-wide issue or node isolation.
+
+      # ── Warning ───────────────────────────────────────────────────────
+
+      - alert: RustChainEpochStuck
+        expr: changes(rustchain_epoch_current[30m]) == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Epoch has not advanced in 30 minutes"
+          description: >-
+            The epoch counter has not changed in the last 30 minutes.
+            This may indicate a stalled chain or node sync issue.
+
+      - alert: RustChainBackupStale
+        expr: rustchain_backup_age_hours > 6
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Database backup is stale (>6 hours old)"
+          description: >-
+            The latest database backup is {{ $value | printf "%.1f" }} hours old.
+            Verify the backup cron job is running.
+
+      - alert: RustChainHighAPILatency
+        expr: histogram_quantile(0.95, rate(rustchain_api_request_duration_seconds_bucket[5m])) > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High API latency on RustChain node"
+          description: >-
+            The 95th percentile API latency is above 2 seconds.
+            The node may be under heavy load or experiencing resource contention.

--- a/docs/prometheus/prometheus.yml
+++ b/docs/prometheus/prometheus.yml
@@ -1,0 +1,39 @@
+# Prometheus scrape configuration for the RustChain exporter
+# Bounty #765 — Observable RustChain
+#
+# Add this to your prometheus.yml under scrape_configs.
+# See docs/PROMETHEUS_METRICS.md for full setup instructions.
+
+# Example: paste this block into your existing prometheus.yml
+# (or use this file as a standalone prometheus.yml for testing)
+
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+rule_files:
+  - "alert_rules.yml"
+
+scrape_configs:
+  - job_name: "rustchain"
+    scrape_interval: 30s
+    scrape_timeout: 20s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["localhost:9120"]
+        labels:
+          instance: "rustchain-primary"
+          environment: "production"
+
+    # Optional: relabel to make instance labels cleaner in dashboards
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __address__
+        replacement: "localhost:9120"
+
+  # If you run multiple exporters (one per node), add more targets:
+  # - job_name: "rustchain-secondary"
+  #   static_configs:
+  #     - targets: ["secondary-host:9120"]
+  #       labels:
+  #         instance: "rustchain-secondary"

--- a/scripts/Dockerfile.metrics
+++ b/scripts/Dockerfile.metrics
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+LABEL maintainer="rustchain-community"
+LABEL description="Prometheus metrics exporter for RustChain nodes"
+
+WORKDIR /app
+
+COPY requirements-metrics.txt .
+RUN pip install --no-cache-dir -r requirements-metrics.txt
+
+COPY prometheus_exporter.py .
+
+EXPOSE 9120
+
+ENTRYPOINT ["python", "prometheus_exporter.py"]
+CMD ["--port", "9120"]

--- a/scripts/prometheus_exporter.py
+++ b/scripts/prometheus_exporter.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""Prometheus metrics exporter for RustChain nodes.
+
+A standalone sidecar that polls the RustChain node JSON APIs and
+re-exposes them as Prometheus-compatible metrics on GET /metrics.
+
+Usage:
+    python prometheus_exporter.py --node-url https://50.28.86.131 --port 9120
+
+Architecture:
+    Uses a custom Prometheus collector (RustChainCollector) that fetches
+    fresh data from the node on every scrape — no background threads,
+    no stale data.  This is the standard exporter pattern used by
+    node_exporter, blackbox_exporter, etc.
+
+Bounty: #765 — Prometheus Metrics Exporter — Observable RustChain
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import ssl
+import time
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.error import HTTPError, URLError
+
+from prometheus_client import CollectorRegistry, start_http_server
+from prometheus_client.core import (
+    CounterMetricFamily,
+    GaugeMetricFamily,
+    HistogramMetricFamily,
+)
+
+logger = logging.getLogger("rustchain_exporter")
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+DEFAULT_NODE_URL = "https://50.28.86.131"
+DEFAULT_PORT = 9120
+DEFAULT_POLL_TIMEOUT = 15
+
+# Histogram bucket boundaries for API latency
+LATENCY_BUCKETS = (0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0)
+
+
+def _request_json(
+    url: str,
+    timeout_s: int = DEFAULT_POLL_TIMEOUT,
+    verify_tls: bool = False,
+) -> Tuple[Optional[Any], Optional[str], float]:
+    """Fetch JSON from *url*.  Returns (data, error_string, elapsed_seconds)."""
+    ctx = None
+    if url.startswith("https://") and not verify_tls:
+        ctx = ssl._create_unverified_context()
+
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/json")
+    req.add_header("User-Agent", "rustchain-prometheus-exporter/1.0")
+
+    t0 = time.monotonic()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s, context=ctx) as resp:
+            raw = resp.read().decode("utf-8")
+        elapsed = time.monotonic() - t0
+        try:
+            return json.loads(raw), None, elapsed
+        except json.JSONDecodeError:
+            return None, "invalid_json", elapsed
+    except HTTPError as exc:
+        return None, f"http_{exc.code}", time.monotonic() - t0
+    except URLError as exc:
+        return None, f"url_error:{exc.reason}", time.monotonic() - t0
+    except TimeoutError:
+        return None, "timeout", time.monotonic() - t0
+    except Exception as exc:  # pragma: no cover — defensive
+        return None, f"error:{type(exc).__name__}", time.monotonic() - t0
+
+
+def fetch_endpoint(
+    base_url: str,
+    path: str,
+    timeout_s: int = DEFAULT_POLL_TIMEOUT,
+    verify_tls: bool = False,
+) -> Tuple[Optional[Any], Optional[str], float]:
+    """Fetch a RustChain API endpoint.  Thin wrapper around _request_json."""
+    url = f"{base_url.rstrip('/')}{path}"
+    return _request_json(url, timeout_s=timeout_s, verify_tls=verify_tls)
+
+
+def fetch_wallet_balance(
+    base_url: str,
+    miner_id: str,
+    timeout_s: int = DEFAULT_POLL_TIMEOUT,
+    verify_tls: bool = False,
+) -> Tuple[Optional[Dict[str, Any]], Optional[str], float]:
+    """Fetch balance for a single wallet."""
+    encoded = urllib.parse.quote(miner_id, safe="")
+    url = f"{base_url.rstrip('/')}/wallet/balance?miner_id={encoded}"
+    return _request_json(url, timeout_s=timeout_s, verify_tls=verify_tls)
+
+
+# ---------------------------------------------------------------------------
+# Custom Prometheus Collector
+# ---------------------------------------------------------------------------
+
+
+class RustChainCollector:
+    """Custom collector called by prometheus_client on every ``/metrics`` scrape.
+
+    Each call to :meth:`collect` makes fresh HTTP requests to the node,
+    guaranteeing that Prometheus never receives stale data.
+
+    All metrics (including the API latency histogram) are yielded from
+    ``collect()`` as MetricFamily objects.  Nothing is registered in the
+    global default registry, so multiple instances can coexist safely
+    (e.g. in tests).
+    """
+
+    def __init__(
+        self,
+        node_url: str = DEFAULT_NODE_URL,
+        poll_timeout: int = DEFAULT_POLL_TIMEOUT,
+        verify_tls: bool = False,
+        tracked_wallets: Optional[List[str]] = None,
+    ) -> None:
+        self.node_url = node_url.rstrip("/")
+        self.poll_timeout = poll_timeout
+        self.verify_tls = verify_tls
+        self.tracked_wallets: List[str] = tracked_wallets or []
+
+        # Persistent state across scrapes
+        self._scrape_errors: Dict[str, int] = {}
+
+        # Manual histogram accumulator: {endpoint: [observation, ...]}
+        self._latency_observations: Dict[str, List[float]] = {}
+
+    # ---- helpers -----------------------------------------------------------
+
+    def _record_latency(self, endpoint: str, elapsed: float) -> None:
+        self._latency_observations.setdefault(endpoint, []).append(elapsed)
+
+    def _fetch(self, path: str) -> Tuple[Optional[Any], Optional[str]]:
+        data, err, elapsed = fetch_endpoint(
+            self.node_url,
+            path,
+            timeout_s=self.poll_timeout,
+            verify_tls=self.verify_tls,
+        )
+        self._record_latency(path, elapsed)
+        if err:
+            self._scrape_errors[path] = self._scrape_errors.get(path, 0) + 1
+            logger.warning("scrape error on %s: %s", path, err)
+        return data, err
+
+    def _fetch_balance(self, wallet: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        data, err, elapsed = fetch_wallet_balance(
+            self.node_url,
+            wallet,
+            timeout_s=self.poll_timeout,
+            verify_tls=self.verify_tls,
+        )
+        self._record_latency("/wallet/balance", elapsed)
+        if err:
+            ep = f"/wallet/balance?miner_id={wallet}"
+            self._scrape_errors[ep] = self._scrape_errors.get(ep, 0) + 1
+            logger.warning("scrape error on /wallet/balance miner_id=%s: %s", wallet, err)
+        return data, err
+
+    def _build_histogram_family(self) -> HistogramMetricFamily:
+        """Build a HistogramMetricFamily from accumulated latency observations."""
+        hist = HistogramMetricFamily(
+            "rustchain_api_request_duration_seconds",
+            "Latency of the exporter's own HTTP polls to the RustChain node",
+            labels=["endpoint"],
+        )
+        for endpoint, observations in self._latency_observations.items():
+            buckets = []
+            for bound in LATENCY_BUCKETS:
+                count = sum(1 for obs in observations if obs <= bound)
+                buckets.append([str(bound), count])
+            total_sum = sum(observations)
+            total_count = len(observations)
+            hist.add_metric(
+                [endpoint], buckets, sum_value=total_sum
+            )
+        return hist
+
+    # ---- main collect ------------------------------------------------------
+
+    def collect(self):  # noqa: C901 — complexity driven by metric count
+        """Yield Prometheus metric families.  Called on every scrape."""
+
+        # -- 1.  Fetch data --------------------------------------------------
+        health, health_err = self._fetch("/health")
+        epoch, epoch_err = self._fetch("/epoch")
+        miners_list, miners_err = self._fetch("/api/miners")
+
+        # -- 2.  Node health metrics -----------------------------------------
+        node_up = GaugeMetricFamily(
+            "rustchain_node_up",
+            "Whether the RustChain node is reachable and healthy (1=up, 0=down)",
+        )
+        if isinstance(health, dict) and health.get("ok"):
+            node_up.add_metric([], 1)
+        else:
+            node_up.add_metric([], 0)
+        yield node_up
+
+        uptime = GaugeMetricFamily(
+            "rustchain_node_uptime_seconds",
+            "Node uptime in seconds",
+        )
+        if isinstance(health, dict) and health.get("uptime_s") is not None:
+            uptime.add_metric([], float(health["uptime_s"]))
+        yield uptime
+
+        version_info = GaugeMetricFamily(
+            "rustchain_node_version_info",
+            "Node version (always 1, version in label)",
+            labels=["version"],
+        )
+        if isinstance(health, dict) and health.get("version"):
+            version_info.add_metric([str(health["version"])], 1)
+        yield version_info
+
+        db_rw = GaugeMetricFamily(
+            "rustchain_db_rw",
+            "Whether the database is read-write (1=rw, 0=ro)",
+        )
+        if isinstance(health, dict) and health.get("db_rw") is not None:
+            db_rw.add_metric([], 1 if health["db_rw"] else 0)
+        yield db_rw
+
+        backup_age = GaugeMetricFamily(
+            "rustchain_backup_age_hours",
+            "Age of the latest database backup in hours",
+        )
+        if isinstance(health, dict) and health.get("backup_age_hours") is not None:
+            backup_age.add_metric([], float(health["backup_age_hours"]))
+        yield backup_age
+
+        tip_age = GaugeMetricFamily(
+            "rustchain_tip_age_slots",
+            "Age of the blockchain tip in slots (0 = fully synced)",
+        )
+        if isinstance(health, dict) and health.get("tip_age_slots") is not None:
+            tip_age.add_metric([], float(health["tip_age_slots"]))
+        yield tip_age
+
+        # -- 3.  Epoch metrics -----------------------------------------------
+        epoch_current = GaugeMetricFamily(
+            "rustchain_epoch_current",
+            "Current epoch number",
+        )
+        if isinstance(epoch, dict) and epoch.get("epoch") is not None:
+            epoch_current.add_metric([], float(epoch["epoch"]))
+        yield epoch_current
+
+        epoch_slot = GaugeMetricFamily(
+            "rustchain_epoch_slot",
+            "Current slot number within the epoch",
+        )
+        if isinstance(epoch, dict) and epoch.get("slot") is not None:
+            epoch_slot.add_metric([], float(epoch["slot"]))
+        yield epoch_slot
+
+        blocks_per_epoch = GaugeMetricFamily(
+            "rustchain_epoch_blocks_per_epoch",
+            "Number of blocks per epoch",
+        )
+        if isinstance(epoch, dict) and epoch.get("blocks_per_epoch") is not None:
+            blocks_per_epoch.add_metric([], float(epoch["blocks_per_epoch"]))
+        yield blocks_per_epoch
+
+        enrolled = GaugeMetricFamily(
+            "rustchain_epoch_enrolled_miners",
+            "Number of miners enrolled in the current epoch",
+        )
+        if isinstance(epoch, dict) and epoch.get("enrolled_miners") is not None:
+            enrolled.add_metric([], float(epoch["enrolled_miners"]))
+        yield enrolled
+
+        pot = GaugeMetricFamily(
+            "rustchain_epoch_pot_rtc",
+            "Epoch reward pot in RTC",
+        )
+        if isinstance(epoch, dict) and epoch.get("epoch_pot") is not None:
+            pot.add_metric([], float(epoch["epoch_pot"]))
+        yield pot
+
+        # -- 4.  Miner metrics -----------------------------------------------
+        miners_active = GaugeMetricFamily(
+            "rustchain_miners_active",
+            "Number of currently active (attesting) miners",
+        )
+        miners_data: list = []
+        if isinstance(miners_list, list):
+            miners_data = miners_list
+            miners_active.add_metric([], float(len(miners_data)))
+        else:
+            miners_active.add_metric([], 0)
+        yield miners_active
+
+        miners_total = GaugeMetricFamily(
+            "rustchain_miners_total",
+            "Total number of miners seen in the API response",
+        )
+        miners_total.add_metric([], float(len(miners_data)))
+        yield miners_total
+
+        # Per-miner metrics
+        now_ts = time.time()
+
+        attest_age = GaugeMetricFamily(
+            "rustchain_attestation_age_seconds",
+            "Seconds since the miner last attested",
+            labels=["miner"],
+        )
+        entropy = GaugeMetricFamily(
+            "rustchain_miner_entropy_score",
+            "Entropy score of the miner's hardware fingerprint",
+            labels=["miner"],
+        )
+        antiquity = GaugeMetricFamily(
+            "rustchain_miner_antiquity_multiplier",
+            "Antiquity reward multiplier for the miner",
+            labels=["miner"],
+        )
+
+        for m in miners_data:
+            miner_id = str(m.get("miner", "unknown"))
+            last = m.get("last_attest")
+            if last is not None:
+                try:
+                    age = max(0.0, now_ts - float(last))
+                    attest_age.add_metric([miner_id], age)
+                except (TypeError, ValueError):
+                    pass
+
+            es = m.get("entropy_score")
+            if es is not None:
+                try:
+                    entropy.add_metric([miner_id], float(es))
+                except (TypeError, ValueError):
+                    pass
+
+            aq = m.get("antiquity_multiplier")
+            if aq is not None:
+                try:
+                    antiquity.add_metric([miner_id], float(aq))
+                except (TypeError, ValueError):
+                    pass
+
+        yield attest_age
+        yield entropy
+        yield antiquity
+
+        # -- 5.  Wallet / balance metrics ------------------------------------
+        wallet_balance = GaugeMetricFamily(
+            "rustchain_wallet_balance_rtc",
+            "Wallet balance in RTC",
+            labels=["wallet"],
+        )
+        for wallet_name in self.tracked_wallets:
+            bal_data, bal_err = self._fetch_balance(wallet_name)
+            if isinstance(bal_data, dict) and bal_data.get("amount_rtc") is not None:
+                try:
+                    wallet_balance.add_metric(
+                        [wallet_name], float(bal_data["amount_rtc"])
+                    )
+                except (TypeError, ValueError):
+                    pass
+        yield wallet_balance
+
+        # -- 6.  API latency histogram ---------------------------------------
+        yield self._build_histogram_family()
+
+        # -- 7.  Scrape error counter ----------------------------------------
+        scrape_errors = CounterMetricFamily(
+            "rustchain_scrape_errors_total",
+            "Total number of failed scrapes per endpoint",
+            labels=["endpoint"],
+        )
+        for ep, count in self._scrape_errors.items():
+            scrape_errors.add_metric([ep], float(count))
+        yield scrape_errors
+
+
+# ---------------------------------------------------------------------------
+# CLI & entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: Optional[list] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Prometheus metrics exporter for RustChain nodes",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--node-url",
+        default=DEFAULT_NODE_URL,
+        help="Base URL of the RustChain node to scrape",
+    )
+    p.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help="Port to serve /metrics on",
+    )
+    p.add_argument(
+        "--poll-timeout",
+        type=int,
+        default=DEFAULT_POLL_TIMEOUT,
+        help="HTTP request timeout in seconds for each node API call",
+    )
+    p.add_argument(
+        "--tracked-wallets",
+        default="",
+        help="Comma-separated wallet IDs to track balances for",
+    )
+    p.add_argument(
+        "--verify-tls",
+        action="store_true",
+        help="Verify TLS certificates (off by default — official node uses self-signed TLS)",
+    )
+    p.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Optional[list] = None) -> None:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    wallets = [w.strip() for w in args.tracked_wallets.split(",") if w.strip()]
+
+    collector = RustChainCollector(
+        node_url=args.node_url,
+        poll_timeout=args.poll_timeout,
+        verify_tls=args.verify_tls,
+        tracked_wallets=wallets,
+    )
+
+    # Register in the default REGISTRY used by start_http_server
+    from prometheus_client import REGISTRY
+
+    REGISTRY.register(collector)
+
+    logger.info(
+        "Starting RustChain Prometheus exporter on :%d (node=%s)",
+        args.port,
+        args.node_url,
+    )
+    start_http_server(args.port)
+
+    # Block forever
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        logger.info("Shutting down.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements-metrics.txt
+++ b/scripts/requirements-metrics.txt
@@ -1,0 +1,2 @@
+# Requirements for the Prometheus metrics exporter (scripts/prometheus_exporter.py)
+prometheus-client>=0.17.0,<1.0.0

--- a/tests/test_prometheus_metrics_exporter.py
+++ b/tests/test_prometheus_metrics_exporter.py
@@ -1,0 +1,345 @@
+"""Unit tests for the RustChain Prometheus metrics exporter.
+
+All tests use mocked HTTP responses — no live node required.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from prometheus_client import CollectorRegistry, generate_latest
+
+from scripts.prometheus_exporter import RustChainCollector, fetch_endpoint
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic JSON responses from the RustChain node
+# ---------------------------------------------------------------------------
+
+HEALTH_OK = {
+    "backup_age_hours": 0.08,
+    "db_rw": True,
+    "ok": True,
+    "tip_age_slots": 0,
+    "uptime_s": 97760,
+    "version": "2.2.1-rip200",
+}
+
+EPOCH_OK = {
+    "blocks_per_epoch": 144,
+    "enrolled_miners": 22,
+    "epoch": 94,
+    "epoch_pot": 1.5,
+    "slot": 13580,
+}
+
+MINERS_OK = [
+    {
+        "miner": "dual-g4-125",
+        "hardware_type": "Vintage PowerPC",
+        "device_arch": "ppc",
+        "device_family": "PowerMac G4",
+        "antiquity_multiplier": 2.5,
+        "last_attest": int(time.time()) - 300,
+        "entropy_score": 0.87,
+    },
+    {
+        "miner": "victus-x86-scott",
+        "hardware_type": "Modern x86-64",
+        "device_arch": "x86_64",
+        "device_family": "HP Victus",
+        "antiquity_multiplier": 1.0,
+        "last_attest": int(time.time()) - 60,
+        "entropy_score": 0.92,
+    },
+]
+
+WALLET_OK = {
+    "amount_i64": 8231900000,
+    "amount_rtc": 82319.0,
+    "miner_id": "founder_community",
+}
+
+
+def _make_collector(
+    health=HEALTH_OK,
+    epoch=EPOCH_OK,
+    miners=MINERS_OK,
+    wallet=WALLET_OK,
+    health_err=None,
+    epoch_err=None,
+    miners_err=None,
+    wallet_err=None,
+    tracked_wallets=None,
+):
+    """Create a RustChainCollector with mocked HTTP calls."""
+
+    def mock_fetch(base_url, path, timeout_s=15, verify_tls=False):
+        mapping = {
+            "/health": (health, health_err, 0.01),
+            "/epoch": (epoch, epoch_err, 0.01),
+            "/api/miners": (miners, miners_err, 0.01),
+        }
+        return mapping.get(path, (None, "unknown_path", 0.01))
+
+    def mock_wallet_fetch(base_url, miner_id, timeout_s=15, verify_tls=False):
+        if wallet_err:
+            return None, wallet_err, 0.01
+        return wallet, None, 0.01
+
+    collector = RustChainCollector(
+        node_url="http://mock-node:8099",
+        poll_timeout=5,
+        tracked_wallets=tracked_wallets or [],
+    )
+
+    # Patch the module-level fetch functions
+    collector._orig_fetch = collector._fetch
+    collector._orig_fetch_balance = collector._fetch_balance
+
+    def patched_fetch(path):
+        data, err, elapsed = mock_fetch(collector.node_url, path)
+        if err:
+            collector._scrape_errors[path] = collector._scrape_errors.get(path, 0) + 1
+        return data, err
+
+    def patched_fetch_balance(wallet_name):
+        data, err, elapsed = mock_wallet_fetch(collector.node_url, wallet_name)
+        if err:
+            ep = f"/wallet/balance?miner_id={wallet_name}"
+            collector._scrape_errors[ep] = collector._scrape_errors.get(ep, 0) + 1
+        return data, err
+
+    collector._fetch = patched_fetch
+    collector._fetch_balance = patched_fetch_balance
+
+    return collector
+
+
+def _collect_to_text(collector):
+    """Run the collector and return Prometheus text exposition format."""
+    registry = CollectorRegistry()
+    registry.register(collector)
+    return generate_latest(registry).decode("utf-8")
+
+
+def _metric_value(text: str, metric_name: str) -> str | None:
+    """Extract the value of a metric line from Prometheus text output."""
+    for line in text.splitlines():
+        if line.startswith(metric_name + " ") or line.startswith(metric_name + "{"):
+            # e.g. "rustchain_node_up 1.0" → "1.0"
+            return line.rsplit(" ", 1)[-1]
+    return None
+
+
+def _metric_lines(text: str, prefix: str) -> list[str]:
+    """Return all lines starting with a given metric prefix."""
+    return [
+        line
+        for line in text.splitlines()
+        if line.startswith(prefix) and not line.startswith("# ")
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TestHealthMetrics(unittest.TestCase):
+    def test_node_up_when_healthy(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(_metric_value(text, "rustchain_node_up"), "1.0")
+
+    def test_node_up_zero_when_down(self):
+        text = _collect_to_text(_make_collector(health=None, health_err="timeout"))
+        self.assertEqual(_metric_value(text, "rustchain_node_up"), "0.0")
+
+    def test_uptime_seconds(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(_metric_value(text, "rustchain_node_uptime_seconds"), "97760.0")
+
+    def test_version_info_label(self):
+        text = _collect_to_text(_make_collector())
+        lines = _metric_lines(text, "rustchain_node_version_info")
+        self.assertTrue(len(lines) >= 1)
+        self.assertIn('version="2.2.1-rip200"', lines[0])
+        self.assertTrue(lines[0].endswith("1.0"))
+
+    def test_db_rw_metric(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(_metric_value(text, "rustchain_db_rw"), "1.0")
+
+    def test_backup_age_hours(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(_metric_value(text, "rustchain_backup_age_hours"), "0.08")
+
+    def test_tip_age_slots(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(_metric_value(text, "rustchain_tip_age_slots"), "0.0")
+
+
+class TestEpochMetrics(unittest.TestCase):
+    def test_epoch_current(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(_metric_value(text, "rustchain_epoch_current"), "94.0")
+
+    def test_epoch_slot(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(_metric_value(text, "rustchain_epoch_slot"), "13580.0")
+
+    def test_blocks_per_epoch(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(
+            _metric_value(text, "rustchain_epoch_blocks_per_epoch"), "144.0"
+        )
+
+    def test_enrolled_miners(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(
+            _metric_value(text, "rustchain_epoch_enrolled_miners"), "22.0"
+        )
+
+    def test_epoch_pot_rtc(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(_metric_value(text, "rustchain_epoch_pot_rtc"), "1.5")
+
+
+class TestMinerMetrics(unittest.TestCase):
+    def test_active_miners_count(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(_metric_value(text, "rustchain_miners_active"), "2.0")
+
+    def test_miners_total(self):
+        text = _collect_to_text(_make_collector())
+        self.assertEqual(_metric_value(text, "rustchain_miners_total"), "2.0")
+
+    def test_per_miner_attestation_age(self):
+        text = _collect_to_text(_make_collector())
+        lines = _metric_lines(text, "rustchain_attestation_age_seconds")
+        self.assertTrue(len(lines) >= 2, f"Expected >=2 attestation age lines, got: {lines}")
+        miner_names = " ".join(lines)
+        self.assertIn("dual-g4-125", miner_names)
+        self.assertIn("victus-x86-scott", miner_names)
+
+    def test_per_miner_entropy_score(self):
+        text = _collect_to_text(_make_collector())
+        lines = _metric_lines(text, "rustchain_miner_entropy_score")
+        self.assertTrue(len(lines) >= 2)
+        combined = " ".join(lines)
+        self.assertIn("dual-g4-125", combined)
+
+    def test_per_miner_antiquity_multiplier(self):
+        text = _collect_to_text(_make_collector())
+        lines = _metric_lines(text, "rustchain_miner_antiquity_multiplier")
+        self.assertTrue(len(lines) >= 2)
+
+    def test_no_miners_returns_zero(self):
+        text = _collect_to_text(_make_collector(miners=[], miners_err=None))
+        self.assertEqual(_metric_value(text, "rustchain_miners_active"), "0.0")
+
+    def test_miners_error_returns_zero(self):
+        text = _collect_to_text(
+            _make_collector(miners=None, miners_err="http_500")
+        )
+        self.assertEqual(_metric_value(text, "rustchain_miners_active"), "0.0")
+
+
+class TestWalletMetrics(unittest.TestCase):
+    def test_wallet_balance(self):
+        text = _collect_to_text(
+            _make_collector(tracked_wallets=["founder_community"])
+        )
+        lines = _metric_lines(text, "rustchain_wallet_balance_rtc")
+        self.assertTrue(len(lines) >= 1, f"Expected wallet balance line, got: {lines}")
+        self.assertIn("founder_community", lines[0])
+        self.assertIn("82319.0", lines[0])
+
+    def test_no_tracked_wallets(self):
+        text = _collect_to_text(_make_collector(tracked_wallets=[]))
+        lines = _metric_lines(text, "rustchain_wallet_balance_rtc")
+        self.assertEqual(len(lines), 0)
+
+
+class TestScrapeErrors(unittest.TestCase):
+    def test_scrape_error_increments_on_failure(self):
+        collector = _make_collector(health=None, health_err="timeout")
+        _collect_to_text(collector)  # first scrape
+        _collect_to_text(collector)  # second scrape — error count goes to 2
+        text = _collect_to_text(collector)  # third scrape — 3
+
+        lines = _metric_lines(text, "rustchain_scrape_errors_total")
+        self.assertTrue(len(lines) >= 1, f"Expected scrape errors, got: {lines}")
+        # The /health endpoint should have an error count of 3
+        health_lines = [l for l in lines if "/health" in l]
+        self.assertTrue(len(health_lines) >= 1)
+        self.assertIn("3.0", health_lines[0])
+
+
+class TestPrometheusTextFormat(unittest.TestCase):
+    def test_output_is_valid_prometheus_format(self):
+        text = _collect_to_text(_make_collector())
+        # Every non-empty, non-comment line should be "<metric_name>{labels} value"
+        for line in text.splitlines():
+            if not line or line.startswith("#"):
+                continue
+            parts = line.rsplit(" ", 1)
+            self.assertEqual(
+                len(parts),
+                2,
+                f"Invalid Prometheus line format: {line!r}",
+            )
+            # Value should be parseable as float
+            try:
+                float(parts[1])
+            except ValueError:
+                self.fail(f"Non-numeric metric value in line: {line!r}")
+
+    def test_help_and_type_comments_present(self):
+        text = _collect_to_text(_make_collector())
+        self.assertIn("# HELP rustchain_node_up", text)
+        self.assertIn("# TYPE rustchain_node_up gauge", text)
+        self.assertIn("# HELP rustchain_epoch_current", text)
+        self.assertIn("# TYPE rustchain_epoch_current gauge", text)
+
+
+class TestPartialFailures(unittest.TestCase):
+    """Verify that a failure on one endpoint doesn't block others."""
+
+    def test_health_down_epoch_still_exported(self):
+        text = _collect_to_text(
+            _make_collector(health=None, health_err="timeout")
+        )
+        self.assertEqual(_metric_value(text, "rustchain_node_up"), "0.0")
+        # Epoch should still be present
+        self.assertEqual(_metric_value(text, "rustchain_epoch_current"), "94.0")
+
+    def test_epoch_down_miners_still_exported(self):
+        text = _collect_to_text(
+            _make_collector(epoch=None, epoch_err="http_503")
+        )
+        # Miners should still show up
+        self.assertEqual(_metric_value(text, "rustchain_miners_active"), "2.0")
+
+    def test_all_endpoints_down(self):
+        text = _collect_to_text(
+            _make_collector(
+                health=None,
+                epoch=None,
+                miners=None,
+                health_err="timeout",
+                epoch_err="timeout",
+                miners_err="timeout",
+            )
+        )
+        self.assertEqual(_metric_value(text, "rustchain_node_up"), "0.0")
+        self.assertEqual(_metric_value(text, "rustchain_miners_active"), "0.0")
+        # Should still produce valid output, not crash
+        self.assertIn("# HELP", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Bounty:** #765 
### What
A standalone Prometheus metrics exporter ([scripts/prometheus_exporter.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/rustchain-bounties/scripts/prometheus_exporter.py:0:0-0:0)) that polls the RustChain node's JSON APIs and re-exposes them as Prometheus-compatible metrics on `GET /metrics`.
### Why standalone (not patched into Flask)
The Flask app (`rustchain_v2_integrated_v2.2.1_rip200.py`) lives on the production server, not in this repo. A sidecar exporter:
- Ships from this repo, testable offline with mocks
- Zero risk to production node
- Standard Prometheus pattern (like `node_exporter`, `blackbox_exporter`)
- Metric definitions can be copy-pasted into Flask later if desired
### Deliverables
| Milestone | File | Status |
|---|---|---|
| `GET /metrics` endpoint (Prometheus format) | [scripts/prometheus_exporter.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/rustchain-bounties/scripts/prometheus_exporter.py:0:0-0:0) | ✅ |
| Core metrics (epoch, miners, balances, uptime) | included | ✅ |
| Grafana dashboard (10 panels, exceeds 6 requirement) | [docs/grafana/rustchain-dashboard.json](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/rustchain-bounties/docs/grafana/rustchain-dashboard.json:0:0-0:0) | ✅ |
| Alert rules (6 rules: node down, epoch stuck, DB, miners, latency, backup) | [docs/prometheus/alert_rules.yml](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/rustchain-bounties/docs/prometheus/alert_rules.yml:0:0-0:0) | ✅ |
| Per-miner metrics (attestation age, entropy score, antiquity multiplier) | per-miner labeled gauges | ✅ |
### Metrics exported (20+)
**Node health:** `rustchain_node_up`, `rustchain_node_uptime_seconds`, `rustchain_node_version_info`, `rustchain_db_rw`, `rustchain_backup_age_hours`, `rustchain_tip_age_slots`
**Epoch:** `rustchain_epoch_current`, `rustchain_epoch_slot`, `rustchain_epoch_blocks_per_epoch`, `rustchain_epoch_enrolled_miners`, `rustchain_epoch_pot_rtc`
**Miners:** `rustchain_miners_active`, `rustchain_miners_total`, `rustchain_attestation_age_seconds{miner="..."}`, `rustchain_miner_entropy_score{miner="..."}`, `rustchain_miner_antiquity_multiplier{miner="..."}`
**Wallets:** `rustchain_wallet_balance_rtc{wallet="..."}`
**Internal:** `rustchain_api_request_duration_seconds` (histogram), `rustchain_scrape_errors_total`
### Tests
27 unit tests, all passing (0.15s), fully mocked — no live node required:
<img width="1900" height="898" alt="image" src="https://github.com/user-attachments/assets/57fb9e1a-ce3f-4144-beda-aab13199b6a9" />
### Live metrics from the real RustChain node:

<img width="1415" height="868" alt="image" src="https://github.com/user-attachments/assets/c0672607-521e-4cda-870d-62c0cc3abab1" />

<img width="1154" height="974" alt="image" src="https://github.com/user-attachments/assets/5fcf080a-47a8-4eb0-96fc-a68536729234" />

<img width="1108" height="969" alt="image" src="https://github.com/user-attachments/assets/5f754434-9b77-4103-901b-bbc0ef765883" />

<img width="932" height="240" alt="image" src="https://github.com/user-attachments/assets/0dafa815-4cbb-4135-aa27-fad55d2bdece" />


### Quick start
```bash
pip install -r scripts/requirements-metrics.txt
python scripts/prometheus_exporter.py --node-url https://50.28.86.131 --port 9120
curl http://localhost:9120/metrics
```


#Docker
```bash
cd scripts && docker build -f Dockerfile.metrics -t rustchain-exporter .
docker run -d -p 9120:9120 rustchain-exporter --node-url https://50.28.86.131
```
### Wallet  : aroky-x86-miner