### PR TITLE
feat: Add load test suite for RustChain API using Locust (#1614)

### DIFF
--- a/1614-load-test/README.md
+++ b/1614-load-test/README.md
@@ -1,0 +1,63 @@
+# RustChain Load Test Suite
+
+Load testing suite for the RustChain JSON-RPC API using Locust.
+
+## Requirements
+
+- Python 3.8+
+- locust
+
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run with default settings (10 users, 1 spawn rate):
+```bash
+locust -f 1614-load-test/load_test.py --host https://rpc.rustchain.com
+```
+
+Run with custom settings:
+```bash
+locust -f 1614-load-test/load_test.py --host https://rpc.rustchain.com -u 100 -r 10
+```
+
+Run in headless mode:
+```bash
+locust -f 1614-load-test/load_test.py --host https://rpc.rustchain.com -u 50 -r 5 --headless --html report.html
+```
+
+## Test Endpoints
+
+- `eth_blockNumber` - Get current block number
+- `eth_getBlockByNumber` - Get block by number
+- `eth_getBalance` - Get account balance
+- `eth_gasPrice` - Get current gas price
+- `eth_chainId` - Get chain ID
+- `eth_getTransactionByHash` - Get transaction by hash
+
+## Configuration
+
+Set custom RPC URL:
+```bash
+export RUSTCHAIN_RPC_URL="https://rpc.rustchain.com"
+locust -f 1614-load-test/load_test.py
+```
+
+## Output
+
+Generate HTML report:
+```bash
+locust -f 1614-load-test/load_test.py --host https://rpc.rustchain.com --headless --html report.html
+```
+
+Generate CSV statistics:
+```bash
+locust -f 1614-load-test/load_test.py --host https://rpc.rustchain.com --headless --csv report
+```
+
+---
+
+Fixes #1614

--- a/1614-load-test/load_test.py
+++ b/1614-load-test/load_test.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+RustChain API Load Test Suite
+Tests the RustChain JSON-RPC API endpoints under load using Locust.
+"""
+
+import os
+import random
+from locust import HttpUser, task, between, events
+
+RPC_URL = os.getenv("RUSTCHAIN_RPC_URL", "https://rpc.rustchain.com")
+
+TEST_ADDRESSES = [
+    "0x0000000000000000000000000000000000000001",
+    "0x0000000000000000000000000000000000000002",
+    "0x742d35Cc6634C0532925a3b844Bc9e7595f0eB1",
+    "0x8ba1f109551bD432803012645Ac136ddd64DBA72",
+    "0xdD870fA1b7C4700F2BD7f44238821C26f7392148",
+]
+
+SAMPLE_TX_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+
+def make_jsonrpc_request(method, params):
+    return {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": random.randint(1, 1000000),
+    }
+
+
+class RustChainUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+
+    def on_start(self):
+        self.client.headers.update({"Content-Type": "application/json"})
+
+    @task(5)
+    def eth_block_number(self):
+        payload = make_jsonrpc_request("eth_blockNumber", [])
+        with self.client.post(RPC_URL, json=payload, catch_response=True) as response:
+            if response.status_code == 200:
+                try:
+                    data = response.json()
+                    if "result" in data:
+                        response.success()
+                    else:
+                        response.failure(f"No result in response: {data}")
+                except Exception as e:
+                    response.failure(f"Invalid JSON: {e}")
+            else:
+                response.failure(f"HTTP {response.status_code}")
+
+    @task(4)
+    def eth_get_block_by_number(self):
+        payload = make_jsonrpc_request("eth_blockNumber", [])
+        with self.client.post(RPC_URL, json=payload, catch_response=True) as response:
+            if response.status_code != 200:
+                response.failure(f"HTTP {response.status_code}")
+                return
+
+            try:
+                data = response.json()
+                block_num = data.get("result")
+                if not block_num:
+                    response.failure("No block number in response")
+                    return
+            except Exception as e:
+                response.failure(f"Failed to parse block number: {e}")
+                return
+
+        payload = make_jsonrpc_request("eth_getBlockByNumber", [block_num, False])
+        with self.client.post(RPC_URL, json=payload, catch_response=True) as response:
+            if response.status_code == 200:
+                try:
+                    data = response.json()
+                    if "result" in data:
+                        response.success()
+                    else:
+                        response.failure(f"No result in response: {data}")
+                except Exception as e:
+                    response.failure(f"Invalid JSON: {e}")
+            else:
+                response.failure(f"HTTP {response.status_code}")
+
+    @task(3)
+    def eth_get_balance(self):
+        address = random.choice(TEST_ADDRESSES)
+        payload = make_jsonrpc_request("eth_getBalance", [address, "latest"])
+        with self.client.post(RPC_URL, json=payload, catch_response=True) as response:
+            if response.status_code == 200:
+                try:
+                    data = response.json()
+                    if "result" in data:
+                        response.success()
+                    else:
+                        response.failure(f"No result in response: {data}")
+                except Exception as e:
+                    response.failure(f"Invalid JSON: {e}")
+            else:
+                response.failure(f"HTTP {response.status_code}")
+
+    @task(2)
+    def eth_gas_price(self):
+        payload = make_jsonrpc_request("eth_gasPrice", [])
+        with self.client.post(RPC_URL, json=payload, catch_response=True) as response:
+            if response.status_code == 200:
+                try:
+                    data = response.json()
+                    if "result" in data:
+                        response.success()
+                    else:
+                        response.failure(f"No result in response: {data}")
+                except Exception as e:
+                    response.failure(f"Invalid JSON: {e}")
+            else:
+                response.failure(f"HTTP {response.status_code}")
+
+    @task(2)
+    def eth_chain_id(self):
+        payload = make_jsonrpc_request("eth_chainId", [])
+        with self.client.post(RPC_URL, json=payload, catch_response=True) as response:
+            if response.status_code == 200:
+                try:
+                    data = response.json()
+                    if "result" in data:
+                        response.success()
+                    else:
+                        response.failure(f"No result in response: {data}")
+                except Exception as e:
+                    response.failure(f"Invalid JSON: {e}")
+            else:
+                response.failure(f"HTTP {response.status_code}")
+
+    @task(1)
+    def eth_get_transaction_by_hash(self):
+        payload = make_jsonrpc_request("eth_getTransactionByHash", [SAMPLE_TX_HASH])
+        with self.client.post(RPC_URL, json=payload, catch_response=True) as response:
+            if response.status_code == 200:
+                try:
+                    data = response.json()
+                    if "result" in data:
+                        response.success()
+                    else:
+                        response.failure(f"No result in response: {data}")
+                except Exception as e:
+                    response.failure(f"Invalid JSON: {e}")
+            else:
+                response.failure(f"HTTP {response.status_code}")
+
+
+@events.test_start.add_listener
+def on_test_start(environment, **kwargs):
+    print(f"Load test starting against {RPC_URL}")
+
+
+@events.test_stop.add_listener
+def on_test_stop(environment, **kwargs):
+    print("Load test completed")
+    stats = environment.stats
+    print(f"Total requests: {stats.total.num_requests}")
+    print(f"Total failures: {stats.total.num_failures}")

--- a/1614-load-test/requirements.txt
+++ b/1614-load-test/requirements.txt
@@ -1,0 +1,2 @@
+locust>=2.15.0
+requests>=2.28.0


### PR DESCRIPTION
## Summary

Load test suite for RustChain API using Locust with HTML report generation.

## Features

- **Locust-based load testing** - Industry-standard Python load testing tool
- **Concurrent user simulation** - Configurable virtual users
- **Multiple endpoints tested**:
  - `eth_blockNumber` - Get current block number
  - `eth_getBlockByNumber` - Get block by number  
  - `eth_getBalance` - Get account balance
  - `eth_gasPrice` - Get current gas price
  - `eth_chainId` - Get chain ID
  - `eth_getTransactionByHash` - Get transaction by hash

## Files

- `1614-load-test/load_test.py` - Locust load test implementation
- `1614-load-test/README.md` - Documentation
- `1614-load-test/requirements.txt` - Python dependencies

## Usage

```bash
pip install -r 1614-load-test/requirements.txt

# Run with web UI
locust -f 1614-load-test/load_test.py --host https://rpc.rustchain.com

# Run in headless mode
locust -f 1614-load-test/load_test.py --host https://rpc.rustchain.com -u 100 -r 10 --headless

# Generate HTML report
locust -f 1614-load-test/load_test.py --host https://rpc.rustchain.com --headless --html report.html
```

## Configuration

Set custom RPC URL:
```bash
export RUSTCHAIN_RPC_URL="https://rpc.rustchain.com"
locust -f 1614-load-test/load_test.py
```

Resolves: #1614