### PR TITLE
Fix broken /wallet/pending link in payout verification

### DIFF
--- a/BOUNTY_LEDGER.md
+++ b/BOUNTY_LEDGER.md
@@ -300,8 +300,7 @@ curl -s https://50.28.86.131/explorer
 # Query a specific wallet balance
 curl -s "https://50.28.86.131/wallet/balance?miner_id=YOUR_WALLET"
 
-# View pending transfers
-curl -s "https://50.28.86.131/wallet/pending?miner_id=YOUR_WALLET"
+# Pending transfers are listed in this ledger under "Pending Transfers" (and in the explorer UI above).
 ```
 
 ---


### PR DESCRIPTION
Bounty: #444

`BOUNTY_LEDGER.md` referenced `GET /wallet/pending?miner_id=...` which currently returns 404. This PR removes that broken endpoint and clarifies that pending transfers are visible via the ledger + explorer UI.

Wallet (miner id) for RTC payout: `miner-20260309-e82e953d`