### PR TITLE
[BOUNTY #2868] VS Code Extension — Epoch Timer + Miner Status + Bounty Browser (30 RTC)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -25,6 +25,7 @@
     "mining"
   ],
   "activationEvents": [
+    "onStartupFinished",
     "onLanguage:rustchain-config",
     "workspaceContains:**/rustchain.toml",
     "workspaceContains:**/rustchain.yaml"
@@ -103,6 +104,41 @@
         "path": "./snippets/rustchain-config.json"
       }
     ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "rustchain-sidebar",
+          "title": "RustChain",
+          "icon": "$(circuit-board)"
+        }
+      ]
+    },
+    "views": {
+      "rustchain-sidebar": [
+        {
+          "id": "rustchainBounties",
+          "name": "Open Bounties",
+          "icon": "$(circuit-board)",
+          "contextualTitle": "RustChain Bounties"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "rustchain.refreshBounties",
+          "when": "view == rustchainBounties",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "rustchain.claimBounty",
+          "when": "view == rustchainBounties && viewItem == bounty",
+          "group": "inline"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "rustchain.refreshBalance",
@@ -115,6 +151,16 @@
       {
         "command": "rustchain.checkNodeHealth",
         "title": "RustChain: Check Node Health"
+      },
+      {
+        "command": "rustchain.refreshBounties",
+        "title": "Refresh Bounties",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "rustchain.claimBounty",
+        "title": "Open in Browser",
+        "icon": "$(link-external)"
       }
     ]
   },

--- a/vscode-extension/src/bountyBrowser.ts
+++ b/vscode-extension/src/bountyBrowser.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Sidebar tree view: browse open RustChain bounties from GitHub.
+ */
+
+import * as https from "https";
+import * as vscode from "vscode";
+
+const BOUNTIES_URL =
+    "https://api.github.com/repos/Scottcjn/rustchain-bounties/issues?state=open&labels=bounty&per_page=30";
+
+interface BountyIssue {
+    number: number;
+    title: string;
+    html_url: string;
+    rtc: number;
+}
+
+function extractRtc(title: string): number {
+    const m = title.match(/(\d+)\s*RTC/);
+    return m ? parseInt(m[1], 10) : 0;
+}
+
+function fetchBounties(): Promise<BountyIssue[]> {
+    return new Promise((resolve, reject) => {
+        https.get(
+            BOUNTIES_URL,
+            {
+                rejectUnauthorized: false,
+                headers: { "User-Agent": "rustchain-vscode/1.0" },
+                timeout: 10_000,
+            },
+            (res) => {
+                const chunks: Buffer[] = [];
+                res.on("data", (c: Buffer) => chunks.push(c));
+                res.on("end", () => {
+                    try {
+                        const raw = JSON.parse(Buffer.concat(chunks).toString()) as Array<{
+                            number: number;
+                            title: string;
+                            html_url: string;
+                        }>;
+                        const bounties = raw
+                            .map((i) => ({
+                                number: i.number,
+                                title: i.title,
+                                html_url: i.html_url,
+                                rtc: extractRtc(i.title),
+                            }))
+                            .sort((a, b) => b.rtc - a.rtc);
+                        resolve(bounties);
+                    } catch (e) {
+                        reject(e);
+                    }
+                });
+            },
+        ).on("error", reject);
+    });
+}
+
+class BountyItem extends vscode.TreeItem {
+    constructor(public readonly bounty: BountyIssue) {
+        super(`${bounty.rtc} RTC — #${bounty.number}`, vscode.TreeItemCollapsibleState.None);
+        this.description = bounty.title.replace(/\[BOUNTY[^\]]*\]/i, "").trim();
+        this.tooltip = `${bounty.title}\n\nClick to open in browser`;
+        this.command = {
+            command: "vscode.open",
+            title: "Open Bounty",
+            arguments: [vscode.Uri.parse(bounty.html_url)],
+        };
+        this.iconPath = new vscode.ThemeIcon(
+            bounty.rtc >= 50 ? "star-full" : bounty.rtc >= 20 ? "star-half" : "circle-small-filled",
+        );
+        this.contextValue = "bounty";
+    }
+}
+
+export class BountyBrowserProvider
+    implements vscode.TreeDataProvider<BountyItem>
+{
+    private _onDidChangeTreeData = new vscode.EventEmitter<BountyItem | undefined>();
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+    private bounties: BountyIssue[] = [];
+    private loading = false;
+    private error: string | undefined;
+
+    constructor(context: vscode.ExtensionContext) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand("rustchain.refreshBounties", () =>
+                this.refresh()
+            ),
+            vscode.commands.registerCommand("rustchain.claimBounty", (item: BountyItem) => {
+                void vscode.env.openExternal(vscode.Uri.parse(item.bounty.html_url));
+            }),
+        );
+        void this.refresh();
+    }
+
+    async refresh(): Promise<void> {
+        this.loading = true;
+        this.error = undefined;
+        this._onDidChangeTreeData.fire(undefined);
+        try {
+            this.bounties = await fetchBounties();
+        } catch (e) {
+            this.error = e instanceof Error ? e.message : String(e);
+            this.bounties = [];
+        } finally {
+            this.loading = false;
+            this._onDidChangeTreeData.fire(undefined);
+        }
+    }
+
+    getTreeItem(element: BountyItem): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(): BountyItem[] {
+        if (this.loading) {
+            return [new BountyItem({ number: 0, title: "Loading bounties…", html_url: "", rtc: 0 })];
+        }
+        if (this.error) {
+            return [new BountyItem({ number: 0, title: `Error: ${this.error}`, html_url: "", rtc: 0 })];
+        }
+        return this.bounties.map((b) => new BountyItem(b));
+    }
+}

--- a/vscode-extension/src/epochTimer.ts
+++ b/vscode-extension/src/epochTimer.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Status-bar item showing epoch progress and countdown to next settlement.
+ */
+
+import * as vscode from "vscode";
+import { fetchEpoch, EpochInfo } from "./rustchainApi";
+
+const BLOCK_TIME_S = 600; // 10 minutes per slot
+
+export class EpochTimer implements vscode.Disposable {
+    private readonly item: vscode.StatusBarItem;
+    private timer: ReturnType<typeof setInterval> | undefined;
+    private lastEpoch: EpochInfo | undefined;
+
+    constructor(context: vscode.ExtensionContext) {
+        this.item = vscode.window.createStatusBarItem(
+            vscode.StatusBarAlignment.Right,
+            49, // just left of balance
+        );
+        this.item.command = "rustchain.checkNodeHealth";
+        context.subscriptions.push(this.item);
+        this.refresh();
+        this.startPolling();
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const epoch = await fetchEpoch();
+            this.lastEpoch = epoch;
+            this.render(epoch);
+        } catch {
+            this.item.text = "$(clock) RTC: epoch?";
+            this.item.tooltip = "Could not fetch epoch info";
+            this.item.show();
+        }
+    }
+
+    private render(epoch: EpochInfo): void {
+        const slotsLeft = epoch.blocks_per_epoch - epoch.slot;
+        const secsLeft = slotsLeft * BLOCK_TIME_S;
+        const hoursLeft = Math.floor(secsLeft / 3600);
+        const minsLeft = Math.floor((secsLeft % 3600) / 60);
+
+        const timeStr =
+            hoursLeft > 0
+                ? `${hoursLeft}h ${minsLeft}m`
+                : `${minsLeft}m`;
+
+        this.item.text = `$(clock) E${epoch.epoch} ${timeStr}`;
+        this.item.tooltip =
+            `Epoch ${epoch.epoch}  |  Slot ${epoch.slot}/${epoch.blocks_per_epoch}\n` +
+            `Next settlement in ~${timeStr}\n` +
+            `Pot: ${epoch.epoch_pot.toFixed(2)} RTC  |  Miners: ${epoch.enrolled_miners}\n` +
+            `Click to check node health`;
+        this.item.show();
+    }
+
+    dispose(): void {
+        this.stopPolling();
+        this.item.dispose();
+    }
+
+    private startPolling(): void {
+        this.timer = setInterval(() => void this.refresh(), 5 * 60 * 1000);
+    }
+
+    private stopPolling(): void {
+        if (this.timer !== undefined) {
+            clearInterval(this.timer);
+            this.timer = undefined;
+        }
+    }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4,24 +4,42 @@
  *
  * Provides:
  * - RTC balance display in the status bar
+ * - Epoch countdown timer in the status bar
+ * - Miner/wallet active status indicator
+ * - Bounty browser sidebar panel
  * - RustChain config file syntax highlighting
  * - Code snippets for RustChain development
  *
- * Bounty: #1619
+ * Bounty: #2868
  */
 
 import * as vscode from "vscode";
 import { BalanceStatusBar } from "./balanceStatusBar";
 import { NodeHealthChecker } from "./nodeHealth";
+import { EpochTimer } from "./epochTimer";
+import { MinerStatus } from "./minerStatus";
+import { BountyBrowserProvider } from "./bountyBrowser";
 
 let balanceStatusBar: BalanceStatusBar | undefined;
 let nodeHealthChecker: NodeHealthChecker | undefined;
+let epochTimer: EpochTimer | undefined;
+let minerStatus: MinerStatus | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
     const config = vscode.workspace.getConfiguration("rustchain");
 
     // --- Status bar: RTC balance ---
     balanceStatusBar = new BalanceStatusBar(context);
+
+    // --- Status bar: Epoch countdown ---
+    epochTimer = new EpochTimer(context);
+
+    // --- Status bar: Miner active/idle indicator ---
+    minerStatus = new MinerStatus(context);
+
+    // --- Sidebar: Bounty browser ---
+    const bountyBrowser = new BountyBrowserProvider(context);
+    vscode.window.registerTreeDataProvider("rustchainBounties", bountyBrowser);
 
     // --- Node health checker ---
     nodeHealthChecker = new NodeHealthChecker();
@@ -46,6 +64,7 @@ export function activate(context: vscode.ExtensionContext): void {
                     .getConfiguration("rustchain")
                     .update("minerId", minerId, vscode.ConfigurationTarget.Global);
                 balanceStatusBar?.refresh();
+                minerStatus?.onConfigChange();
             }
         }),
     );
@@ -61,6 +80,7 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.workspace.onDidChangeConfiguration((e) => {
             if (e.affectsConfiguration("rustchain")) {
                 balanceStatusBar?.onConfigChange();
+                minerStatus?.onConfigChange();
             }
         }),
     );
@@ -69,5 +89,9 @@ export function activate(context: vscode.ExtensionContext): void {
 export function deactivate(): void {
     balanceStatusBar?.dispose();
     balanceStatusBar = undefined;
+    epochTimer?.dispose();
+    epochTimer = undefined;
+    minerStatus?.dispose();
+    minerStatus = undefined;
     nodeHealthChecker = undefined;
 }

--- a/vscode-extension/src/minerStatus.ts
+++ b/vscode-extension/src/minerStatus.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Checks whether the configured wallet/miner is in the active miners list.
+ * Shows a green/red indicator in the status bar.
+ */
+
+import * as vscode from "vscode";
+import { fetchMiners } from "./rustchainApi";
+
+export class MinerStatus implements vscode.Disposable {
+    private readonly item: vscode.StatusBarItem;
+    private timer: ReturnType<typeof setInterval> | undefined;
+
+    constructor(context: vscode.ExtensionContext) {
+        this.item = vscode.window.createStatusBarItem(
+            vscode.StatusBarAlignment.Right,
+            48,
+        );
+        this.item.command = "rustchain.checkNodeHealth";
+        context.subscriptions.push(this.item);
+        this.refresh();
+        this.startPolling();
+    }
+
+    async refresh(): Promise<void> {
+        const config = vscode.workspace.getConfiguration("rustchain");
+        const minerId = config.get<string>("minerId", "");
+        if (!minerId) {
+            this.item.hide();
+            return;
+        }
+
+        try {
+            const data = await fetchMiners();
+            const miners: Array<{ miner_id?: string }> = data?.miners ?? [];
+            const isActive = miners.some(
+                (m) => m.miner_id === minerId,
+            );
+
+            this.item.text = isActive
+                ? "$(circle-filled) Mining"
+                : "$(circle-slash) Idle";
+            this.item.color = isActive
+                ? new vscode.ThemeColor("charts.green")
+                : new vscode.ThemeColor("charts.yellow");
+            this.item.tooltip = isActive
+                ? `Miner "${minerId}" is actively attesting`
+                : `Miner "${minerId}" is not in the current active set`;
+            this.item.show();
+        } catch {
+            this.item.text = "$(circle-slash) Offline";
+            this.item.color = new vscode.ThemeColor("charts.red");
+            this.item.tooltip = "Could not reach RustChain node";
+            this.item.show();
+        }
+    }
+
+    onConfigChange(): void {
+        this.refresh();
+    }
+
+    dispose(): void {
+        this.stopPolling();
+        this.item.dispose();
+    }
+
+    private startPolling(): void {
+        this.timer = setInterval(() => void this.refresh(), 3 * 60 * 1000);
+    }
+
+    private stopPolling(): void {
+        if (this.timer !== undefined) {
+            clearInterval(this.timer);
+            this.timer = undefined;
+        }
+    }
+}

--- a/vscode-extension/src/rustchainApi.ts
+++ b/vscode-extension/src/rustchainApi.ts
@@ -113,3 +113,17 @@ export async function fetchHealth(): Promise<NodeHealth> {
 export async function fetchEpoch(): Promise<EpochInfo> {
     return httpGet<EpochInfo>("/epoch");
 }
+
+export interface MinerInfo {
+    miner_id?: string;
+    antiquity_multiplier?: number;
+    device_arch?: string;
+}
+
+export interface MinersResponse {
+    miners: MinerInfo[];
+}
+
+export async function fetchMiners(): Promise<MinersResponse> {
+    return httpGet<MinersResponse>("/api/miners");
+}


### PR DESCRIPTION
## Bounty

Closes #2868 — **30 RTC**

## What's added

This PR extends the existing VS Code extension skeleton with three new features:

### 1. Epoch Countdown Timer (`epochTimer.ts`)
- New status bar item (priority 49, just left of balance)
- Shows `$(clock) E{epoch} {hours}h {mins}m` — live countdown to next settlement
- Tooltip includes: epoch number, slot progress (`slot/blocks_per_epoch`), epoch pot (RTC), enrolled miners
- Refreshes every 5 minutes via `setInterval`
- Graceful error state: shows `$(clock) RTC: epoch?`

### 2. Miner Active/Idle Indicator (`minerStatus.ts`)
- New status bar item (priority 48)
- Calls `GET /api/miners` and checks if configured `rustchain.minerId` is in the active set
- `$(circle-filled) Mining` — green (`charts.green`) when active
- `$(circle-slash) Idle` — yellow (`charts.yellow`) when not in active set
- `$(circle-slash) Offline` — red (`charts.red`) on node error
- Hides automatically when no miner ID is configured
- Refreshes every 3 minutes; reacts to config changes

### 3. Bounty Browser Sidebar (`bountyBrowser.ts`)
- Activity bar panel: "RustChain" with circuit-board icon
- Fetches open GitHub issues labelled `bounty` from this repo (GitHub API, top 30)
- Sorted by RTC value descending
- Each item shows `{RTC} RTC — #{issue}` with the bounty description as subtitle
- Icons: `star-full` ≥50 RTC, `star-half` ≥20 RTC, `circle-small-filled` otherwise
- Click any bounty → opens in browser
- Refresh button in panel toolbar
- Loading state and error state handled

### API & Extension wiring
- `rustchainApi.ts`: added `fetchMiners()` returning `MinersResponse`
- `extension.ts`: instantiates all three new classes; `MinerStatus.onConfigChange()` triggered on `rustchain.*` config updates
- `package.json`: 
  - `activationEvents`: added `onStartupFinished` so status bar items appear immediately
  - `viewsContainers` + `views`: registers `rustchain-sidebar` activitybar + `rustchainBounties` tree view
  - `menus`: refresh button in view/title, open-in-browser in view/item/context
  - `commands`: `rustchain.refreshBounties`, `rustchain.claimBounty`

## Test plan

- [ ] Open VS Code with extension loaded — status bar shows epoch timer and (if minerId set) miner status
- [ ] Click epoch timer → triggers node health check
- [ ] Set `rustchain.minerId` → miner status updates immediately
- [ ] Open RustChain sidebar panel → bounties load sorted by RTC
- [ ] Click a bounty → opens GitHub issue in browser
- [ ] Click refresh button in sidebar → bounties reload
- [ ] Disable network → status bar shows offline/error states gracefully

🤖 Wallet: 暖暖