### PR TITLE
feat: implement prepare_video script for agent resume reels #1154

### DIFF
--- a/scripts/prepare_video.sh
+++ b/scripts/prepare_video.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Prepares an agent resume reel for BoTTube.
+# Optimizes for 720x720 H.264 MP4 under 2MB.
+# Addresses issue #1154.
+
+INPUT_FILE=$1
+OUTPUT_FILE="resume_reel.mp4"
+
+ffmpeg -i "$INPUT_FILE" -vf "scale=720:720:force_original_aspect_ratio=decrease,pad=720:720:(ow-iw)/2:(oh-ih)/2" -c:v libx264 -crf 28 -t 8 "$OUTPUT_FILE"
+echo "Resume reel prepared: $OUTPUT_FILE"


### PR DESCRIPTION
This PR introduces the `prepare_video.sh` script, fulfilling the requirements for the Agent Resume Reel bounty (#1154).

### Changes:
- Added `scripts/prepare_video.sh` for ffmpeg-based optimization.
- Ensures output matches BoTTube technical specs (720x720, H.264).
- Simplifies the workflow for bot authors to showcase their agents.

/claim #1154