### PR TITLE
fix(glassworm-protocol): trivially bypassable poa signature verification

### DIFF
--- a/glassworm-protocol/src/main.py
+++ b/glassworm-protocol/src/main.py
@@ -5,13 +5,20 @@ import json
 from github import Github
 
 def verify_poa(commit_sha, poa_hash, rpc_url):
-    # Mocking Proof of Antiquity verification against RustChain
-    # A real implementation would call the RustChain RPC to verify the micro-hash
-    # against the block header and difficulty target.
-    print(f"Verifying PoA Hash {poa_hash} for commit {commit_sha}...")
-    if poa_hash and poa_hash.startswith("poa_"):
-        return True
-    return False
+    if not rpc_url:
+        print("ERROR: No RPC URL configured; cannot verify PoA.")
+        return False
+    try:
+        resp = requests.post(
+            f"{rpc_url}/verify_poa",
+            json={"commit_sha": commit_sha, "poa_hash": poa_hash},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json().get("valid", False)
+    except Exception as exc:
+        print(f"PoA verification failed: {exc}")
+        return False
 
 def main():
     token = os.environ.get("INPUT_GITHUB-TOKEN")
@@ -57,7 +64,7 @@ def main():
     is_valid = verify_poa(latest_commit.sha, poa_hash, rpc_url)
     
     if is_valid:
-        pr.create_issue_comment("✅ **Glassworm Protocol Verified** ✅\n\nProof of Antiquity signature successfully validated. Hardware fingerprint confirmed.")
+        pr.create_issue_comment("\u2705 **Glassworm Protocol Verified** \u2705\n\nProof of Antiquity signature successfully validated. Hardware fingerprint confirmed.")
         pr.add_to_labels("poa-verified")
         try:
             pr.remove_from_labels("poa-failed")
@@ -66,7 +73,7 @@ def main():
         print("PoA signature valid.")
         sys.exit(0)
     else:
-        pr.create_issue_comment("🛑 **Glassworm Protocol Alert** 🛑\n\nInvalid Proof of Antiquity signature detected. Hardware Sybil attempt flagged.")
+        pr.create_issue_comment("\ud83d\uded1 **Glassworm Protocol Alert** \ud83d\uded1\n\nInvalid Proof of Antiquity signature detected. Hardware Sybil attempt flagged.")
         pr.add_to_labels("poa-failed")
         try:
             pr.remove_from_labels("poa-verified")


### PR DESCRIPTION
## Security Fix

### Problem
The verify_poa() function in glassworm-protocol/src/main.py only checks that the PoA hash starts with 'poa_' — any string like 'poa_fake' passes as valid. This means anyone can spoof hardware attestation by simply prefixing their commit message signature with 'poa_', bypassing the entire Proof of Antiquity validation. The function is supposed to call the RustChain RPC to validate the hash against the block header but never does, making the security control completely ineffective.

**Severity**: `critical`
**File**: `glassworm-protocol/src/main.py`

### Solution
Replace the stub with a real RPC call to verify the PoA hash on-chain. At minimum, fail closed (return False) rather than passing on a trivial prefix check until real verification is implemented:

def verify_poa(commit_sha: str, poa_hash: str, rpc_url: str) -> bool:
    if not rpc_url:
        print("ERROR: No RPC URL configured; cannot verify PoA.")
        return False
    try:
        resp = requests.post(
            f"{rpc_url}/verify_poa",
            json={"commit_sha": commit_sha, "poa_hash": poa_hash},
            timeout=10,
        )
        resp.raise_for_status()
        return resp.json().get("valid", False)
    except Exception as exc:
        print(f"PoA verification failed: {exc}")
        return False

### Changes
- `glassworm-protocol/src/main.py` (modified)

## Bounty Submission

**Bounty**: Closes #ISSUE_NUMBER

**RTC Wallet**: YOUR_WALLET_NAME

> **RTC wallets are string names** (e.g. `my-wallet`, `alice`, `builder-fred`).
> Do NOT use ETH/SOL/ERG addresses. Pick any name and start mining:
> `pip install clawrtc && clawrtc --wallet your-name`
>
> RustChain is a long-term project. Bounties grow the ecosystem — not for quick cash-outs.
> If you won't support what you build, don't build it.

## BCOS Checklist (Required For Non-Doc PRs)

- [ ] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [ ] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [ ] Provide test evidence (commands + output or screenshots)

## Changes

- ...

## Testing

- [ ] `npm test` / `python -m pytest` / manual verification passes
- [ ] Demo or reproduction steps provided

## Evidence

- Proof links (screenshots/logs/metrics):
- Before vs after summary:
- Validation method:

## Quality Gate Self-Score (0-5)

| Dimension | Score | Notes |
|---|---:|---|
| Impact |  |  |
| Correctness |  |  |
| Evidence |  |  |
| Craft |  |  |

Suggested gate for maintainers: >=13/20 total and Correctness > 0.

## Checklist

- [ ] All acceptance criteria from the bounty issue are met
- [ ] Code is tested
- [ ] No secrets or credentials committed
- [ ] Submission does not match any global disqualifier


## Supply-Chain Proof (Required if changed)

Complete this if your PR changes dependencies, install docs, CI tooling, or external artifacts.

- [ ] Dependency versions are pinned (or intentionally ranged with reason)
- [ ] External repo references include commit SHA
- [ ] Artifact checksum/container digest provided
- [ ] No `curl | bash` or equivalent blind install steps

Proof details:
- Dependency diff summary:
- SHA/checksum/digest:
- Repro command used by reviewer:

Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #2789