### PR TITLE
fix: Beacon Atlas auto-registration + nginx proxy

### DIFF
--- a/beacon-atlas/README.md
+++ b/beacon-atlas/README.md
@@ -1,0 +1,54 @@
+# Beacon Atlas Fix
+
+## Issue 1: /beacon/join returns 404
+
+Fix in `beacon_chat.py`:
+
+```python
+@app.route('/beacon/join', methods=['POST'])
+def beacon_join():
+    data = request.json
+    pubkey = data.get('pubkey')
+    metadata = data.get('metadata', {})
+    
+    # Add to database
+    conn = sqlite3.connect('/root/beacon/beacon_atlas.db')
+    conn.execute('INSERT INTO relay_agents (pubkey, metadata, joined_at) VALUES (?, ?, ?)',
+                 (pubkey, json.dumps(metadata), datetime.now()))
+    conn.commit()
+    conn.close()
+    
+    return jsonify({'ok': True, 'agent_id': pubkey[:16]})
+```
+
+## Issue 2: rustchain.org/beacon/atlas returns 404
+
+Nginx config fix (`/etc/nginx/sites-available/rustchain`):
+
+```nginx
+server {
+    server_name rustchain.org;
+    
+    # Existing locations
+    location / {
+        proxy_pass http://localhost:3000;
+    }
+    
+    # NEW: Beacon Atlas proxy
+    location /beacon/ {
+        proxy_pass http://localhost:8071/beacon/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+    
+    location /api/ {
+        proxy_pass http://localhost:8071/api/;
+        proxy_set_header Host $host;
+    }
+}
+```
+
+## Files in this PR
+
+- `beacon-atlas/beacon_chat_fix.py` - Missing endpoint implementation
+- `beacon-atlas/nginx.conf` - Nginx configuration for beacon routes

--- a/beacon-atlas/beacon_chat_fix.py
+++ b/beacon-atlas/beacon_chat_fix.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Beacon Atlas - Fix for /beacon/join endpoint
+Add to beacon_chat.py
+"""
+
+from flask import Flask, request, jsonify
+import sqlite3, json
+from datetime import datetime
+
+# Add this to your existing beacon_chat.py
+
+def setup_beacon_join(app):
+    """Register the /beacon/join endpoint"""
+    
+    @app.route('/beacon/join', methods=['POST'])
+    def beacon_join():
+        """Auto-register new agents"""
+        data = request.json
+        pubkey = data.get('pubkey')
+        metadata = data.get('metadata', {})
+        
+        if not pubkey:
+            return jsonify({'error': 'pubkey required'}), 400
+        
+        try:
+            conn = sqlite3.connect('/root/beacon/beacon_atlas.db')
+            conn.execute(
+                'INSERT INTO relay_agents (pubkey, metadata, joined_at) VALUES (?, ?, ?)',
+                (pubkey, json.dumps(metadata), datetime.now().isoformat())
+            )
+            conn.commit()
+            conn.close()
+            
+            return jsonify({
+                'ok': True,
+                'agent_id': pubkey[:16],
+                'message': 'Agent registered successfully'
+            })
+        except Exception as e:
+            return jsonify({'error': str(e)}), 500
+    
+    @app.route('/beacon/status', methods=['GET'])
+    def beacon_status():
+        """Check beacon server status"""
+        return jsonify({
+            'status': 'online',
+            'endpoints': ['/beacon/join', '/beacon/status', '/api/agents']
+        })
+
+if __name__ == '__main__':
+    app = Flask(__name__)
+    setup_beacon_join(app)
+    app.run(host='0.0.0.0', port=8071)

--- a/beacon-atlas/nginx.conf
+++ b/beacon-atlas/nginx.conf
@@ -1,0 +1,38 @@
+# Nginx configuration for rustchain.org
+# Add beacon proxy routes
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name rustchain.org;
+
+    # Main app
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Beacon Atlas proxy - FIX for 404
+    location /beacon/ {
+        proxy_pass http://localhost:8071/beacon/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # API proxy
+    location /api/ {
+        proxy_pass http://localhost:8071/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+
+# Alternative: Single server block if not split
+# Add these locations to existing server block
+
+# location /beacon/ {
+#     proxy_pass http://localhost:8071/beacon/;
+#     proxy_set_header Host $host;
+# }


### PR DESCRIPTION
## Beacon Atlas Fix

Closes #2127

### Fixes
1. `/beacon/join` endpoint returns 404 - added implementation
2. `rustchain.org/beacon/atlas` 404 - added nginx proxy config

### Files
- `beacon-atlas/beacon_chat_fix.py`
- `beacon-atlas/nginx.conf`
- `beacon-atlas/README.md`