### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+registries: {}
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "deps"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
Configure automated dependency updates for the repository.

## Changes
- Added `.github/dependabot.yml` configuration file
- Configured 3 package ecosystems:
  - **npm**: JavaScript/Node.js dependencies
  - **pip**: Python dependencies  
  - **github-actions**: GitHub Actions workflows
- Schedule: Weekly updates on Monday at 09:00 Asia/Shanghai
- Auto-label PRs with `dependencies` and `security` tags
- Group npm dependencies by production/development

## Bounty
Addresses issue #1613 - Set up Dependabot or Renovate for any Elyan Labs repo

## Testing
Dependabot will automatically run after merge. Configuration follows GitHub's official schema.