### PR TITLE
docs: RustChain vs Ethereum PoS technical comparison [Bounty #1610]

### DIFF
--- a/docs/rustchain-vs-ethereum-pos.md
+++ b/docs/rustchain-vs-ethereum-pos.md
@@ -1,0 +1,121 @@
+# RustChain vs Ethereum PoS: A Technical Comparison
+
+A side-by-side analysis of RustChain's Proof-of-Antiquity (PoA) consensus and Ethereum's Proof-of-Stake (PoS), covering consensus mechanics, hardware requirements, energy consumption, and decentralization characteristics.
+
+---
+
+## 1. Consensus Mechanism
+
+### Ethereum: Proof-of-Stake
+
+Ethereum transitioned from Proof-of-Work to Proof-of-Stake with The Merge in September 2022. Validators lock 32 ETH (~$80,000+ at current prices) as collateral. The protocol randomly selects a validator to propose each block, and committees of validators attest to its validity. Misbehavior results in slashing — permanent loss of staked ETH.
+
+Block finality requires two epochs (~12.8 minutes). The security model assumes an attacker would need to control 33% of all staked ETH to halt the chain, or 66% to finalize conflicting blocks.
+
+### RustChain: Proof-of-Antiquity
+
+RustChain inverts conventional blockchain incentives. Instead of rewarding computational speed or capital, it rewards the age and authenticity of hardware. Miners run on vintage PowerPC processors (G3, G4, G5), and the protocol uses hardware fingerprinting to verify that blocks are genuinely mined on old machines.
+
+Vintage hardware earns a 2.5x mining multiplier over modern processors. A 2003 PowerPC G4 iBook legitimately earns more RTC than a modern Threadripper. Block production is deliberately slow by design — the chain values sustainability over throughput.
+
+### Key Differences
+
+| Aspect | Ethereum PoS | RustChain PoA |
+|--------|-------------|---------------|
+| Barrier to entry | 32 ETH (~$80,000+) | A vintage Mac ($20-100 on eBay) |
+| What's staked | Financial capital | Physical hardware identity |
+| Sybil resistance | Economic (slashing) | Hardware fingerprinting |
+| Block proposal | Random validator selection | Hardware-verified mining |
+| Finality | ~12.8 minutes (2 epochs) | Per-block confirmation |
+
+---
+
+## 2. Hardware Requirements
+
+### Ethereum
+
+Running an Ethereum validator node requires modern hardware: 4+ core CPU, 16+ GB RAM, 2 TB SSD (for the full execution + consensus client), and a stable internet connection. The real barrier is the 32 ETH stake, not the hardware. Liquid staking protocols like Lido lower the capital requirement but centralize validation among a few node operators.
+
+### RustChain
+
+RustChain deliberately targets obsolete hardware. Supported systems include PowerPC G3 (1997-2003), G4 (1999-2005), and G5 (2003-2006) Macs. The miner runs in Python and needs minimal resources — 256 MB RAM is sufficient. These machines would otherwise be e-waste.
+
+The protocol fingerprints CPU characteristics (instruction timing, cache behavior, FPU quirks) to cryptographically prove that mining occurred on genuine vintage silicon. Emulation and virtualization are detectable and rejected.
+
+---
+
+## 3. Energy Consumption
+
+### Ethereum
+
+Post-merge Ethereum reduced energy consumption by approximately 99.95% compared to its PoW era. A validator node consumes roughly 10-50 watts — comparable to a home router. The entire network's annual energy consumption dropped from ~112 TWh to approximately 0.01 TWh.
+
+### RustChain
+
+RustChain's energy profile is inherently modest. A PowerPC G4 iBook draws 20-45 watts under load. A G5 Power Mac draws more (150-200W) but is still far below GPU mining rigs. The network's total energy consumption is negligible given the small number of active nodes (currently 3 validators).
+
+The philosophical distinction matters: RustChain repurposes hardware that already exists and would otherwise sit in landfills. There is no incentive to manufacture or purchase new, energy-hungry equipment. Every joule spent mining on a G4 is a joule that keeps an old machine from becoming e-waste.
+
+| Metric | Ethereum PoS | RustChain PoA |
+|--------|-------------|---------------|
+| Per-node power | 10-50W | 20-200W (varies by hardware era) |
+| Network-wide (est.) | ~0.01 TWh/year | Negligible (< 0.0001 TWh/year) |
+| Hardware lifecycle | New hardware every 3-5 years | 20+ year old hardware reused |
+| E-waste impact | Moderate (retired validators) | Negative (diverts e-waste) |
+
+---
+
+## 4. Decentralization
+
+### Ethereum
+
+Ethereum has roughly 1,000,000+ validators, but decentralization is more nuanced than the raw count suggests. Lido controls approximately 28-30% of all staked ETH. The top 4 staking providers control over 50%. Geographic concentration is heavy in the US and Europe. Client diversity has improved but Geth still runs on a majority of execution-layer nodes, creating a single point of failure.
+
+The 32 ETH requirement prices out most individuals in most countries. Liquid staking abstracts this away but routes trust through smart contracts and DAO governance rather than direct participation.
+
+### RustChain
+
+RustChain's barrier to entry is a working vintage Mac, which can be found for $20-100 on secondary markets worldwide. This makes participation accessible to anyone with an old machine, regardless of financial status. The hardware fingerprinting requirement makes Sybil attacks expensive — an attacker would need to physically acquire many distinct vintage machines.
+
+Current decentralization is limited by the network's early stage (3 active nodes), but the design incentivizes a long tail of small, geographically distributed miners. The Solana bridge (wRTC) extends the token's accessibility without centralizing consensus.
+
+| Factor | Ethereum PoS | RustChain PoA |
+|--------|-------------|---------------|
+| Validators | ~1,000,000+ | 3 (early stage) |
+| Capital barrier | 32 ETH (~$80K) | $20-100 (vintage hardware) |
+| Top-4 concentration | >50% of stake | N/A (too early) |
+| Geographic reach | US/EU heavy | Anywhere old Macs exist |
+| Sybil cost | Acquire ETH | Acquire distinct vintage hardware |
+| Client diversity | Improving (Geth dominant) | Single implementation |
+
+---
+
+## 5. Trade-offs and Complementary Strengths
+
+Ethereum and RustChain are not competitors — they occupy fundamentally different niches.
+
+Ethereum is optimized for global-scale smart contract execution, DeFi, and programmable money. It sacrifices accessibility (32 ETH barrier) for economic security at scale. Its validator set is large enough to resist nation-state attacks.
+
+RustChain is optimized for a different thesis: that old hardware has value, that mining should be accessible, and that blockchains can serve as incentive mechanisms for sustainability. It trades throughput and validator count for radical hardware accessibility and an anti-e-waste mission.
+
+The wRTC bridge connecting RustChain to Solana demonstrates that these ecosystems can be complementary rather than competing — RustChain secures its own chain with vintage hardware, while the token circulates freely on high-throughput networks.
+
+---
+
+## Summary
+
+| Dimension | Ethereum PoS | RustChain PoA |
+|-----------|-------------|---------------|
+| **Consensus** | Stake-weighted random selection | Hardware-fingerprinted mining |
+| **Entry cost** | ~$80,000 (32 ETH) | ~$50 (vintage Mac) |
+| **Security model** | Economic (slashing) | Physical (hardware identity) |
+| **Energy** | Very low (~0.01 TWh/yr) | Negligible, reuses e-waste |
+| **Decentralization** | High validator count, concentrated stake | Low count, accessible entry |
+| **Throughput** | ~15-30 TPS (L1) | Low (by design) |
+| **Mission** | Programmable global settlement | Sustainable hardware incentives |
+
+Both chains demonstrate that consensus mechanisms can be designed around the values a community wants to embody. Ethereum chose capital efficiency. RustChain chose hardware preservation.
+
+---
+
+*Closes [#1610](https://github.com/Scottcjn/rustchain-bounties/issues/1610)*


### PR DESCRIPTION
## Summary
- 800+ word technical comparison of RustChain PoA vs Ethereum PoS
- Covers consensus mechanics, hardware requirements, energy consumption, and decentralization
- Includes comparison tables for quick reference
- Discusses trade-offs and complementary strengths

## Bounty
Closes #1610 — [BOUNTY: 3 RTC] Write a comparison: RustChain vs Ethereum PoS

## Deliverable
`docs/rustchain-vs-ethereum-pos.md` — complete technical comparison with 5 sections and summary tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)