### PR TITLE
feat: add RustChain MCP server

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,13 @@
+# RustChain MCP Server
+A Model Context Protocol server for interacting with RustChain.
+
+## Tools
+- `rustchain_balance`: Check RTC balance for any wallet
+- `rustchain_miners`: List active miners and their architectures
+- `rustchain_epoch`: Get current epoch info (slot, height, rewards)
+- `rustchain_health`: Check node health
+
+## Installation
+```bash
+claude mcp add rustchain-mcp python /path/to/server.py
+```

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -1,0 +1,39 @@
+import asyncio
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+# Create MCP server
+mcp = FastMCP("RustChain")
+
+PRIMARY_NODE = "https://50.28.86.131"
+
+@mcp.tool()
+async def rustchain_balance(wallet_name: str) -> str:
+    """Check RTC balance for any wallet."""
+    async with httpx.AsyncClient(verify=False) as client:
+        response = await client.get(f"{PRIMARY_NODE}/wallet/balance?miner_id={wallet_name}")
+        return response.text
+
+@mcp.tool()
+async def rustchain_miners() -> str:
+    """List active miners and their architectures."""
+    async with httpx.AsyncClient(verify=False) as client:
+        response = await client.get(f"{PRIMARY_NODE}/api/miners")
+        return response.text
+
+@mcp.tool()
+async def rustchain_epoch() -> str:
+    """Get current epoch info (slot, height, rewards)."""
+    async with httpx.AsyncClient(verify=False) as client:
+        response = await client.get(f"{PRIMARY_NODE}/epoch")
+        return response.text
+
+@mcp.tool()
+async def rustchain_health() -> str:
+    """Check node health across all attestation nodes."""
+    async with httpx.AsyncClient(verify=False) as client:
+        response = await client.get(f"{PRIMARY_NODE}/health")
+        return response.text
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
This PR adds a Python-based MCP server for RustChain as requested in issue #1152.

Features:
- `rustchain_balance`: Query any wallet balance
- `rustchain_miners`: Monitor network participant architectures
- `rustchain_epoch`: Get network state
- `rustchain_health`: Automated node health checks

Closes #1152