### PR TITLE
RustChain Hardware Trading Cards

### DIFF
--- a/docs/trading-cards/card-template.svg
+++ b/docs/trading-cards/card-template.svg
@@ -1,0 +1,113 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 560" width="400" height="560">
+  <defs>
+    <!-- Card border gradient -->
+    <linearGradient id="borderGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#c9a400;stop-opacity:1" />
+      <stop offset="50%" style="stop-color:#f5d442;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#c9a400;stop-opacity:1" />
+    </linearGradient>
+
+    <!-- Rarity backgrounds -->
+    <linearGradient id="rarityCommon" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#8B6914" />
+      <stop offset="100%" style="stop-color:#CD853F" />
+    </linearGradient>
+    <linearGradient id="rarityUncommon" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#708090" />
+      <stop offset="100%" style="stop-color:#C0C0C0" />
+    </linearGradient>
+    <linearGradient id="rarityRare" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#B8860B" />
+      <stop offset="100%" style="stop-color:#FFD700" />
+    </linearGradient>
+    <linearGradient id="rarityEpic" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#4B0082" />
+      <stop offset="100%" style="stop-color:#9370DB" />
+    </linearGradient>
+    <linearGradient id="rarityLegendary" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#FF6347" />
+      <stop offset="25%" style="stop-color:#FFD700" />
+      <stop offset="50%" style="stop-color:#00CED1" />
+      <stop offset="75%" style="stop-color:#FF69B4" />
+      <stop offset="100%" style="stop-color:#FF6347" />
+    </linearGradient>
+    <linearGradient id="rarityMythic" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#FF0000" />
+      <stop offset="20%" style="stop-color:#FF8C00" />
+      <stop offset="40%" style="stop-color:#FFD700" />
+      <stop offset="60%" style="stop-color:#00FF00" />
+      <stop offset="80%" style="stop-color:#4169E1" />
+      <stop offset="100%" style="stop-color:#8B00FF" />
+    </linearGradient>
+
+    <!-- Card background pattern -->
+    <pattern id="circuitPattern" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+      <rect width="40" height="40" fill="none"/>
+      <path d="M0 20 H15 M25 20 H40 M20 0 V15 M20 25 V40" stroke="#2a2a2a" stroke-width="0.5" fill="none"/>
+      <circle cx="20" cy="20" r="2" fill="#333"/>
+    </pattern>
+  </defs>
+
+  <!-- Outer border -->
+  <rect x="0" y="0" width="400" height="560" rx="16" ry="16" fill="url(#borderGradient)" />
+
+  <!-- Inner card background -->
+  <rect x="6" y="6" width="388" height="548" rx="12" ry="12" fill="#1a1a1a" />
+
+  <!-- Circuit board pattern overlay -->
+  <rect x="6" y="6" width="388" height="548" rx="12" ry="12" fill="url(#circuitPattern)" opacity="0.3" />
+
+  <!-- Card header bar -->
+  <rect x="20" y="16" width="360" height="36" rx="6" ry="6" fill="#0d0d0d" stroke="#444" stroke-width="1"/>
+  <text x="30" y="40" font-family="'Courier New', monospace" font-size="11" fill="#888" font-weight="bold">RUSTCHAIN HARDWARE CARD</text>
+  <text x="340" y="40" font-family="'Courier New', monospace" font-size="11" fill="#c9a400" font-weight="bold" text-anchor="end">#000</text>
+
+  <!-- Art frame -->
+  <rect x="30" y="62" width="340" height="180" rx="4" ry="4" fill="#0d0d0d" stroke="#555" stroke-width="1"/>
+
+  <!-- Placeholder art area -->
+  <text x="200" y="140" font-family="'Courier New', monospace" font-size="14" fill="#444" text-anchor="middle">[ HARDWARE IMAGE ]</text>
+  <text x="200" y="160" font-family="'Courier New', monospace" font-size="10" fill="#333" text-anchor="middle">Replace with ASCII art or illustration</text>
+
+  <!-- Card name plate -->
+  <rect x="30" y="252" width="340" height="32" rx="4" ry="4" fill="#0d0d0d" stroke="url(#borderGradient)" stroke-width="1.5"/>
+  <text x="200" y="274" font-family="'Courier New', monospace" font-size="16" fill="#f5d442" font-weight="bold" text-anchor="middle">CARD NAME HERE</text>
+
+  <!-- Rarity and multiplier row -->
+  <rect x="30" y="292" width="165" height="24" rx="4" ry="4" fill="#111" stroke="#444" stroke-width="0.5"/>
+  <text x="112" y="309" font-family="'Courier New', monospace" font-size="11" fill="#aaa" text-anchor="middle">Rarity: -------</text>
+
+  <rect x="205" y="292" width="165" height="24" rx="4" ry="4" fill="#111" stroke="#444" stroke-width="0.5"/>
+  <text x="287" y="309" font-family="'Courier New', monospace" font-size="11" fill="#4fc3f7" text-anchor="middle">Multiplier: --x</text>
+
+  <!-- Stats block -->
+  <rect x="30" y="324" width="340" height="100" rx="4" ry="4" fill="#0a0a0a" stroke="#333" stroke-width="1"/>
+
+  <text x="44" y="346" font-family="'Courier New', monospace" font-size="11" fill="#888">Clock Speed</text>
+  <text x="356" y="346" font-family="'Courier New', monospace" font-size="11" fill="#e0e0e0" text-anchor="end">--- MHz</text>
+  <line x1="44" y1="352" x2="356" y2="352" stroke="#222" stroke-width="0.5"/>
+
+  <text x="44" y="368" font-family="'Courier New', monospace" font-size="11" fill="#888">Architecture</text>
+  <text x="356" y="368" font-family="'Courier New', monospace" font-size="11" fill="#e0e0e0" text-anchor="end">-----------</text>
+  <line x1="44" y1="374" x2="356" y2="374" stroke="#222" stroke-width="0.5"/>
+
+  <text x="44" y="390" font-family="'Courier New', monospace" font-size="11" fill="#888">Year</text>
+  <text x="356" y="390" font-family="'Courier New', monospace" font-size="11" fill="#e0e0e0" text-anchor="end">----</text>
+  <line x1="44" y1="396" x2="356" y2="396" stroke="#222" stroke-width="0.5"/>
+
+  <text x="44" y="412" font-family="'Courier New', monospace" font-size="11" fill="#888">Hash Rate</text>
+  <text x="356" y="412" font-family="'Courier New', monospace" font-size="11" fill="#4fc3f7" text-anchor="end">--- H/s</text>
+
+  <!-- Flavor text block -->
+  <rect x="30" y="432" width="340" height="60" rx="4" ry="4" fill="#111" stroke="#333" stroke-width="1"/>
+  <text x="200" y="454" font-family="Georgia, serif" font-size="10" fill="#999" text-anchor="middle" font-style="italic">"Flavor text goes here.</text>
+  <text x="200" y="468" font-family="Georgia, serif" font-size="10" fill="#999" text-anchor="middle" font-style="italic">Replace with card lore."</text>
+
+  <!-- Special ability bar -->
+  <rect x="30" y="500" width="340" height="28" rx="4" ry="4" fill="#1a0a2e" stroke="#7c4dff" stroke-width="1"/>
+  <text x="40" y="519" font-family="'Courier New', monospace" font-size="10" fill="#7c4dff" font-weight="bold">ABILITY:</text>
+  <text x="110" y="519" font-family="'Courier New', monospace" font-size="10" fill="#b388ff">Ability Name Here</text>
+
+  <!-- Footer -->
+  <text x="200" y="546" font-family="'Courier New', monospace" font-size="8" fill="#444" text-anchor="middle">RUSTCHAIN HARDWARE SERIES v1.0</text>
+</svg>

--- a/docs/trading-cards/cards.md
+++ b/docs/trading-cards/cards.md
@@ -1,0 +1,564 @@
+# RustChain Hardware Trading Cards
+
+> *Mine blocks with legendary silicon. Collect them all.*
+
+---
+
+## Card Rarity Tiers
+
+| Tier | Color | Drop Rate |
+|------|-------|-----------|
+| Common | Bronze | 40% |
+| Uncommon | Silver | 25% |
+| Rare | Gold | 18% |
+| Epic | Purple | 10% |
+| Legendary | Holographic | 5% |
+| Mythic | Prismatic | 2% |
+
+---
+
+## Card #001 — Apple II
+
+```
+ ╔══════════════════════════════════════╗
+ ║  ┌────────────────────────────────┐  ║
+ ║  │  RUSTCHAIN HARDWARE CARD #001  │  ║
+ ║  │  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░  │  ║
+ ║  │       ___________________       │  ║
+ ║  │      /                   \      │  ║
+ ║  │     /   ┌─────────────┐   \     │  ║
+ ║  │    │    │  >_          │    │    │  ║
+ ║  │    │    │  HELLO WORLD │    │    │  ║
+ ║  │    │    │  ]RUN MINER  │    │    │  ║
+ ║  │    │    └─────────────┘    │    │  ║
+ ║  │     \   ══════════════   /      │  ║
+ ║  │      \_______    _______/       │  ║
+ ║  │              \__/               │  ║
+ ║  │                                  │  ║
+ ║  │  ── APPLE II ──                  │  ║
+ ║  │  Rarity: Common                 │  ║
+ ║  │  Mining Multiplier: 0.5x        │  ║
+ ║  │                                  │  ║
+ ║  │  Clock Speed .... 1 MHz         │  ║
+ ║  │  Architecture ... MOS 6502      │  ║
+ ║  │  Year ........... 1977          │  ║
+ ║  │  RAM ............ 4 KB          │  ║
+ ║  │  Hash Rate ...... 0.001 H/s     │  ║
+ ║  │                                  │  ║
+ ║  │  "The garage where it all       │  ║
+ ║  │   began. Every hash counts      │  ║
+ ║  │   when you're mining with       │  ║
+ ║  │   Wozniak's masterpiece."       │  ║
+ ║  └────────────────────────────────┘  ║
+ ╚══════════════════════════════════════╝
+```
+
+| Stat | Value |
+|------|-------|
+| **Name** | Apple II |
+| **Rarity** | Common (Bronze) |
+| **Mining Multiplier** | 0.5x |
+| **Clock Speed** | 1 MHz |
+| **Architecture** | MOS 6502 |
+| **Year** | 1977 |
+| **RAM** | 4 KB |
+| **Estimated Hash Rate** | 0.001 H/s |
+| **Flavor Text** | *"The garage where it all began. Every hash counts when you're mining with Wozniak's masterpiece."* |
+| **Special Ability** | **Nostalgia Bonus** — +10% RTC when paired with another Common card |
+
+---
+
+## Card #002 — Commodore Amiga 500
+
+```
+ ╔══════════════════════════════════════╗
+ ║  ┌────────────────────────────────┐  ║
+ ║  │  RUSTCHAIN HARDWARE CARD #002  │  ║
+ ║  │  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░  │  ║
+ ║  │     ┌──────────────────────┐    │  ║
+ ║  │     │ ╔══════════════════╗ │    │  ║
+ ║  │     │ ║  ████  AMIGA     ║ │    │  ║
+ ║  │     │ ║  ████  WORKBENCH ║ │    │  ║
+ ║  │     │ ║  ▓▓▓▓  v1.3      ║ │    │  ║
+ ║  │     │ ╚══════════════════╝ │    │  ║
+ ║  │     │  ┌──┐  ┌──┐  ┌──┐   │    │  ║
+ ║  │     └──┴──┴──┴──┴──┴──┴───┘    │  ║
+ ║  │     ┌──────────────────────┐    │  ║
+ ║  │     │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│    │  ║
+ ║  │     └──────────────────────┘    │  ║
+ ║  │                                  │  ║
+ ║  │  ── COMMODORE AMIGA 500 ──      │  ║
+ ║  │  Rarity: Uncommon               │  ║
+ ║  │  Mining Multiplier: 1.2x        │  ║
+ ║  │                                  │  ║
+ ║  │  Clock Speed .... 7.16 MHz      │  ║
+ ║  │  Architecture ... Motorola 68k  │  ║
+ ║  │  Year ........... 1987          │  ║
+ ║  │  RAM ............ 512 KB        │  ║
+ ║  │  Hash Rate ...... 0.05 H/s      │  ║
+ ║  │                                  │  ║
+ ║  │  "Custom chips named Agnus,     │  ║
+ ║  │   Denise, and Paula handle      │  ║
+ ║  │   what others can't. The        │  ║
+ ║  │   demoscene lives here."        │  ║
+ ║  └────────────────────────────────┘  ║
+ ╚══════════════════════════════════════╝
+```
+
+| Stat | Value |
+|------|-------|
+| **Name** | Commodore Amiga 500 |
+| **Rarity** | Uncommon (Silver) |
+| **Mining Multiplier** | 1.2x |
+| **Clock Speed** | 7.16 MHz |
+| **Architecture** | Motorola 68000 |
+| **Year** | 1987 |
+| **RAM** | 512 KB |
+| **Estimated Hash Rate** | 0.05 H/s |
+| **Flavor Text** | *"Custom chips named Agnus, Denise, and Paula handle what others can't. The demoscene lives here."* |
+| **Special Ability** | **Copper Effect** — GPU co-processing grants +15% block validation speed |
+
+---
+
+## Card #003 — Sega Dreamcast
+
+```
+ ╔══════════════════════════════════════╗
+ ║  ┌────────────────────────────────┐  ║
+ ║  │  RUSTCHAIN HARDWARE CARD #003  │  ║
+ ║  │  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░  │  ║
+ ║  │          ┌──────────┐           │  ║
+ ║  │        ╱╱            ╲╲         │  ║
+ ║  │       ╱  ┌──────────┐  ╲        │  ║
+ ║  │      │   │  ((🌀))  │   │       │  ║
+ ║  │      │   │ DREAMCAST│   │       │  ║
+ ║  │       ╲  └──────────┘  ╱        │  ║
+ ║  │        ╲╲   ○    ○   ╱╱         │  ║
+ ║  │          └──────────┘           │  ║
+ ║  │            ┌──────┐             │  ║
+ ║  │            │ VMU  │             │  ║
+ ║  │            └──────┘             │  ║
+ ║  │                                  │  ║
+ ║  │  ── SEGA DREAMCAST ──           │  ║
+ ║  │  Rarity: Rare                   │  ║
+ ║  │  Mining Multiplier: 1.8x        │  ║
+ ║  │                                  │  ║
+ ║  │  Clock Speed .... 200 MHz       │  ║
+ ║  │  Architecture ... Hitachi SH-4  │  ║
+ ║  │  Year ........... 1998          │  ║
+ ║  │  RAM ............ 16 MB         │  ║
+ ║  │  Hash Rate ...... 2.4 H/s       │  ║
+ ║  │                                  │  ║
+ ║  │  "It was thinking ahead of      │  ║
+ ║  │   its time. Built-in modem,     │  ║
+ ║  │   online play, and now—         │  ║
+ ║  │   decentralized block mining."  │  ║
+ ║  └────────────────────────────────┘  ║
+ ╚══════════════════════════════════════╝
+```
+
+| Stat | Value |
+|------|-------|
+| **Name** | Sega Dreamcast |
+| **Rarity** | Rare (Gold) |
+| **Mining Multiplier** | 1.8x |
+| **Clock Speed** | 200 MHz |
+| **Architecture** | Hitachi SH-4 |
+| **Year** | 1998 |
+| **RAM** | 16 MB |
+| **Estimated Hash Rate** | 2.4 H/s |
+| **Flavor Text** | *"It was thinking ahead of its time. Built-in modem, online play, and now -- decentralized block mining."* |
+| **Special Ability** | **VMU Wallet** — stores an extra 5% RTC in offline cold storage per block |
+
+---
+
+## Card #004 — PowerPC G3 (Blue & White)
+
+```
+ ╔══════════════════════════════════════╗
+ ║  ┌────────────────────────────────┐  ║
+ ║  │  RUSTCHAIN HARDWARE CARD #004  │  ║
+ ║  │  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  │  ║
+ ║  │       ┌────────────────┐        │  ║
+ ║  │       │ ╭────────────╮ │        │  ║
+ ║  │       │ │ ░░░░░░░░░░ │ │        │  ║
+ ║  │       │ │ ░░ G3  ░░░ │ │        │  ║
+ ║  │       │ │ ░░░░░░░░░░ │ │        │  ║
+ ║  │       │ ╰────────────╯ │        │  ║
+ ║  │       │  ═══╗    ╔═══  │        │  ║
+ ║  │       │     ║ () ║     │        │  ║
+ ║  │       │  ═══╝    ╚═══  │        │  ║
+ ║  │       │   [::::::::]   │        │  ║
+ ║  │       └────────────────┘        │  ║
+ ║  │                                  │  ║
+ ║  │  ── POWERPC G3 ──               │  ║
+ ║  │  Rarity: Uncommon               │  ║
+ ║  │  Mining Multiplier: 1.5x        │  ║
+ ║  │                                  │  ║
+ ║  │  Clock Speed .... 300 MHz       │  ║
+ ║  │  Architecture ... PowerPC 750   │  ║
+ ║  │  Year ........... 1999          │  ║
+ ║  │  RAM ............ 256 MB        │  ║
+ ║  │  Hash Rate ...... 5.1 H/s       │  ║
+ ║  │                                  │  ║
+ ║  │  "Blue and white translucent    │  ║
+ ║  │   plastic hides serious power.  │  ║
+ ║  │   The tower that brought RISC   │  ║
+ ║  │   to the people."               │  ║
+ ║  └────────────────────────────────┘  ║
+ ╚══════════════════════════════════════╝
+```
+
+| Stat | Value |
+|------|-------|
+| **Name** | PowerPC G3 (Blue & White) |
+| **Rarity** | Uncommon (Silver) |
+| **Mining Multiplier** | 1.5x |
+| **Clock Speed** | 300 MHz |
+| **Architecture** | PowerPC 750 |
+| **Year** | 1999 |
+| **RAM** | 256 MB |
+| **Estimated Hash Rate** | 5.1 H/s |
+| **Flavor Text** | *"Blue and white translucent plastic hides serious power. The tower that brought RISC to the people."* |
+| **Special Ability** | **AltiVec Preview** — unlocks early SIMD path, +8% parallel hash throughput |
+
+---
+
+## Card #005 — PowerPC G4 (Quicksilver)
+
+```
+ ╔══════════════════════════════════════╗
+ ║  ┌────────────────────────────────┐  ║
+ ║  │  RUSTCHAIN HARDWARE CARD #005  │  ║
+ ║  │  ████████████████████████████████  │  ║
+ ║  │      ┌──────────────────┐       │  ║
+ ║  │      │ ╔════════════╗   │       │  ║
+ ║  │      │ ║            ║   │       │  ║
+ ║  │      │ ║   G4       ║   │       │  ║
+ ║  │      │ ║  VELOCITY  ║   │       │  ║
+ ║  │      │ ║  ENGINE    ║   │       │  ║
+ ║  │      │ ║            ║   │       │  ║
+ ║  │      │ ╚════════════╝   │       │  ║
+ ║  │      │  [===========]   │       │  ║
+ ║  │      │  [===========]   │       │  ║
+ ║  │      └──────────────────┘       │  ║
+ ║  │                                  │  ║
+ ║  │  ── POWERPC G4 ──               │  ║
+ ║  │  Rarity: Rare                   │  ║
+ ║  │  Mining Multiplier: 2.5x        │  ║
+ ║  │                                  │  ║
+ ║  │  Clock Speed .... 867 MHz       │  ║
+ ║  │  Architecture ... PowerPC 7450  │  ║
+ ║  │  Year ........... 2001          │  ║
+ ║  │  RAM ............ 1.5 GB        │  ║
+ ║  │  Hash Rate ...... 18 H/s        │  ║
+ ║  │                                  │  ║
+ ║  │  "Classified as a weapon by     │  ║
+ ║  │   the US government. AltiVec    │  ║
+ ║  │   crunches hashes like it was   │  ║
+ ║  │   born to mine RustChain."      │  ║
+ ║  └────────────────────────────────┘  ║
+ ╚══════════════════════════════════════╝
+```
+
+| Stat | Value |
+|------|-------|
+| **Name** | PowerPC G4 (Quicksilver) |
+| **Rarity** | Rare (Gold) |
+| **Mining Multiplier** | 2.5x |
+| **Clock Speed** | 867 MHz |
+| **Architecture** | PowerPC 7450 |
+| **Year** | 2001 |
+| **RAM** | 1.5 GB |
+| **Estimated Hash Rate** | 18 H/s |
+| **Flavor Text** | *"Classified as a weapon by the US government. AltiVec crunches hashes like it was born to mine RustChain."* |
+| **Special Ability** | **Velocity Engine** — AltiVec SIMD grants 2x burst mining for 10 seconds every minute |
+
+---
+
+## Card #006 — PowerPC G5 (Quad)
+
+```
+ ╔══════════════════════════════════════╗
+ ║  ┌────────────────────────────────┐  ║
+ ║  │  RUSTCHAIN HARDWARE CARD #006  │  ║
+ ║  │  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  │  ║
+ ║  │    ┌────────────────────────┐    │  ║
+ ║  │    │  ┌──┐┌──┐┌──┐┌──┐    │    │  ║
+ ║  │    │  │G5││G5││G5││G5│    │    │  ║
+ ║  │    │  └──┘└──┘└──┘└──┘    │    │  ║
+ ║  │    │  ════════════════     │    │  ║
+ ║  │    │  │██│ LIQUID COOL│    │    │  ║
+ ║  │    │  │██│ SYSTEM     │    │    │  ║
+ ║  │    │  ════════════════     │    │  ║
+ ║  │    │  [||||||||||||||||]   │    │  ║
+ ║  │    │  [||||||||||||||||]   │    │  ║
+ ║  │    └────────────────────────┘    │  ║
+ ║  │                                  │  ║
+ ║  │  ── POWERPC G5 (QUAD) ──        │  ║
+ ║  │  Rarity: Epic                   │  ║
+ ║  │  Mining Multiplier: 4.0x        │  ║
+ ║  │                                  │  ║
+ ║  │  Clock Speed .... 2.5 GHz       │  ║
+ ║  │  Architecture ... PowerPC 970MP │  ║
+ ║  │  Year ........... 2005          │  ║
+ ║  │  RAM ............ 16 GB         │  ║
+ ║  │  Hash Rate ...... 92 H/s        │  ║
+ ║  │                                  │  ║
+ ║  │  "Liquid-cooled quad cores in   │  ║
+ ║  │   an anodized aluminum fortress.│  ║
+ ║  │   The last PowerPC. The finest  │  ║
+ ║  │   Mac ever forged."             │  ║
+ ║  └────────────────────────────────┘  ║
+ ╚══════════════════════════════════════╝
+```
+
+| Stat | Value |
+|------|-------|
+| **Name** | PowerPC G5 (Quad) |
+| **Rarity** | Epic (Purple) |
+| **Mining Multiplier** | 4.0x |
+| **Clock Speed** | 2.5 GHz |
+| **Architecture** | PowerPC 970MP |
+| **Year** | 2005 |
+| **RAM** | 16 GB |
+| **Estimated Hash Rate** | 92 H/s |
+| **Flavor Text** | *"Liquid-cooled quad cores in an anodized aluminum fortress. The last PowerPC. The finest Mac ever forged."* |
+| **Special Ability** | **Liquid Cooling** — no thermal throttling; sustained max hash rate with zero decay |
+
+---
+
+## Card #007 — SGI Indigo2
+
+```
+ ╔══════════════════════════════════════╗
+ ║  ┌────────────────────────────────┐  ║
+ ║  │  RUSTCHAIN HARDWARE CARD #007  │  ║
+ ║  │  ████████████████████████████████  │  ║
+ ║  │      ┌──────────────────┐       │  ║
+ ║  │      │▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓│       │  ║
+ ║  │      │▓▓  SILICON  ▓▓▓▓▓│       │  ║
+ ║  │      │▓▓  GRAPHICS ▓▓▓▓▓│       │  ║
+ ║  │      │▓▓  INDIGO2  ▓▓▓▓▓│       │  ║
+ ║  │      │▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓│       │  ║
+ ║  │      │  ┌─┐ ┌─┐ ┌─┐     │       │  ║
+ ║  │      │  │▒│ │▒│ │▒│     │       │  ║
+ ║  │      │  └─┘ └─┘ └─┘     │       │  ║
+ ║  │      └──────────────────┘       │  ║
+ ║  │                                  │  ║
+ ║  │  ── SGI INDIGO2 ──              │  ║
+ ║  │  Rarity: Legendary              │  ║
+ ║  │  Mining Multiplier: 5.0x        │  ║
+ ║  │                                  │  ║
+ ║  │  Clock Speed .... 195 MHz       │  ║
+ ║  │  Architecture ... MIPS R10000   │  ║
+ ║  │  Year ........... 1995          │  ║
+ ║  │  RAM ............ 384 MB        │  ║
+ ║  │  Hash Rate ...... 44 H/s        │  ║
+ ║  │                                  │  ║
+ ║  │  "The machine that rendered     │  ║
+ ║  │   Jurassic Park now renders     │  ║
+ ║  │   blocks. IMPACT graphics       │  ║
+ ║  │   pipeline repurposed for       │  ║
+ ║  │   proof-of-work."               │  ║
+ ║  └────────────────────────────────┘  ║
+ ╚══════════════════════════════════════╝
+```
+
+| Stat | Value |
+|------|-------|
+| **Name** | SGI Indigo2 |
+| **Rarity** | Legendary (Holographic) |
+| **Mining Multiplier** | 5.0x |
+| **Clock Speed** | 195 MHz |
+| **Architecture** | MIPS R10000 |
+| **Year** | 1995 |
+| **RAM** | 384 MB |
+| **Estimated Hash Rate** | 44 H/s |
+| **Flavor Text** | *"The machine that rendered Jurassic Park now renders blocks. IMPACT graphics pipeline repurposed for proof-of-work."* |
+| **Special Ability** | **IRIX Pipeline** — dedicated geometry engine processes transactions in parallel, +25% block throughput |
+
+---
+
+## Card #008 — Cray-1 Supercomputer
+
+```
+ ╔══════════════════════════════════════╗
+ ║  ┌────────────────────────────────┐  ║
+ ║  │  RUSTCHAIN HARDWARE CARD #008  │  ║
+ ║  │  ◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆  │  ║
+ ║  │                                  │  ║
+ ║  │           ╱────────╲             │  ║
+ ║  │          ╱ ┌──────┐ ╲            │  ║
+ ║  │         │  │ CRAY │  │           │  ║
+ ║  │         │  │  -1  │  │           │  ║
+ ║  │         │  │██████│  │           │  ║
+ ║  │         │  │██████│  │           │  ║
+ ║  │         │  │██████│  │           │  ║
+ ║  │         │  └──────┘  │           │  ║
+ ║  │          ╲__________╱            │  ║
+ ║  │         [████BENCH████]          │  ║
+ ║  │                                  │  ║
+ ║  │  ── CRAY-1 SUPERCOMPUTER ──     │  ║
+ ║  │  Rarity: Mythic                 │  ║
+ ║  │  Mining Multiplier: 10.0x       │  ║
+ ║  │                                  │  ║
+ ║  │  Clock Speed .... 80 MHz        │  ║
+ ║  │  Architecture ... Cray Vector   │  ║
+ ║  │  Year ........... 1976          │  ║
+ ║  │  RAM ............ 8 MB          │  ║
+ ║  │  Hash Rate ...... 160 H/s       │  ║
+ ║  │                                  │  ║
+ ║  │  "Shaped like a throne for a    │  ║
+ ║  │   reason. Seymour Cray built    │  ║
+ ║  │   the fastest machine on Earth  │  ║
+ ║  │   and put a bench around it.    │  ║
+ ║  │   Vector pipes eat hashes."     │  ║
+ ║  └────────────────────────────────┘  ║
+ ╚══════════════════════════════════════╝
+```
+
+| Stat | Value |
+|------|-------|
+| **Name** | Cray-1 Supercomputer |
+| **Rarity** | Mythic (Prismatic) |
+| **Mining Multiplier** | 10.0x |
+| **Clock Speed** | 80 MHz |
+| **Architecture** | Cray Vector |
+| **Year** | 1976 |
+| **RAM** | 8 MB |
+| **Estimated Hash Rate** | 160 H/s |
+| **Flavor Text** | *"Shaped like a throne for a reason. Seymour Cray built the fastest machine on Earth and put a bench around it. Vector pipes eat hashes."* |
+| **Special Ability** | **Vector Dominance** — processes 8 hashes per clock cycle; all nearby miners gain +5% hash rate aura |
+
+---
+
+## Card #009 — NeXTcube
+
+```
+ ╔══════════════════════════════════════╗
+ ║  ┌────────────────────────────────┐  ║
+ ║  │  RUSTCHAIN HARDWARE CARD #009  │  ║
+ ║  │  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  │  ║
+ ║  │                                  │  ║
+ ║  │        ┌──────────────┐          │  ║
+ ║  │       ╱│             ╱│          │  ║
+ ║  │      ╱ │            ╱ │          │  ║
+ ║  │     ┌──────────────┐  │          │  ║
+ ║  │     │              │  │          │  ║
+ ║  │     │    NeXT       │  │          │  ║
+ ║  │     │     ██        │ ╱           │  ║
+ ║  │     │              │╱            │  ║
+ ║  │     └──────────────┘             │  ║
+ ║  │                                  │  ║
+ ║  │  ── NeXTcube ──                  │  ║
+ ║  │  Rarity: Epic                   │  ║
+ ║  │  Mining Multiplier: 3.5x        │  ║
+ ║  │                                  │  ║
+ ║  │  Clock Speed .... 25 MHz        │  ║
+ ║  │  Architecture ... Motorola 68040│  ║
+ ║  │  Year ........... 1990          │  ║
+ ║  │  RAM ............ 64 MB         │  ║
+ ║  │  Hash Rate ...... 12 H/s        │  ║
+ ║  │                                  │  ║
+ ║  │  "Tim Berners-Lee invented      │  ║
+ ║  │   the web on this black cube.   │  ║
+ ║  │   Now it mines the chain that   │  ║
+ ║  │   the web made possible."       │  ║
+ ║  └────────────────────────────────┘  ║
+ ╚══════════════════════════════════════╝
+```
+
+| Stat | Value |
+|------|-------|
+| **Name** | NeXTcube |
+| **Rarity** | Epic (Purple) |
+| **Mining Multiplier** | 3.5x |
+| **Clock Speed** | 25 MHz |
+| **Architecture** | Motorola 68040 |
+| **Year** | 1990 |
+| **RAM** | 64 MB |
+| **Estimated Hash Rate** | 12 H/s |
+| **Flavor Text** | *"Tim Berners-Lee invented the web on this black cube. Now it mines the chain that the web made possible."* |
+| **Special Ability** | **WWW Genesis** — first node to connect in a mining pool gets 2x block reward |
+
+---
+
+## Card #010 — DEC VAX-11/780
+
+```
+ ╔══════════════════════════════════════╗
+ ║  ┌────────────────────────────────┐  ║
+ ║  │  RUSTCHAIN HARDWARE CARD #010  │  ║
+ ║  │  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░  │  ║
+ ║  │                                  │  ║
+ ║  │    ┌──┐┌──┐┌──┐┌──┐┌──┐        │  ║
+ ║  │    │▓▓││▓▓││▓▓││▓▓││▓▓│        │  ║
+ ║  │    │▓▓││▓▓││▓▓││▓▓││▓▓│        │  ║
+ ║  │    │▓▓││▓▓││▓▓││▓▓││▓▓│        │  ║
+ ║  │    │▓▓││▓▓││▓▓││▓▓││▓▓│        │  ║
+ ║  │    │▓▓││▓▓││▓▓││▓▓││▓▓│        │  ║
+ ║  │    │▓▓││▓▓││▓▓││▓▓││▓▓│        │  ║
+ ║  │    └──┘└──┘└──┘└──┘└──┘        │  ║
+ ║  │       D  E  C    V  A  X       │  ║
+ ║  │                                  │  ║
+ ║  │  ── DEC VAX-11/780 ──           │  ║
+ ║  │  Rarity: Legendary              │  ║
+ ║  │  Mining Multiplier: 4.5x        │  ║
+ ║  │                                  │  ║
+ ║  │  Clock Speed .... 5 MHz         │  ║
+ ║  │  Architecture ... VAX (CISC)    │  ║
+ ║  │  Year ........... 1977          │  ║
+ ║  │  RAM ............ 2 MB          │  ║
+ ║  │  Hash Rate ...... 8 H/s         │  ║
+ ║  │                                  │  ║
+ ║  │  "One VUPS. The universal       │  ║
+ ║  │   benchmark of an era. If you   │  ║
+ ║  │   measured in VAX MIPS, you     │  ║
+ ║  │   understood computing."        │  ║
+ ║  └────────────────────────────────┘  ║
+ ╚══════════════════════════════════════╝
+```
+
+| Stat | Value |
+|------|-------|
+| **Name** | DEC VAX-11/780 |
+| **Rarity** | Legendary (Holographic) |
+| **Mining Multiplier** | 4.5x |
+| **Clock Speed** | 5 MHz |
+| **Architecture** | VAX (CISC) |
+| **Year** | 1977 |
+| **RAM** | 2 MB |
+| **Estimated Hash Rate** | 8 H/s |
+| **Flavor Text** | *"One VUPS. The universal benchmark of an era. If you measured in VAX MIPS, you understood computing."* |
+| **Special Ability** | **VMS Uptime** — this miner never goes offline; earns passive RTC even when not actively mining |
+
+---
+
+## Synergy Combos
+
+Combine cards for bonus effects during mining sessions:
+
+| Combo Name | Cards Required | Bonus |
+|------------|---------------|-------|
+| **Apple Orchard** | Apple II + PowerPC G3 + G4 + G5 | +50% RTC, all Apple cards get 2x multiplier |
+| **PowerPC Trinity** | G3 + G4 + G5 | +30% hash rate across all three |
+| **Retro Console Wars** | Dreamcast + Amiga 500 | +20% RTC, unlock hidden "Blast Processing" mode |
+| **Big Iron** | Cray-1 + DEC VAX-11/780 + SGI Indigo2 | +100% block reward, "Mainframe Supremacy" title |
+| **Web Origins** | NeXTcube + Apple II | +15% network propagation speed |
+| **Full Collection** | All 10 cards | +200% RTC, "Hardware Historian" badge, prismatic card borders |
+
+---
+
+## How Cards Work in RustChain
+
+1. **Equip** a card to your miner node configuration
+2. The **Mining Multiplier** scales your base hash rate
+3. **Special Abilities** activate under specific conditions
+4. **Synergy Combos** trigger when multiple cards are equipped simultaneously
+5. Cards can be **traded** on-chain between RustChain wallets
+6. Rarer cards have higher multipliers but lower drop rates from block rewards
+
+---
+
+*RustChain Hardware Trading Cards v1.0 -- Collect. Mine. Dominate.*


### PR DESCRIPTION
## Summary

- Designed 10 vintage hardware trading cards for RustChain mining: Apple II, Commodore Amiga 500, Sega Dreamcast, PowerPC G3/G4/G5, SGI Indigo2, Cray-1, NeXTcube, and DEC VAX-11/780
- Each card includes: name, rarity tier (Common through Mythic), mining multiplier, hardware stats (clock speed, architecture, year, RAM, hash rate), ASCII art, flavor text, and a unique special ability
- Added synergy combos for card combinations and an SVG card template for future card design

## Files

- `docs/trading-cards/cards.md` — Full card collection with 10 cards, rarity tiers, synergy combos, and gameplay mechanics
- `docs/trading-cards/card-template.svg` — Reusable SVG template with circuit-board pattern, stat blocks, and rarity gradient styles

## Bounty

Resolves #2072 — 8 RTC bounty for designing RustChain Hardware Trading Cards