### PR TITLE
feat: add fossil record attestation archaeology visualizer

### DIFF
--- a/docs/FOSSIL_RECORD.md
+++ b/docs/FOSSIL_RECORD.md
@@ -1,0 +1,83 @@
+# Fossil Record — Attestation Archaeology Visualizer
+
+Built for bounty **#2311**.
+
+## What it is
+
+`widgets/fossil-record.html` is a self-contained attestation timeline / stratigraphy viewer for RustChain.
+It renders architecture layers over time:
+
+- **X-axis** — time / epoch progression
+- **Y-axis** — architecture strata (oldest at the bottom)
+- **Width** — number of active miners in that architecture at the sampled moment
+- **Color** — architecture family
+- **Hover** — miner IDs, fingerprint quality, RTC earned, epoch, timestamp
+- **Markers** — epoch settlement lines + first-seen architecture points
+
+## Important reality check
+
+The public endpoint `GET /api/miners` exposes a **current snapshot**, not full historical attestation records.
+That means a true “since genesis” fossil record requires one of these inputs:
+
+1. **SQLite export** from the node database, or
+2. **Accumulated snapshots** sampled over time from `/api/miners`
+
+This implementation supports both.
+
+## Files
+
+- `widgets/fossil-record.html` — interactive visualization
+- `scripts/build_fossil_record.py` — normalize SQLite or JSON/JSONL history into chart-ready JSON
+- `scripts/sample_miners_history.py` — collect live `/api/miners` snapshots into JSONL
+- `widgets/data/miners-snapshots.sample.json` — sample seed history
+- `widgets/data/fossil-record.sample.json` — prebuilt demo dataset
+
+## Quick start
+
+### 1) View the demo
+
+Open:
+
+```bash
+open widgets/fossil-record.html
+```
+
+It loads `widgets/data/fossil-record.sample.json` by default.
+
+### 2) Build from a JSONL snapshot archive
+
+```bash
+python3 scripts/build_fossil_record.py   --input-json widgets/data/miners-history.jsonl   --output widgets/data/fossil-record.json
+```
+
+Then point the HTML at `fossil-record.json` (or replace the sample file).
+
+### 3) Build from SQLite history
+
+```bash
+python3 scripts/build_fossil_record.py   --input-sqlite /path/to/rustchain.db   --output widgets/data/fossil-record.json
+```
+
+The script auto-detects common attestation table names (`attestations`, `attestation_history`, `miner_attestations`, `attestation_events`).
+
+### 4) Start sampling live data
+
+```bash
+python3 scripts/sample_miners_history.py   --url https://bulbous-bouffant.metalseed.net/api/miners   --output widgets/data/miners-history.jsonl   --count 12   --interval 300
+```
+
+This captures one hour of history at 5-minute intervals. Run it longer to accumulate a deeper “fossil record”.
+
+## Deployment notes
+
+The page is static HTML/CSS/JS with no external dependencies, so it can be dropped directly into a simple site path such as:
+
+- `rustchain.org/fossils`
+- GitHub Pages
+- nginx static hosting
+
+## Known limitations
+
+- Without SQLite/history export, no tool can reconstruct “every attestation since genesis” from a single `/api/miners` call.
+- Public miner snapshots currently expose limited per-event metadata, so `rtc_earned` / fingerprint quality are best when sourced from database exports.
+- The builder normalizes several likely schemas, but a production RustChain DB export may need a tiny column mapping tweak if the table differs.

--- a/scripts/build_fossil_record.py
+++ b/scripts/build_fossil_record.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Build normalized fossil timeline data for the RustChain attestation archaeology visualizer.
+
+Inputs supported:
+1. SQLite database containing an attestations/history table.
+2. JSON/JSONL snapshot samples collected over time from /api/miners.
+
+Output is a normalized JSON file consumable by widgets/fossil-record.html.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+ARCH_ORDER = [
+    '68k', 'g3', 'g4', 'g5', 'sparc', 'mips', 'power8', 'apple_silicon', 'modern_x86', 'arm', 'other'
+]
+
+ARCH_META = {
+    '68k': {'label': '68K', 'color': '#7a4a00', 'bucket': 'vintage'},
+    'g3': {'label': 'G3', 'color': '#a85c2c', 'bucket': 'vintage'},
+    'g4': {'label': 'G4', 'color': '#c46a2d', 'bucket': 'vintage'},
+    'g5': {'label': 'G5', 'color': '#b87333', 'bucket': 'vintage'},
+    'sparc': {'label': 'SPARC', 'color': '#9f2b2b', 'bucket': 'retro'},
+    'mips': {'label': 'MIPS', 'color': '#1f8a70', 'bucket': 'retro'},
+    'power8': {'label': 'POWER8', 'color': '#1f4e79', 'bucket': 'retro'},
+    'apple_silicon': {'label': 'Apple Silicon', 'color': '#c0c0c0', 'bucket': 'modern'},
+    'modern_x86': {'label': 'Modern x86', 'color': '#b9c0c9', 'bucket': 'modern'},
+    'arm': {'label': 'ARM', 'color': '#4c9aff', 'bucket': 'modern'},
+    'other': {'label': 'Other', 'color': '#6b7280', 'bucket': 'modern'},
+}
+
+
+def iso_utc(ts: int | float | None) -> str | None:
+    if ts is None:
+        return None
+    return datetime.fromtimestamp(float(ts), tz=timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def canonical_arch(row: Dict[str, Any]) -> str:
+    arch = str(row.get('device_arch') or '').lower()
+    hw = str(row.get('hardware_type') or '').lower()
+    fam = str(row.get('device_family') or '').lower()
+    if '68' in arch or '68k' in hw:
+        return '68k'
+    if 'g3' in arch or 'g3' in hw:
+        return 'g3'
+    if 'g4' in arch or 'g4' in hw:
+        return 'g4'
+    if 'g5' in arch or 'g5' in hw:
+        return 'g5'
+    if 'sparc' in arch or 'sparc' in hw:
+        return 'sparc'
+    if 'mips' in arch or 'mips' in hw:
+        return 'mips'
+    if 'power8' in arch or 'power8' in hw or 'powerpc' in fam:
+        return 'power8'
+    if 'apple_silicon' in arch or 'apple silicon' in hw:
+        return 'apple_silicon'
+    if 'modern' in arch or fam == 'x86' or 'x86' in hw or 'ivy_bridge' in arch:
+        return 'modern_x86'
+    if fam == 'arm' or fam == 'aarch64' or arch == 'aarch64' or arch == 'arm':
+        return 'arm'
+    return 'other'
+
+
+def load_json_samples(path: Path) -> List[Dict[str, Any]]:
+    text = path.read_text()
+    if path.suffix.lower() == '.jsonl':
+        rows = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+        return rows
+    data = json.loads(text)
+    if isinstance(data, dict) and 'samples' in data:
+        return data['samples']
+    if isinstance(data, list):
+        return data
+    raise ValueError(f'Unsupported JSON structure in {path}')
+
+
+def read_sqlite_rows(db_path: Path) -> List[Dict[str, Any]]:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    tables = [r[0] for r in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+    target = None
+    for candidate in ('attestations', 'attestation_history', 'miner_attestations', 'attestation_events'):
+        if candidate in tables:
+            target = candidate
+            break
+    if not target:
+        raise SystemExit(f'No known attestation table found in {db_path}; tables={tables}')
+    cols = [r[1] for r in cur.execute(f'PRAGMA table_info({target})')]
+    colmap = {c.lower(): c for c in cols}
+    query = f'SELECT * FROM {target} ORDER BY ' + (colmap.get('timestamp') or colmap.get('attested_at') or colmap.get('created_at') or cols[0])
+    out = []
+    for row in cur.execute(query):
+        d = dict(row)
+        out.append({
+            'miner': d.get(colmap.get('miner')) or d.get(colmap.get('miner_id')),
+            'device_arch': d.get(colmap.get('device_arch')),
+            'device_family': d.get(colmap.get('device_family')),
+            'hardware_type': d.get(colmap.get('hardware_type')),
+            'entropy_score': d.get(colmap.get('entropy_score')),
+            'fingerprint_quality': d.get(colmap.get('fingerprint_quality')) or d.get(colmap.get('quality_score')),
+            'rtc_earned': d.get(colmap.get('rtc_earned')) or d.get(colmap.get('reward')) or 0,
+            'epoch': d.get(colmap.get('epoch')),
+            'timestamp': d.get(colmap.get('timestamp')) or d.get(colmap.get('attested_at')) or d.get(colmap.get('created_at')),
+        })
+    conn.close()
+    return out
+
+
+def normalize_samples(samples: List[Dict[str, Any]]) -> Dict[str, Any]:
+    events: List[Dict[str, Any]] = []
+    arch_seen: Dict[str, Dict[str, Any]] = {}
+    settlements = []
+    grouped: Dict[Tuple[str, int], List[Dict[str, Any]]] = defaultdict(list)
+
+    for sample in samples:
+        ts = sample.get('captured_at') or sample.get('timestamp') or sample.get('sampled_at')
+        if isinstance(ts, str) and ts.endswith('Z'):
+            sample_ts = int(datetime.fromisoformat(ts.replace('Z', '+00:00')).timestamp())
+        else:
+            sample_ts = int(ts)
+        epoch = sample.get('epoch')
+        miners = sample.get('miners') or sample.get('data') or []
+        settlements.append({'timestamp': sample_ts, 'iso_time': iso_utc(sample_ts), 'epoch': epoch})
+        for row in miners:
+            arch = canonical_arch(row)
+            event = {
+                'miner': row.get('miner'),
+                'arch': arch,
+                'arch_label': ARCH_META[arch]['label'],
+                'device_arch': row.get('device_arch'),
+                'device_family': row.get('device_family'),
+                'hardware_type': row.get('hardware_type'),
+                'entropy_score': row.get('entropy_score'),
+                'fingerprint_quality': row.get('fingerprint_quality', row.get('entropy_score')),
+                'rtc_earned': row.get('rtc_earned', row.get('reward', 0)),
+                'timestamp': sample_ts,
+                'iso_time': iso_utc(sample_ts),
+                'epoch': epoch,
+                'source': sample.get('source', 'snapshot'),
+            }
+            events.append(event)
+            grouped[(arch, sample_ts)].append(event)
+            if arch not in arch_seen:
+                arch_seen[arch] = {
+                    'arch': arch,
+                    'label': ARCH_META[arch]['label'],
+                    'timestamp': sample_ts,
+                    'iso_time': iso_utc(sample_ts),
+                    'epoch': epoch,
+                }
+
+    layers = []
+    for (arch, ts), rows in sorted(grouped.items(), key=lambda x: (x[0][1], ARCH_ORDER.index(x[0][0]) if x[0][0] in ARCH_ORDER else 999)):
+        layers.append({
+            'arch': arch,
+            'arch_label': ARCH_META[arch]['label'],
+            'timestamp': ts,
+            'iso_time': iso_utc(ts),
+            'epoch': rows[0].get('epoch'),
+            'count': len(rows),
+            'avg_entropy_score': round(sum(float(r.get('entropy_score') or 0) for r in rows) / max(len(rows), 1), 3),
+            'avg_fingerprint_quality': round(sum(float(r.get('fingerprint_quality') or 0) for r in rows) / max(len(rows), 1), 3),
+            'total_rtc_earned': round(sum(float(r.get('rtc_earned') or 0) for r in rows), 4),
+            'miners': [r['miner'] for r in rows],
+        })
+
+    return {
+        'generated_at': iso_utc(datetime.now(tz=timezone.utc).timestamp()),
+        'arch_order': ARCH_ORDER,
+        'arch_meta': ARCH_META,
+        'summary': {
+            'events': len(events),
+            'samples': len(samples),
+            'unique_miners': len({e['miner'] for e in events if e.get('miner')}),
+            'architectures': len({e['arch'] for e in events}),
+        },
+        'first_seen_architectures': list(sorted(arch_seen.values(), key=lambda r: r['timestamp'])),
+        'settlement_markers': settlements,
+        'layers': layers,
+        'events': events,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description='Build normalized fossil record data JSON')
+    ap.add_argument('--input-json', default='', help='JSON or JSONL sample history')
+    ap.add_argument('--input-sqlite', default='', help='SQLite DB with attestation history table')
+    ap.add_argument('--output', required=True, help='Output JSON path')
+    args = ap.parse_args()
+
+    if not args.input_json and not args.input_sqlite:
+        raise SystemExit('Provide --input-json or --input-sqlite')
+
+    if args.input_sqlite:
+        rows = read_sqlite_rows(Path(args.input_sqlite))
+        samples = [{'captured_at': r['timestamp'], 'epoch': r.get('epoch'), 'miners': [r], 'source': 'sqlite'} for r in rows]
+    else:
+        samples = load_json_samples(Path(args.input_json))
+
+    result = normalize_samples(samples)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2))
+    print(f'Wrote {out} with {result["summary"]["events"]} events')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/sample_miners_history.py
+++ b/scripts/sample_miners_history.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Append /api/miners snapshots into JSONL so fossil-record.html can build history over time.
+
+Example:
+  python3 scripts/sample_miners_history.py --output widgets/data/miners-history.jsonl --count 12 --interval 300
+"""
+from __future__ import annotations
+import argparse, json, time, urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+def now_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat().replace('+00:00', 'Z')
+
+def fetch_json(url: str):
+    req = urllib.request.Request(url, headers={'User-Agent': 'rustchain-fossil-sampler/1.0'})
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.load(resp)
+
+def main():
+    ap = argparse.ArgumentParser(description='Sample /api/miners into a JSONL history file')
+    ap.add_argument('--url', default='https://bulbous-bouffant.metalseed.net/api/miners')
+    ap.add_argument('--epoch-url', default='')
+    ap.add_argument('--output', required=True)
+    ap.add_argument('--count', type=int, default=1)
+    ap.add_argument('--interval', type=int, default=300, help='seconds between snapshots')
+    args = ap.parse_args()
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    for i in range(args.count):
+        miners = fetch_json(args.url)
+        epoch = None
+        if args.epoch_url:
+            try:
+                epoch_payload = fetch_json(args.epoch_url)
+                epoch = epoch_payload.get('epoch') if isinstance(epoch_payload, dict) else None
+            except Exception:
+                epoch = None
+        row = {
+            'captured_at': now_iso(),
+            'epoch': epoch,
+            'source': args.url,
+            'miners': miners,
+        }
+        with out.open('a') as fh:
+            fh.write(json.dumps(row) + '
+')
+        print(f'[{i+1}/{args.count}] wrote snapshot with {len(miners)} miners to {out}')
+        if i < args.count - 1:
+            time.sleep(args.interval)
+
+if __name__ == '__main__':
+    main()

--- a/widgets/data/fossil-record.sample.json
+++ b/widgets/data/fossil-record.sample.json
@@ -1,0 +1,557 @@
+{
+  "generated_at": "2026-03-22T07:41:23.606157Z",
+  "arch_order": [
+    "68k",
+    "g3",
+    "g4",
+    "g5",
+    "sparc",
+    "mips",
+    "power8",
+    "apple_silicon",
+    "modern_x86",
+    "arm",
+    "other"
+  ],
+  "arch_meta": {
+    "68k": {
+      "label": "68K",
+      "color": "#7a4a00",
+      "bucket": "vintage"
+    },
+    "g3": {
+      "label": "G3",
+      "color": "#a85c2c",
+      "bucket": "vintage"
+    },
+    "g4": {
+      "label": "G4",
+      "color": "#c46a2d",
+      "bucket": "vintage"
+    },
+    "g5": {
+      "label": "G5",
+      "color": "#b87333",
+      "bucket": "vintage"
+    },
+    "sparc": {
+      "label": "SPARC",
+      "color": "#9f2b2b",
+      "bucket": "retro"
+    },
+    "mips": {
+      "label": "MIPS",
+      "color": "#1f8a70",
+      "bucket": "retro"
+    },
+    "power8": {
+      "label": "POWER8",
+      "color": "#1f4e79",
+      "bucket": "retro"
+    },
+    "apple_silicon": {
+      "label": "Apple Silicon",
+      "color": "#c0c0c0",
+      "bucket": "modern"
+    },
+    "modern_x86": {
+      "label": "Modern x86",
+      "color": "#b9c0c9",
+      "bucket": "modern"
+    },
+    "arm": {
+      "label": "ARM",
+      "color": "#4c9aff",
+      "bucket": "modern"
+    },
+    "other": {
+      "label": "Other",
+      "color": "#6b7280",
+      "bucket": "modern"
+    }
+  },
+  "summary": {
+    "events": 15,
+    "samples": 4,
+    "unique_miners": 10,
+    "architectures": 4
+  },
+  "first_seen_architectures": [
+    {
+      "arch": "power8",
+      "label": "POWER8",
+      "timestamp": 1774164300,
+      "iso_time": "2026-03-22T07:25:00Z",
+      "epoch": 1201
+    },
+    {
+      "arch": "apple_silicon",
+      "label": "Apple Silicon",
+      "timestamp": 1774164300,
+      "iso_time": "2026-03-22T07:25:00Z",
+      "epoch": 1201
+    },
+    {
+      "arch": "modern_x86",
+      "label": "Modern x86",
+      "timestamp": 1774164300,
+      "iso_time": "2026-03-22T07:25:00Z",
+      "epoch": 1201
+    },
+    {
+      "arch": "arm",
+      "label": "ARM",
+      "timestamp": 1774164600,
+      "iso_time": "2026-03-22T07:30:00Z",
+      "epoch": 1202
+    }
+  ],
+  "settlement_markers": [
+    {
+      "timestamp": 1774164300,
+      "iso_time": "2026-03-22T07:25:00Z",
+      "epoch": 1201
+    },
+    {
+      "timestamp": 1774164600,
+      "iso_time": "2026-03-22T07:30:00Z",
+      "epoch": 1202
+    },
+    {
+      "timestamp": 1774164900,
+      "iso_time": "2026-03-22T07:35:00Z",
+      "epoch": 1203
+    },
+    {
+      "timestamp": 1774165200,
+      "iso_time": "2026-03-22T07:40:00Z",
+      "epoch": 1204
+    }
+  ],
+  "layers": [
+    {
+      "arch": "power8",
+      "arch_label": "POWER8",
+      "timestamp": 1774164300,
+      "iso_time": "2026-03-22T07:25:00Z",
+      "epoch": 1201,
+      "count": 1,
+      "avg_entropy_score": 0.94,
+      "avg_fingerprint_quality": 0.96,
+      "total_rtc_earned": 1.8,
+      "miners": [
+        "power8-s824-sophia"
+      ]
+    },
+    {
+      "arch": "apple_silicon",
+      "arch_label": "Apple Silicon",
+      "timestamp": 1774164300,
+      "iso_time": "2026-03-22T07:25:00Z",
+      "epoch": 1201,
+      "count": 1,
+      "avg_entropy_score": 0.78,
+      "avg_fingerprint_quality": 0.83,
+      "total_rtc_earned": 1.0,
+      "miners": [
+        "m2-mac-mini-sophia"
+      ]
+    },
+    {
+      "arch": "modern_x86",
+      "arch_label": "Modern x86",
+      "timestamp": 1774164300,
+      "iso_time": "2026-03-22T07:25:00Z",
+      "epoch": 1201,
+      "count": 1,
+      "avg_entropy_score": 0.67,
+      "avg_fingerprint_quality": 0.71,
+      "total_rtc_earned": 0.9,
+      "miners": [
+        "modern-sophiacore-3a168058"
+      ]
+    },
+    {
+      "arch": "power8",
+      "arch_label": "POWER8",
+      "timestamp": 1774164600,
+      "iso_time": "2026-03-22T07:30:00Z",
+      "epoch": 1202,
+      "count": 1,
+      "avg_entropy_score": 0.95,
+      "avg_fingerprint_quality": 0.97,
+      "total_rtc_earned": 1.9,
+      "miners": [
+        "power8-s824-sophia"
+      ]
+    },
+    {
+      "arch": "apple_silicon",
+      "arch_label": "Apple Silicon",
+      "timestamp": 1774164600,
+      "iso_time": "2026-03-22T07:30:00Z",
+      "epoch": 1202,
+      "count": 1,
+      "avg_entropy_score": 0.79,
+      "avg_fingerprint_quality": 0.84,
+      "total_rtc_earned": 1.1,
+      "miners": [
+        "claw-qinlingrongdeMacBook-Pro-48097"
+      ]
+    },
+    {
+      "arch": "modern_x86",
+      "arch_label": "Modern x86",
+      "timestamp": 1774164600,
+      "iso_time": "2026-03-22T07:30:00Z",
+      "epoch": 1202,
+      "count": 1,
+      "avg_entropy_score": 0.72,
+      "avg_fingerprint_quality": 0.79,
+      "total_rtc_earned": 1.1,
+      "miners": [
+        "trashcan-d500-scott"
+      ]
+    },
+    {
+      "arch": "arm",
+      "arch_label": "ARM",
+      "timestamp": 1774164600,
+      "iso_time": "2026-03-22T07:30:00Z",
+      "epoch": 1202,
+      "count": 1,
+      "avg_entropy_score": 0.42,
+      "avg_fingerprint_quality": 0.54,
+      "total_rtc_earned": 0.2,
+      "miners": [
+        "claw-jojo-51658"
+      ]
+    },
+    {
+      "arch": "power8",
+      "arch_label": "POWER8",
+      "timestamp": 1774164900,
+      "iso_time": "2026-03-22T07:35:00Z",
+      "epoch": 1203,
+      "count": 1,
+      "avg_entropy_score": 0.96,
+      "avg_fingerprint_quality": 0.98,
+      "total_rtc_earned": 2.0,
+      "miners": [
+        "power8-s824-sophia"
+      ]
+    },
+    {
+      "arch": "apple_silicon",
+      "arch_label": "Apple Silicon",
+      "timestamp": 1774164900,
+      "iso_time": "2026-03-22T07:35:00Z",
+      "epoch": 1203,
+      "count": 1,
+      "avg_entropy_score": 0.8,
+      "avg_fingerprint_quality": 0.85,
+      "total_rtc_earned": 1.1,
+      "miners": [
+        "m2-mac-mini-sophia"
+      ]
+    },
+    {
+      "arch": "modern_x86",
+      "arch_label": "Modern x86",
+      "timestamp": 1774164900,
+      "iso_time": "2026-03-22T07:35:00Z",
+      "epoch": 1203,
+      "count": 1,
+      "avg_entropy_score": 0.69,
+      "avg_fingerprint_quality": 0.76,
+      "total_rtc_earned": 0.8,
+      "miners": [
+        "ForestLee"
+      ]
+    },
+    {
+      "arch": "arm",
+      "arch_label": "ARM",
+      "timestamp": 1774164900,
+      "iso_time": "2026-03-22T07:35:00Z",
+      "epoch": 1203,
+      "count": 1,
+      "avg_entropy_score": 0.44,
+      "avg_fingerprint_quality": 0.57,
+      "total_rtc_earned": 0.25,
+      "miners": [
+        "terramaster-nas-arm64"
+      ]
+    },
+    {
+      "arch": "power8",
+      "arch_label": "POWER8",
+      "timestamp": 1774165200,
+      "iso_time": "2026-03-22T07:40:00Z",
+      "epoch": 1204,
+      "count": 1,
+      "avg_entropy_score": 0.96,
+      "avg_fingerprint_quality": 0.98,
+      "total_rtc_earned": 2.0,
+      "miners": [
+        "power8-s824-sophia"
+      ]
+    },
+    {
+      "arch": "apple_silicon",
+      "arch_label": "Apple Silicon",
+      "timestamp": 1774165200,
+      "iso_time": "2026-03-22T07:40:00Z",
+      "epoch": 1204,
+      "count": 1,
+      "avg_entropy_score": 0.81,
+      "avg_fingerprint_quality": 0.86,
+      "total_rtc_earned": 1.15,
+      "miners": [
+        "m2-mac-mini-sophia"
+      ]
+    },
+    {
+      "arch": "modern_x86",
+      "arch_label": "Modern x86",
+      "timestamp": 1774165200,
+      "iso_time": "2026-03-22T07:40:00Z",
+      "epoch": 1204,
+      "count": 2,
+      "avg_entropy_score": 0.59,
+      "avg_fingerprint_quality": 0.68,
+      "total_rtc_earned": 1.15,
+      "miners": [
+        "stepehenreed",
+        "tianlin-rtc"
+      ]
+    }
+  ],
+  "events": [
+    {
+      "miner": "power8-s824-sophia",
+      "arch": "power8",
+      "arch_label": "POWER8",
+      "device_arch": "power8",
+      "device_family": "powerpc",
+      "hardware_type": "PowerPC (Vintage)",
+      "entropy_score": 0.94,
+      "fingerprint_quality": 0.96,
+      "rtc_earned": 1.8,
+      "timestamp": 1774164300,
+      "iso_time": "2026-03-22T07:25:00Z",
+      "epoch": 1201,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "m2-mac-mini-sophia",
+      "arch": "apple_silicon",
+      "arch_label": "Apple Silicon",
+      "device_arch": "apple_silicon",
+      "device_family": "arm",
+      "hardware_type": "Apple Silicon (Modern)",
+      "entropy_score": 0.78,
+      "fingerprint_quality": 0.83,
+      "rtc_earned": 1.0,
+      "timestamp": 1774164300,
+      "iso_time": "2026-03-22T07:25:00Z",
+      "epoch": 1201,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "modern-sophiacore-3a168058",
+      "arch": "modern_x86",
+      "arch_label": "Modern x86",
+      "device_arch": "modern",
+      "device_family": "x86",
+      "hardware_type": "x86-64 (Modern)",
+      "entropy_score": 0.67,
+      "fingerprint_quality": 0.71,
+      "rtc_earned": 0.9,
+      "timestamp": 1774164300,
+      "iso_time": "2026-03-22T07:25:00Z",
+      "epoch": 1201,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "power8-s824-sophia",
+      "arch": "power8",
+      "arch_label": "POWER8",
+      "device_arch": "power8",
+      "device_family": "powerpc",
+      "hardware_type": "PowerPC (Vintage)",
+      "entropy_score": 0.95,
+      "fingerprint_quality": 0.97,
+      "rtc_earned": 1.9,
+      "timestamp": 1774164600,
+      "iso_time": "2026-03-22T07:30:00Z",
+      "epoch": 1202,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "trashcan-d500-scott",
+      "arch": "modern_x86",
+      "arch_label": "Modern x86",
+      "device_arch": "ivy_bridge",
+      "device_family": "x86",
+      "hardware_type": "x86-64 (Modern)",
+      "entropy_score": 0.72,
+      "fingerprint_quality": 0.79,
+      "rtc_earned": 1.1,
+      "timestamp": 1774164600,
+      "iso_time": "2026-03-22T07:30:00Z",
+      "epoch": 1202,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "claw-qinlingrongdeMacBook-Pro-48097",
+      "arch": "apple_silicon",
+      "arch_label": "Apple Silicon",
+      "device_arch": "apple_silicon",
+      "device_family": "arm",
+      "hardware_type": "Apple Silicon (Modern)",
+      "entropy_score": 0.79,
+      "fingerprint_quality": 0.84,
+      "rtc_earned": 1.1,
+      "timestamp": 1774164600,
+      "iso_time": "2026-03-22T07:30:00Z",
+      "epoch": 1202,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "claw-jojo-51658",
+      "arch": "arm",
+      "arch_label": "ARM",
+      "device_arch": "aarch64",
+      "device_family": "ARM",
+      "hardware_type": "Unknown/Other",
+      "entropy_score": 0.42,
+      "fingerprint_quality": 0.54,
+      "rtc_earned": 0.2,
+      "timestamp": 1774164600,
+      "iso_time": "2026-03-22T07:30:00Z",
+      "epoch": 1202,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "power8-s824-sophia",
+      "arch": "power8",
+      "arch_label": "POWER8",
+      "device_arch": "power8",
+      "device_family": "powerpc",
+      "hardware_type": "PowerPC (Vintage)",
+      "entropy_score": 0.96,
+      "fingerprint_quality": 0.98,
+      "rtc_earned": 2.0,
+      "timestamp": 1774164900,
+      "iso_time": "2026-03-22T07:35:00Z",
+      "epoch": 1203,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "m2-mac-mini-sophia",
+      "arch": "apple_silicon",
+      "arch_label": "Apple Silicon",
+      "device_arch": "apple_silicon",
+      "device_family": "arm",
+      "hardware_type": "Apple Silicon (Modern)",
+      "entropy_score": 0.8,
+      "fingerprint_quality": 0.85,
+      "rtc_earned": 1.1,
+      "timestamp": 1774164900,
+      "iso_time": "2026-03-22T07:35:00Z",
+      "epoch": 1203,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "ForestLee",
+      "arch": "modern_x86",
+      "arch_label": "Modern x86",
+      "device_arch": "modern",
+      "device_family": "x86",
+      "hardware_type": "x86-64 (Modern)",
+      "entropy_score": 0.69,
+      "fingerprint_quality": 0.76,
+      "rtc_earned": 0.8,
+      "timestamp": 1774164900,
+      "iso_time": "2026-03-22T07:35:00Z",
+      "epoch": 1203,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "terramaster-nas-arm64",
+      "arch": "arm",
+      "arch_label": "ARM",
+      "device_arch": "aarch64",
+      "device_family": "ARM",
+      "hardware_type": "Unknown/Other",
+      "entropy_score": 0.44,
+      "fingerprint_quality": 0.57,
+      "rtc_earned": 0.25,
+      "timestamp": 1774164900,
+      "iso_time": "2026-03-22T07:35:00Z",
+      "epoch": 1203,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "power8-s824-sophia",
+      "arch": "power8",
+      "arch_label": "POWER8",
+      "device_arch": "power8",
+      "device_family": "powerpc",
+      "hardware_type": "PowerPC (Vintage)",
+      "entropy_score": 0.96,
+      "fingerprint_quality": 0.98,
+      "rtc_earned": 2.0,
+      "timestamp": 1774165200,
+      "iso_time": "2026-03-22T07:40:00Z",
+      "epoch": 1204,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "m2-mac-mini-sophia",
+      "arch": "apple_silicon",
+      "arch_label": "Apple Silicon",
+      "device_arch": "apple_silicon",
+      "device_family": "arm",
+      "hardware_type": "Apple Silicon (Modern)",
+      "entropy_score": 0.81,
+      "fingerprint_quality": 0.86,
+      "rtc_earned": 1.15,
+      "timestamp": 1774165200,
+      "iso_time": "2026-03-22T07:40:00Z",
+      "epoch": 1204,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "stepehenreed",
+      "arch": "modern_x86",
+      "arch_label": "Modern x86",
+      "device_arch": "modern",
+      "device_family": "x86",
+      "hardware_type": "x86-64 (Modern)",
+      "entropy_score": 0.7,
+      "fingerprint_quality": 0.77,
+      "rtc_earned": 0.85,
+      "timestamp": 1774165200,
+      "iso_time": "2026-03-22T07:40:00Z",
+      "epoch": 1204,
+      "source": "sample-seed"
+    },
+    {
+      "miner": "tianlin-rtc",
+      "arch": "modern_x86",
+      "arch_label": "Modern x86",
+      "device_arch": "modern",
+      "device_family": "arm",
+      "hardware_type": "Unknown/Other",
+      "entropy_score": 0.48,
+      "fingerprint_quality": 0.59,
+      "rtc_earned": 0.3,
+      "timestamp": 1774165200,
+      "iso_time": "2026-03-22T07:40:00Z",
+      "epoch": 1204,
+      "source": "sample-seed"
+    }
+  ]
+}

--- a/widgets/data/miners-snapshots.sample.json
+++ b/widgets/data/miners-snapshots.sample.json
@@ -1,0 +1,45 @@
+[
+  {
+    "captured_at": 1774164300,
+    "epoch": 1201,
+    "source": "sample-seed",
+    "miners": [
+      {"miner": "power8-s824-sophia", "device_arch": "power8", "device_family": "powerpc", "hardware_type": "PowerPC (Vintage)", "entropy_score": 0.94, "fingerprint_quality": 0.96, "rtc_earned": 1.8},
+      {"miner": "m2-mac-mini-sophia", "device_arch": "apple_silicon", "device_family": "arm", "hardware_type": "Apple Silicon (Modern)", "entropy_score": 0.78, "fingerprint_quality": 0.83, "rtc_earned": 1.0},
+      {"miner": "modern-sophiacore-3a168058", "device_arch": "modern", "device_family": "x86", "hardware_type": "x86-64 (Modern)", "entropy_score": 0.67, "fingerprint_quality": 0.71, "rtc_earned": 0.9}
+    ]
+  },
+  {
+    "captured_at": 1774164600,
+    "epoch": 1202,
+    "source": "sample-seed",
+    "miners": [
+      {"miner": "power8-s824-sophia", "device_arch": "power8", "device_family": "powerpc", "hardware_type": "PowerPC (Vintage)", "entropy_score": 0.95, "fingerprint_quality": 0.97, "rtc_earned": 1.9},
+      {"miner": "trashcan-d500-scott", "device_arch": "ivy_bridge", "device_family": "x86", "hardware_type": "x86-64 (Modern)", "entropy_score": 0.72, "fingerprint_quality": 0.79, "rtc_earned": 1.1},
+      {"miner": "claw-qinlingrongdeMacBook-Pro-48097", "device_arch": "apple_silicon", "device_family": "arm", "hardware_type": "Apple Silicon (Modern)", "entropy_score": 0.79, "fingerprint_quality": 0.84, "rtc_earned": 1.1},
+      {"miner": "claw-jojo-51658", "device_arch": "aarch64", "device_family": "ARM", "hardware_type": "Unknown/Other", "entropy_score": 0.42, "fingerprint_quality": 0.54, "rtc_earned": 0.2}
+    ]
+  },
+  {
+    "captured_at": 1774164900,
+    "epoch": 1203,
+    "source": "sample-seed",
+    "miners": [
+      {"miner": "power8-s824-sophia", "device_arch": "power8", "device_family": "powerpc", "hardware_type": "PowerPC (Vintage)", "entropy_score": 0.96, "fingerprint_quality": 0.98, "rtc_earned": 2.0},
+      {"miner": "m2-mac-mini-sophia", "device_arch": "apple_silicon", "device_family": "arm", "hardware_type": "Apple Silicon (Modern)", "entropy_score": 0.80, "fingerprint_quality": 0.85, "rtc_earned": 1.1},
+      {"miner": "ForestLee", "device_arch": "modern", "device_family": "x86", "hardware_type": "x86-64 (Modern)", "entropy_score": 0.69, "fingerprint_quality": 0.76, "rtc_earned": 0.8},
+      {"miner": "terramaster-nas-arm64", "device_arch": "aarch64", "device_family": "ARM", "hardware_type": "Unknown/Other", "entropy_score": 0.44, "fingerprint_quality": 0.57, "rtc_earned": 0.25}
+    ]
+  },
+  {
+    "captured_at": 1774165200,
+    "epoch": 1204,
+    "source": "sample-seed",
+    "miners": [
+      {"miner": "power8-s824-sophia", "device_arch": "power8", "device_family": "powerpc", "hardware_type": "PowerPC (Vintage)", "entropy_score": 0.96, "fingerprint_quality": 0.98, "rtc_earned": 2.0},
+      {"miner": "m2-mac-mini-sophia", "device_arch": "apple_silicon", "device_family": "arm", "hardware_type": "Apple Silicon (Modern)", "entropy_score": 0.81, "fingerprint_quality": 0.86, "rtc_earned": 1.15},
+      {"miner": "stepehenreed", "device_arch": "modern", "device_family": "x86", "hardware_type": "x86-64 (Modern)", "entropy_score": 0.70, "fingerprint_quality": 0.77, "rtc_earned": 0.85},
+      {"miner": "tianlin-rtc", "device_arch": "modern", "device_family": "arm", "hardware_type": "Unknown/Other", "entropy_score": 0.48, "fingerprint_quality": 0.59, "rtc_earned": 0.3}
+    ]
+  }
+]

--- a/widgets/fossil-record.html
+++ b/widgets/fossil-record.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>RustChain Fossil Record — Attestation Archaeology</title>
+  <style>
+    :root {
+      --bg: #0b1020;
+      --panel: rgba(15, 23, 42, 0.82);
+      --panel-border: rgba(148, 163, 184, 0.18);
+      --text: #e5e7eb;
+      --muted: #94a3b8;
+      --accent: #f59e0b;
+      --grid: rgba(255,255,255,0.08);
+      --settlement: rgba(255,255,255,0.14);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background:
+        radial-gradient(circle at top, rgba(245, 158, 11, 0.14), transparent 30%),
+        linear-gradient(180deg, #1b2437 0%, var(--bg) 40%, #060912 100%);
+      color: var(--text);
+      min-height: 100vh;
+    }
+    .wrap { max-width: 1500px; margin: 0 auto; padding: 32px 20px 80px; }
+    .hero { margin-bottom: 24px; }
+    h1 { margin: 0 0 10px; font-size: clamp(2rem, 4vw, 3.8rem); }
+    .subtitle { color: var(--muted); max-width: 980px; line-height: 1.6; }
+    .grid { display: grid; grid-template-columns: 320px 1fr; gap: 20px; align-items: start; }
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--panel-border);
+      border-radius: 18px;
+      backdrop-filter: blur(14px);
+      box-shadow: 0 20px 60px rgba(0,0,0,0.35);
+    }
+    .sidebar { padding: 18px; position: sticky; top: 18px; }
+    .metric-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin: 18px 0 24px; }
+    .metric { background: rgba(255,255,255,0.03); border-radius: 14px; padding: 14px; border: 1px solid rgba(255,255,255,0.06); }
+    .metric .k { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; }
+    .metric .v { font-size: 1.55rem; font-weight: 700; margin-top: 8px; }
+    .legend-row { display:flex; align-items:center; gap:10px; margin: 10px 0; font-size: 14px; color: var(--muted); }
+    .swatch { width: 14px; height: 14px; border-radius: 999px; flex: none; }
+    .content { padding: 18px; }
+    .toolbar { display:flex; justify-content:space-between; align-items:center; gap: 10px; flex-wrap: wrap; margin-bottom: 10px; }
+    .toolbar .note { color: var(--muted); font-size: 14px; }
+    .toolbar input {
+      width: 100%; max-width: 360px; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08);
+      color: var(--text); padding: 10px 12px; border-radius: 10px;
+    }
+    svg { width: 100%; height: auto; display:block; }
+    .tooltip {
+      position: fixed; pointer-events: none; opacity: 0; transform: translate(-50%, -110%);
+      background: rgba(2,6,23,0.95); color: white; padding: 10px 12px; border-radius: 10px;
+      border: 1px solid rgba(255,255,255,0.08); font-size: 13px; line-height: 1.45; min-width: 220px;
+      box-shadow: 0 14px 40px rgba(0,0,0,0.4); transition: opacity 0.15s ease;
+      z-index: 20;
+    }
+    .timeline-label, .axis-label { fill: var(--muted); font-size: 12px; }
+    .chart-title { font-size: 14px; fill: #cbd5e1; font-weight: 600; }
+    .settlement-line { stroke: var(--settlement); stroke-dasharray: 4 5; }
+    .first-seen { stroke: white; stroke-width: 1.4; }
+    .empty { padding: 50px 20px; text-align: center; color: var(--muted); }
+    code { background: rgba(255,255,255,0.05); padding: 2px 6px; border-radius: 6px; }
+    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } .sidebar { position: static; } }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="hero">
+      <h1>🪨 The Fossil Record</h1>
+      <div class="subtitle">
+        Attestation archaeology for RustChain. Each band represents an architecture layer across time: old silicon at the bottom,
+        recent arrivals near the surface. Width encodes active miner count. Hover any stratum to inspect miners, fingerprint quality,
+        rewards, and the moment an architecture first emerged.
+      </div>
+    </div>
+    <div class="grid">
+      <aside class="panel sidebar">
+        <div><strong>Data contract</strong></div>
+        <div class="subtitle" style="font-size:14px; margin-top:8px;">
+          Load <code>widgets/data/fossil-record.sample.json</code> or generate your own with
+          <code>python3 scripts/build_fossil_record.py --input-sqlite rustchain.db --output widgets/data/fossil-record.json</code>.
+        </div>
+        <div class="metric-grid" id="metrics"></div>
+        <div style="margin-top: 6px; font-weight: 600;">Architecture strata</div>
+        <div id="legend"></div>
+        <div style="margin-top:18px; font-weight: 600;">First appearance markers</div>
+        <div class="subtitle" style="font-size: 14px; margin-top: 8px;">
+          White rings indicate the first known attestation of an architecture in the loaded dataset.
+          Vertical dashed lines mark epoch settlement snapshots.
+        </div>
+      </aside>
+      <section class="panel content">
+        <div class="toolbar">
+          <div class="note">Built for deploys like <code>rustchain.org/fossils</code>. No build step required.</div>
+          <input id="search" placeholder="Filter miner id…" />
+        </div>
+        <div id="chart"></div>
+      </section>
+    </div>
+  </div>
+  <div class="tooltip" id="tooltip"></div>
+  <script>
+    const tooltip = document.getElementById('tooltip');
+    const search = document.getElementById('search');
+    const SAMPLE_PATH = './data/fossil-record.sample.json';
+
+    const fmtNumber = new Intl.NumberFormat('en-US');
+    const fmtCompact = new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 });
+
+    function el(tag, attrs = {}, text = '') {
+      const node = document.createElement(tag);
+      Object.entries(attrs).forEach(([k, v]) => node.setAttribute(k, v));
+      if (text) node.textContent = text;
+      return node;
+    }
+
+    function showTooltip(html, evt) {
+      tooltip.innerHTML = html;
+      tooltip.style.left = `${evt.clientX}px`;
+      tooltip.style.top = `${evt.clientY}px`;
+      tooltip.style.opacity = 1;
+    }
+    function hideTooltip() { tooltip.style.opacity = 0; }
+
+    function renderMeta(data) {
+      const metrics = document.getElementById('metrics');
+      metrics.innerHTML = '';
+      const summary = data.summary || {};
+      [
+        ['Events', fmtCompact.format(summary.events || 0)],
+        ['Samples', fmtCompact.format(summary.samples || 0)],
+        ['Miners', fmtCompact.format(summary.unique_miners || 0)],
+        ['Architectures', fmtCompact.format(summary.architectures || 0)],
+      ].forEach(([k, v]) => {
+        const card = el('div', { class: 'metric' });
+        card.append(el('div', { class: 'k' }, k));
+        card.append(el('div', { class: 'v' }, v));
+        metrics.append(card);
+      });
+
+      const legend = document.getElementById('legend');
+      legend.innerHTML = '';
+      (data.arch_order || []).forEach(key => {
+        const meta = data.arch_meta[key];
+        if (!meta) return;
+        const row = el('div', { class: 'legend-row' });
+        row.append(el('span', { class: 'swatch', style: `background:${meta.color}` }));
+        row.append(el('span', {}, meta.label));
+        legend.append(row);
+      });
+    }
+
+    function renderChart(data, filter = '') {
+      const chart = document.getElementById('chart');
+      const allLayers = (data.layers || []).filter(layer => !filter || (layer.miners || []).some(m => (m || '').toLowerCase().includes(filter)));
+      if (!allLayers.length) {
+        chart.innerHTML = '<div class="empty">No strata match this filter.</div>';
+        return;
+      }
+      const archOrder = data.arch_order || [];
+      const archMeta = data.arch_meta || {};
+      const times = [...new Set(allLayers.map(d => d.timestamp))].sort((a, b) => a - b);
+      const minT = times[0], maxT = times[times.length - 1];
+      const maxCount = Math.max(...allLayers.map(d => d.count || 0), 1);
+      const width = 1080, height = 780;
+      const margin = { top: 50, right: 20, bottom: 70, left: 120 };
+      const innerW = width - margin.left - margin.right;
+      const innerH = height - margin.top - margin.bottom;
+      const archBand = innerH / Math.max(archOrder.length, 1);
+      const bandPadding = 10;
+      const x = (t) => margin.left + ((t - minT) / Math.max(1, (maxT - minT))) * innerW;
+      const y = (arch) => margin.top + archOrder.indexOf(arch) * archBand;
+      const bandH = archBand - bandPadding;
+      const rectH = Math.max(16, bandH * 0.72);
+      const rectY = (arch) => y(arch) + (bandH - rectH) / 2;
+      const rectW = (count) => Math.max(10, (count / maxCount) * Math.max(50, innerW / Math.max(times.length, 4)));
+
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+      svg.setAttribute('role', 'img');
+      svg.setAttribute('aria-label', 'RustChain fossil timeline');
+
+      const title = document.createElementNS(svg.namespaceURI, 'text');
+      title.setAttribute('x', margin.left);
+      title.setAttribute('y', 24);
+      title.setAttribute('class', 'chart-title');
+      title.textContent = 'Attestation stratigraphy';
+      svg.appendChild(title);
+
+      archOrder.forEach((arch, i) => {
+        const line = document.createElementNS(svg.namespaceURI, 'line');
+        const yy = margin.top + i * archBand + bandH + bandPadding / 2;
+        line.setAttribute('x1', margin.left);
+        line.setAttribute('x2', width - margin.right);
+        line.setAttribute('y1', yy);
+        line.setAttribute('y2', yy);
+        line.setAttribute('stroke', 'var(--grid)');
+        svg.appendChild(line);
+
+        const label = document.createElementNS(svg.namespaceURI, 'text');
+        label.setAttribute('x', margin.left - 12);
+        label.setAttribute('y', rectY(arch) + rectH / 2 + 4);
+        label.setAttribute('text-anchor', 'end');
+        label.setAttribute('class', 'timeline-label');
+        label.textContent = archMeta[arch]?.label || arch;
+        svg.appendChild(label);
+      });
+
+      (data.settlement_markers || []).forEach((marker, idx) => {
+        if (marker.timestamp < minT || marker.timestamp > maxT) return;
+        const lx = x(marker.timestamp);
+        const line = document.createElementNS(svg.namespaceURI, 'line');
+        line.setAttribute('x1', lx);
+        line.setAttribute('x2', lx);
+        line.setAttribute('y1', margin.top - 4);
+        line.setAttribute('y2', height - margin.bottom + 10);
+        line.setAttribute('class', 'settlement-line');
+        svg.appendChild(line);
+        if (idx < 10 || idx === (data.settlement_markers.length - 1)) {
+          const t = document.createElementNS(svg.namespaceURI, 'text');
+          t.setAttribute('x', lx + 4);
+          t.setAttribute('y', margin.top - 10);
+          t.setAttribute('class', 'axis-label');
+          t.textContent = marker.epoch != null ? `E${marker.epoch}` : '';
+          svg.appendChild(t);
+        }
+      });
+
+      allLayers.forEach(layer => {
+        const arch = layer.arch;
+        const meta = archMeta[arch] || { color: '#888', label: arch };
+        const w = rectW(layer.count);
+        const rx = x(layer.timestamp) - w / 2;
+        const ry = rectY(arch);
+        const rect = document.createElementNS(svg.namespaceURI, 'rect');
+        rect.setAttribute('x', rx);
+        rect.setAttribute('y', ry);
+        rect.setAttribute('width', w);
+        rect.setAttribute('height', rectH);
+        rect.setAttribute('rx', Math.min(12, rectH / 2));
+        rect.setAttribute('fill', meta.color);
+        rect.setAttribute('fill-opacity', '0.88');
+        rect.setAttribute('stroke', 'rgba(255,255,255,0.22)');
+        rect.style.cursor = 'pointer';
+        rect.addEventListener('mousemove', (evt) => {
+          showTooltip(`
+            <strong>${meta.label}</strong><br>
+            ${layer.iso_time || ''}${layer.epoch != null ? ` · Epoch ${layer.epoch}` : ''}<br>
+            Active miners: <strong>${layer.count}</strong><br>
+            Avg fingerprint quality: <strong>${layer.avg_fingerprint_quality ?? 'n/a'}</strong><br>
+            RTC earned: <strong>${layer.total_rtc_earned ?? 0}</strong><br>
+            Miners: ${(layer.miners || []).slice(0, 6).join(', ')}${(layer.miners || []).length > 6 ? '…' : ''}
+          `, evt);
+        });
+        rect.addEventListener('mouseleave', hideTooltip);
+        svg.appendChild(rect);
+      });
+
+      (data.first_seen_architectures || []).forEach(item => {
+        if (!archOrder.includes(item.arch) || item.timestamp < minT || item.timestamp > maxT) return;
+        const cx = x(item.timestamp);
+        const cy = rectY(item.arch) + rectH / 2;
+        const circle = document.createElementNS(svg.namespaceURI, 'circle');
+        circle.setAttribute('cx', cx);
+        circle.setAttribute('cy', cy);
+        circle.setAttribute('r', 8);
+        circle.setAttribute('fill', 'none');
+        circle.setAttribute('class', 'first-seen');
+        circle.style.cursor = 'pointer';
+        circle.addEventListener('mousemove', (evt) => {
+          showTooltip(`<strong>First seen:</strong> ${item.label}<br>${item.iso_time || ''}${item.epoch != null ? ` · Epoch ${item.epoch}` : ''}`, evt);
+        });
+        circle.addEventListener('mouseleave', hideTooltip);
+        svg.appendChild(circle);
+      });
+
+      const ticks = 6;
+      for (let i = 0; i < ticks; i++) {
+        const ratio = i / (ticks - 1 || 1);
+        const ts = minT + (maxT - minT) * ratio;
+        const tx = x(ts);
+        const label = document.createElementNS(svg.namespaceURI, 'text');
+        label.setAttribute('x', tx);
+        label.setAttribute('y', height - margin.bottom + 26);
+        label.setAttribute('text-anchor', 'middle');
+        label.setAttribute('class', 'axis-label');
+        label.textContent = new Date(ts * 1000).toISOString().slice(0, 10);
+        svg.appendChild(label);
+      }
+      const xLabel = document.createElementNS(svg.namespaceURI, 'text');
+      xLabel.setAttribute('x', margin.left + innerW / 2);
+      xLabel.setAttribute('y', height - 18);
+      xLabel.setAttribute('text-anchor', 'middle');
+      xLabel.setAttribute('class', 'axis-label');
+      xLabel.textContent = 'Time / epoch progression';
+      svg.appendChild(xLabel);
+
+      chart.innerHTML = '';
+      chart.appendChild(svg);
+    }
+
+    async function load() {
+      const res = await fetch(SAMPLE_PATH);
+      const data = await res.json();
+      renderMeta(data);
+      renderChart(data);
+      search.addEventListener('input', () => renderChart(data, search.value.trim().toLowerCase()));
+    }
+    load().catch(err => {
+      document.getElementById('chart').innerHTML = `<div class="empty">Failed to load fossil data.<br><br>${err}</div>`;
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Description
- add a self-contained `widgets/fossil-record.html` archaeology/timeline visualizer for RustChain attestations
- add `scripts/build_fossil_record.py` to normalize SQLite exports or JSON/JSONL snapshot history into chart-ready data
- add `scripts/sample_miners_history.py` so the public `/api/miners` endpoint can be sampled over time when full DB history is unavailable
- include `docs/FOSSIL_RECORD.md` and sample datasets for local/demo validation

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing
- built `widgets/data/fossil-record.sample.json` from sample snapshots with `python3 scripts/build_fossil_record.py`
- served the static page locally with `python3 -m http.server` and verified the HTML + data load correctly
- verified the current public `/api/miners` endpoint structure and confirmed it is snapshot-only, so full “since genesis” history requires SQLite export or accumulated samples

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested changes locally

## Bounty Claim
If this PR addresses a bounty issue:
- Issue number: #2311
- Wallet ID: tianlin-rtc

Closes #2311
