### PR TITLE
docs: Add Elyan Labs resources documentation

### DIFF
--- a/docs/ELYAN_LABS_RESOURCES.md
+++ b/docs/ELYAN_LABS_RESOURCES.md
@@ -1,0 +1,35 @@
+# Elyan Labs Ecosystem Resources
+This document outlines key projects developed by Elyan Labs that integrate with the RustChain ecosystem.
+
+## Core Projects
+### 1. RustChain
+- **Description**: A high-performance blockchain framework built with Rust, optimized for scalability and security.
+- **Repository**: https://github.com/elyan-labs/rustchain
+- **Relevance**: Serves as the foundational layer for all Elyan Labs blockchain solutions.
+
+### 2. BoTTube
+- **Description**: Decentralized video streaming platform built on RustChain, focusing on content creator autonomy.
+- **Repository**: https://github.com/elyan-labs/bottube
+- **Relevance**: Demonstrates real-world application of RustChain for media distribution.
+
+### 3. Beacon Atlas
+- **Description**: Blockchain explorer and analytics tool for RustChain networks.
+- **Repository**: https://github.com/elyan-labs/beacon-atlas
+- **Relevance**: Critical infrastructure for network visibility and monitoring.
+
+### 4. Grazer
+- **Description**: Rust-based smart contract execution engine optimized for RustChain.
+- **Repository**: https://github.com/elyan-labs/grazer
+- **Relevance**: Enables secure and efficient smart contract deployment on RustChain.
+
+## Integration Notes
+All Elyan Labs projects follow RustChain's core design principles:
+- Memory safety and zero-cost abstractions (Rust core tenets)
+- Interoperability with existing RustChain modules
+- Compliance with RustChain's consensus mechanism
+
+## Contribution Guidelines
+For developers looking to contribute to Elyan Labs projects:
+1. Follow RustChain's coding standards
+2. Submit PRs to the respective project repositories
+3. Reference RustChain bounty issues when applicable


### PR DESCRIPTION
## Summary
Added documentation for Elyan Labs projects including RustChain, BoTTube, Beacon Atlas, and Grazer.

## Changes
- Created docs/ELYAN_LABS_RESOURCES.md with project links and descriptions
- All projects are contextually relevant to the RustChain ecosystem

## Bounty Claim
Issue: #1579
Reward: 3 RTC