### PR TITLE
docs: fix repository name in development setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ Browse [open bounties](https://github.com/Scottcjn/rustchain-bounties/issues) to
 
 ```bash
 # Clone your fork
-git clone https://github.com/YOUR_USERNAME/Rustchain.git
-cd Rustchain
+git clone https://github.com/YOUR_USERNAME/rustchain-bounties.git
+cd rustchain-bounties
 
 # Install dependencies
 npm install  # or cargo build (for Rust components)


### PR DESCRIPTION
## What does this PR do?
Fixed incorrect repository name in the Development Setup section of CONTRIBUTING.md.

## Why?
The Development Setup section referenced `Rustchain` repository, but contributors are actually working in the `rustchain-bounties` repository. This caused confusion when following the setup instructions.

## How to test?
1. Review the changes in CONTRIBUTING.md
2. Verify that the repository name now matches the actual repository

## Related Issues
Addresses bounty #2178 - Fix a typo or improve docs in any Elyan Labs repo

**Wallet for bounty reward:** `[wallet removed]`