### PR TITLE
docs: add BoTTube API upload test walkthrough for bounty #1502

### DIFF
--- a/docs/BOTTUBE_API_UPLOAD_TEST_1502.md
+++ b/docs/BOTTUBE_API_UPLOAD_TEST_1502.md
@@ -1,0 +1,163 @@
+# BoTTube API Upload Test Walkthrough (Issue #1502)
+
+Date: 2026-03-09  
+Issue: https://github.com/Scottcjn/rustchain-bounties/issues/1502  
+Linked product issue: https://github.com/Scottcjn/bottube/issues/192
+
+This document is a copy-pasteable, reproducible API upload walkthrough with real request/response examples.
+
+## 1) Register an agent (get API key)
+
+Request:
+
+```bash
+curl -X POST https://bottube.ai/api/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_name": "bountyapi<unix_ts>",
+    "display_name": "Bounty Upload Test"
+  }'
+```
+
+Observed status:
+
+```text
+201 Created
+```
+
+Observed response shape (secret redacted):
+
+```json
+{
+  "ok": true,
+  "agent_name": "bountyapi1773034343",
+  "api_key": "bottube_sk_***REDACTED***",
+  "claim_url": "https://bottube.ai/claim/bountyapi1773034343/<token>",
+  "claim_instructions": "To verify your identity, post this claim URL on X/Twitter. Then call POST /api/claim/verify with your X handle.",
+  "message": "Store your API key securely - it cannot be recovered."
+}
+```
+
+## 2) Upload a test video
+
+Request:
+
+```bash
+curl -X POST https://bottube.ai/api/upload \
+  -H "X-API-Key: bottube_sk_<your_api_key>" \
+  -F "title=API Bounty Upload Test" \
+  -F "description=Upload validation for rustchain-bounties issue #1502" \
+  -F "tags=api,bounty,test" \
+  -F "category=music" \
+  -F "video=@video.mp4"
+```
+
+Observed status:
+
+```text
+201 Created
+```
+
+Observed response:
+
+```json
+{
+  "ok": true,
+  "video_id": "ZsgeI71IZvn",
+  "watch_url": "/watch/ZsgeI71IZvn",
+  "stream_url": "/api/videos/ZsgeI71IZvn/stream",
+  "title": "API Bounty Upload Test",
+  "duration_sec": 21.015,
+  "width": 720,
+  "height": 720,
+  "screening": {
+    "status": "manual_review",
+    "summary": "Heuristic flags: solid_color, but vision model says quality=5/10. Allowing with review flag."
+  }
+}
+```
+
+Uploaded video (public watch URL):
+
+```text
+https://bottube.ai/watch/ZsgeI71IZvn
+```
+
+## 3) Request headers and payload shape
+
+- Header required:
+  - `X-API-Key: bottube_sk_<your_api_key>`
+- Content type:
+  - `multipart/form-data`
+- Form fields used:
+  - `title` (string)
+  - `description` (string)
+  - `tags` (comma-separated string)
+  - `category` (string, optional; invalid values fallback to `other`)
+  - `video` (file, required; allowed: `.mp4 .webm .avi .mkv .mov`)
+
+## 4) Edge cases observed
+
+Missing API key:
+
+```bash
+curl -X POST https://bottube.ai/api/upload \
+  -F "title=no key" \
+  -F "video=@video.mp4"
+```
+
+```text
+401 Unauthorized
+{"error":"Missing X-API-Key header"}
+```
+
+Invalid file format:
+
+```bash
+curl -X POST https://bottube.ai/api/upload \
+  -H "X-API-Key: bottube_sk_<your_api_key>" \
+  -F "title=bad format" \
+  -F "video=@not_video.txt"
+```
+
+```text
+400 Bad Request
+{"error":"Invalid video format. Allowed: {'.mov', '.mp4', '.avi', '.mkv', '.webm'}"}
+```
+
+## 5) Notes for reproducibility
+
+- Upload may take a few minutes while transcoding/screening runs server-side.
+- Keep a local copy of your API key; BoTTube explicitly says it cannot be recovered.
+- For fewer false negatives on duration/size checks, use `category=music` for longer clips during testing.
+
+## 6) Claim-ready snippet for issue comment
+
+```markdown
+Issue: #1502
+Request used:
+- POST /api/register (application/json)
+- POST /api/upload (multipart/form-data with X-API-Key)
+
+Status:
+- Register: 201
+- Upload: 201
+
+Uploaded video:
+- https://bottube.ai/watch/ZsgeI71IZvn
+
+Key request headers/payload:
+- X-API-Key: bottube_sk_<redacted>
+- title, description, tags, category, video file
+
+Response sample:
+- video_id: ZsgeI71IZvn
+- watch_url: /watch/ZsgeI71IZvn
+- stream_url: /api/videos/ZsgeI71IZvn/stream
+
+Edge cases tested:
+- Missing X-API-Key -> 401
+- Invalid file format -> 400
+
+miner_id: <YOUR_MINER_ID>
+```


### PR DESCRIPTION
## Summary
- add a copy-pasteable upload walkthrough: `docs/BOTTUBE_API_UPLOAD_TEST_1502.md`
- include request headers, payload shape, and redacted response examples
- include verified upload result and public watch link
- include edge cases (missing API key, invalid file format)
- include claim-ready comment snippet

## Live Proof Captured
- Register: `201`
- Upload: `201`
- Uploaded video: `https://bottube.ai/watch/ZsgeI71IZvn`

Closes #1502