### PR TITLE
[BOUNTY #2864] GitHub Action — Auto-Award RTC on PR Merge (20 RTC)

### DIFF
--- a/github-action/README.md
+++ b/github-action/README.md
@@ -1,0 +1,94 @@
+# RustChain RTC Reward Action
+
+A GitHub Action that automatically awards **RTC tokens** to contributors when their pull request is merged.
+
+Any open-source project can add one YAML file and start rewarding contributors with crypto — zero backend required.
+
+## Quick Start
+
+```yaml
+# .github/workflows/rtc-reward.yml
+name: Award RTC on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  reward:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: Scottcjn/rustchain-bounties/github-action@main
+        with:
+          amount: 5
+          wallet-from: my-project-fund
+          admin-key: ${{ secrets.RTC_ADMIN_KEY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## How It Finds the Recipient Wallet
+
+The action searches for the recipient wallet in this order:
+
+1. **PR body** — scans for a line matching `Wallet: <wallet-id>` (customizable regex)
+2. **`.rtc-wallet` file** — reads from the repo root
+3. **GitHub username** — falls back to the PR author's GitHub login
+
+### PR Body Example
+
+Contributors add their wallet to the PR description:
+
+```
+## Changes
+
+Added feature X and fixed bug Y.
+
+Wallet: my-wallet-name
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `node-url` | No | `https://50.28.86.131` | RustChain node URL |
+| `amount` | No | `5` | RTC to award per merged PR |
+| `wallet-from` | **Yes** | — | Sender wallet ID |
+| `admin-key` | **Yes** | — | Admin key (store in Secrets) |
+| `wallet-pattern` | No | `wallet[\s:]+(\S+)` | Regex to find recipient wallet in PR body |
+| `dry-run` | No | `false` | Simulate without real transfer |
+| `comment-on-pr` | No | `true` | Post confirmation comment |
+| `require-label` | No | _(any PR)_ | Only award if PR has this label |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `awarded` | `"true"` if RTC was sent |
+| `recipient-wallet` | Wallet that received the RTC |
+| `tx-id` | RustChain transaction ID |
+| `amount-rtc` | Amount awarded |
+
+## Features
+
+- **Zero npm dependencies** — pure Node.js built-ins, fast cold start
+- **Dry-run mode** — test your setup before going live
+- **Label filtering** — award only bounty-labelled PRs
+- **Auto-fallback** — GitHub username if no wallet found
+- **PR comments** — automatic confirmation with transaction ID
+- **Self-signed cert support** — works with the default RustChain node
+
+## Security
+
+- Store `admin-key` in **GitHub Secrets**, never in workflow files
+- The action only posts comments if `GITHUB_TOKEN` is provided
+- TLS verification can be enforced by removing `rejectUnauthorized: false`
+
+## Bounty
+
+Built for RustChain bounty [#2864](https://github.com/Scottcjn/rustchain-bounties/issues/2864).
+
+**Wallet:** 暖暖

--- a/github-action/action.yml
+++ b/github-action/action.yml
@@ -1,0 +1,62 @@
+name: "RustChain RTC Reward"
+description: "Automatically award RTC tokens to contributors when their pull request is merged."
+author: "RustChain Community"
+
+branding:
+  icon: "award"
+  color: "orange"
+
+inputs:
+  node-url:
+    description: "URL of the RustChain attestation node."
+    required: false
+    default: "https://50.28.86.131"
+
+  amount:
+    description: "Amount of RTC to award per merged PR."
+    required: false
+    default: "5"
+
+  wallet-from:
+    description: "Sender wallet ID (the project fund wallet)."
+    required: true
+
+  admin-key:
+    description: "Admin/private key for the sender wallet. Store in GitHub Secrets."
+    required: true
+
+  wallet-pattern:
+    description: |
+      Regex pattern to extract recipient wallet from PR body.
+      Default matches lines like: Wallet: my-wallet-name
+    required: false
+    default: "(?i)wallet[:\\s]+([a-zA-Z0-9_\\-\\.]{3,64})"
+
+  dry-run:
+    description: "If 'true', simulate the award without making real transfers."
+    required: false
+    default: "false"
+
+  comment-on-pr:
+    description: "If 'true', post a confirmation comment on the PR."
+    required: false
+    default: "true"
+
+  require-label:
+    description: "Only award if PR has this label (leave empty to award all merged PRs)."
+    required: false
+    default: ""
+
+outputs:
+  awarded:
+    description: "Whether RTC was actually awarded ('true' or 'false')."
+  recipient-wallet:
+    description: "The recipient wallet ID that received (or would receive) the RTC."
+  tx-id:
+    description: "Transaction ID from the RustChain node (empty in dry-run mode)."
+  amount-rtc:
+    description: "Amount of RTC awarded."
+
+runs:
+  using: "node20"
+  main: "dist/index.js"

--- a/github-action/dist/index.js
+++ b/github-action/dist/index.js
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: MIT
+// dist/index.js — bundled entry point (no external dependencies, pure Node.js built-ins)
+// Auto-generated from src/index.js — edit src/index.js and copy here for distribution.
+
+const https = require("https");
+const fs = require("fs");
+const path = require("path");
+
+function getInput(name) {
+    const key = `INPUT_${name.toUpperCase().replace(/ /g, "_")}`;
+    return (process.env[key] || "").trim();
+}
+
+function setOutput(name, value) {
+    const outputFile = process.env.GITHUB_OUTPUT;
+    if (outputFile) {
+        fs.appendFileSync(outputFile, `${name}=${value}\n`);
+    } else {
+        console.log(`::set-output name=${name}::${value}`);
+    }
+}
+
+function info(msg) { console.log(`\x1b[36m[RTC]\x1b[0m ${msg}`); }
+function warn(msg) { console.log(`\x1b[33m[WARN]\x1b[0m ${msg}`); }
+function error(msg) { console.log(`\x1b[31m[ERROR]\x1b[0m ${msg}`); }
+function setFailed(msg) { error(msg); process.exit(1); }
+
+function httpsGet(url, options = {}) {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const req = https.get(parsed, { rejectUnauthorized: false, ...options }, (res) => {
+            const chunks = [];
+            res.on("data", (c) => chunks.push(c));
+            res.on("end", () => {
+                const body = Buffer.concat(chunks).toString();
+                resolve({ status: res.statusCode, body, headers: res.headers });
+            });
+        });
+        req.on("error", reject);
+        req.on("timeout", () => { req.destroy(); reject(new Error("Request timed out")); });
+    });
+}
+
+function httpsPost(url, data, options = {}) {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const body = JSON.stringify(data);
+        const req = https.request(
+            {
+                hostname: parsed.hostname,
+                port: parsed.port || 443,
+                path: parsed.pathname + parsed.search,
+                method: "POST",
+                rejectUnauthorized: false,
+                headers: {
+                    "Content-Type": "application/json",
+                    "Content-Length": Buffer.byteLength(body),
+                    ...(options.headers || {}),
+                },
+                timeout: 15_000,
+            },
+            (res) => {
+                const chunks = [];
+                res.on("data", (c) => chunks.push(c));
+                res.on("end", () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }));
+            },
+        );
+        req.on("error", reject);
+        req.on("timeout", () => { req.destroy(); reject(new Error("Request timed out")); });
+        req.write(body);
+        req.end();
+    });
+}
+
+async function githubPost(apiPath, data) {
+    const token = process.env.GITHUB_TOKEN;
+    const bodyStr = JSON.stringify(data);
+    return new Promise((resolve, reject) => {
+        const req = https.request(
+            {
+                hostname: "api.github.com",
+                port: 443,
+                path: apiPath,
+                method: "POST",
+                rejectUnauthorized: false,
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "User-Agent": "rtc-reward-action/1.0",
+                    "Accept": "application/vnd.github+json",
+                    "Content-Type": "application/json",
+                    "Content-Length": Buffer.byteLength(bodyStr),
+                },
+            },
+            (res) => {
+                const chunks = [];
+                res.on("data", (c) => chunks.push(c));
+                res.on("end", () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }));
+            },
+        );
+        req.on("error", reject);
+        req.write(bodyStr);
+        req.end();
+    });
+}
+
+function extractWalletFromBody(prBody, pattern) {
+    if (!prBody) return null;
+    try {
+        const re = new RegExp(pattern, "im");
+        const m = prBody.match(re);
+        return m ? m[1].trim() : null;
+    } catch (e) {
+        warn(`Invalid wallet-pattern regex: ${e.message}`);
+        return null;
+    }
+}
+
+function extractWalletFromFile() {
+    const ws = process.env.GITHUB_WORKSPACE || ".";
+    for (const name of [".rtc-wallet", ".rtc-wallet.txt"]) {
+        const f = path.join(ws, name);
+        if (fs.existsSync(f)) {
+            const content = fs.readFileSync(f, "utf-8").trim();
+            if (content) { info(`Found wallet in ${f}: ${content}`); return content; }
+        }
+    }
+    return null;
+}
+
+async function checkNodeHealth(nodeUrl) {
+    const res = await httpsGet(`${nodeUrl}/health`);
+    const data = JSON.parse(res.body);
+    return data.ok === true;
+}
+
+async function transferRTC(nodeUrl, fromWallet, toWallet, amount, adminKey) {
+    const res = await httpsPost(`${nodeUrl}/wallet/transfer`, {
+        from_wallet: fromWallet,
+        to_wallet: toWallet,
+        amount_rtc: amount,
+        admin_key: adminKey,
+    });
+    if (res.status < 200 || res.status >= 300) {
+        throw new Error(`Transfer failed (HTTP ${res.status}): ${res.body}`);
+    }
+    const data = JSON.parse(res.body);
+    return data.tx_id || data.transaction_id || "unknown";
+}
+
+async function run() {
+    const nodeUrl = getInput("node-url") || "https://50.28.86.131";
+    const amount = parseFloat(getInput("amount") || "5");
+    const walletFrom = getInput("wallet-from");
+    const adminKey = getInput("admin-key");
+    const walletPattern = getInput("wallet-pattern") || "(?i)wallet[:\\s]+([a-zA-Z0-9_\\-\\.]{3,64})";
+    const dryRun = getInput("dry-run") === "true";
+    const commentOnPR = getInput("comment-on-pr") !== "false";
+    const requireLabel = getInput("require-label");
+
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (!eventPath || !fs.existsSync(eventPath)) {
+        setFailed("GITHUB_EVENT_PATH not set — this action must run on pull_request events.");
+        return;
+    }
+    const event = JSON.parse(fs.readFileSync(eventPath, "utf-8"));
+    const pr = event.pull_request;
+    if (!pr) { setFailed("No pull_request in event payload."); return; }
+
+    const repo = process.env.GITHUB_REPOSITORY;
+    const prNumber = pr.number;
+    const prAuthor = pr.user?.login || "unknown";
+    const prBody = pr.body || "";
+    const prLabels = (pr.labels || []).map((l) => l.name);
+    const merged = pr.merged === true;
+
+    info(`PR #${prNumber} by @${prAuthor} — merged: ${merged}`);
+
+    if (!merged) {
+        info("PR closed without merging — skipping.");
+        setOutput("awarded", "false");
+        setOutput("recipient-wallet", "");
+        setOutput("tx-id", "");
+        setOutput("amount-rtc", "0");
+        return;
+    }
+
+    if (requireLabel && !prLabels.includes(requireLabel)) {
+        info(`Label "${requireLabel}" not found on PR — skipping.`);
+        setOutput("awarded", "false");
+        setOutput("recipient-wallet", "");
+        setOutput("tx-id", "");
+        setOutput("amount-rtc", "0");
+        return;
+    }
+
+    let recipientWallet = extractWalletFromBody(prBody, walletPattern);
+    if (!recipientWallet) recipientWallet = extractWalletFromFile();
+    if (!recipientWallet) {
+        recipientWallet = prAuthor;
+        warn(`Wallet not found — falling back to GitHub username: ${recipientWallet}`);
+    }
+
+    info(`Recipient: ${recipientWallet} | Amount: ${amount} RTC | Dry-run: ${dryRun}`);
+    setOutput("recipient-wallet", recipientWallet);
+    setOutput("amount-rtc", String(amount));
+
+    if (dryRun) {
+        info("DRY-RUN — no transfer made.");
+        setOutput("awarded", "false");
+        setOutput("tx-id", "");
+        if (commentOnPR) {
+            await githubPost(`/repos/${repo}/issues/${prNumber}/comments`, {
+                body: [
+                    `### 🧪 RTC Reward Dry-Run`,
+                    ``,
+                    `| | |`,
+                    `|---|---|`,
+                    `| **Would award** | ${amount} RTC |`,
+                    `| **Recipient** | \`${recipientWallet}\` |`,
+                    `| **From** | \`${walletFrom}\` |`,
+                    `| **Node** | ${nodeUrl} |`,
+                    ``,
+                    `_Dry-run mode — no actual transfer was made._`,
+                ].join("\n"),
+            });
+        }
+        return;
+    }
+
+    const healthy = await checkNodeHealth(nodeUrl).catch(() => false);
+    if (!healthy) { setFailed(`Node ${nodeUrl} is unhealthy.`); return; }
+
+    const txId = await transferRTC(nodeUrl, walletFrom, recipientWallet, amount, adminKey)
+        .catch((e) => { setFailed(`Transfer failed: ${e.message}`); return null; });
+    if (!txId) return;
+
+    info(`✅ ${amount} RTC → ${recipientWallet} | tx: ${txId}`);
+    setOutput("awarded", "true");
+    setOutput("tx-id", txId);
+
+    if (commentOnPR) {
+        await githubPost(`/repos/${repo}/issues/${prNumber}/comments`, {
+            body: [
+                `### 🎉 RTC Reward Sent!`,
+                ``,
+                `| | |`,
+                `|---|---|`,
+                `| **Awarded** | ${amount} RTC |`,
+                `| **Recipient** | \`${recipientWallet}\` |`,
+                `| **Transaction** | \`${txId}\` |`,
+                `| **Node** | ${nodeUrl} |`,
+                ``,
+                `Thank you for contributing! 🚀`,
+                ``,
+                `_Powered by [RustChain RTC Reward Action](https://github.com/Scottcjn/rustchain-bounties/tree/main/github-action)_`,
+            ].join("\n"),
+        }).catch((e) => warn(`Could not post comment: ${e.message}`));
+    }
+}
+
+run().catch((e) => setFailed(String(e)));

--- a/github-action/example-workflow.yml
+++ b/github-action/example-workflow.yml
@@ -1,0 +1,41 @@
+# Example: Add this to .github/workflows/rtc-reward.yml in your repo
+name: Award RTC on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  reward:
+    # Only run when the PR was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write  # needed to post the confirmation comment
+
+    steps:
+      - uses: Scottcjn/rustchain-bounties/github-action@main
+        with:
+          # RustChain node URL (default node works out of the box)
+          node-url: https://50.28.86.131
+
+          # How much RTC to award per merged PR
+          amount: 5
+
+          # Your project's fund wallet ID
+          wallet-from: my-project-fund
+
+          # Store the admin key in GitHub Secrets — never hardcode it!
+          admin-key: ${{ secrets.RTC_ADMIN_KEY }}
+
+          # Post a "🎉 RTC Reward Sent!" comment on the PR (default: true)
+          comment-on-pr: true
+
+          # Optional: only reward PRs with a specific label
+          # require-label: "bounty"
+
+          # Optional: test mode — simulates without real transfer
+          # dry-run: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/github-action/src/index.js
+++ b/github-action/src/index.js
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: MIT
+/**
+ * RustChain RTC Reward — GitHub Action
+ *
+ * Awards RTC tokens to contributors when their PR is merged.
+ * Reads recipient wallet from:
+ *   1. PR body (regex match on wallet-pattern input)
+ *   2. .rtc-wallet file in the repo root
+ *   3. Falls back to contributor's GitHub username as wallet ID
+ */
+
+const https = require("https");
+const fs = require("fs");
+const path = require("path");
+
+// ---------------------------------------------------------------------------
+// GitHub Actions core helpers (inline — no @actions/core dependency)
+// ---------------------------------------------------------------------------
+
+function getInput(name) {
+    const key = `INPUT_${name.toUpperCase().replace(/ /g, "_")}`;
+    return (process.env[key] || "").trim();
+}
+
+function setOutput(name, value) {
+    // GitHub Actions output via $GITHUB_OUTPUT
+    const outputFile = process.env.GITHUB_OUTPUT;
+    if (outputFile) {
+        fs.appendFileSync(outputFile, `${name}=${value}\n`);
+    } else {
+        console.log(`::set-output name=${name}::${value}`);
+    }
+}
+
+function info(msg) { console.log(`\x1b[36m[RTC]\x1b[0m ${msg}`); }
+function warn(msg) { console.log(`\x1b[33m[WARN]\x1b[0m ${msg}`); }
+function error(msg) { console.log(`\x1b[31m[ERROR]\x1b[0m ${msg}`); }
+function setFailed(msg) { error(msg); process.exit(1); }
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+function httpsGet(url, options = {}) {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const req = https.get(parsed, { rejectUnauthorized: false, ...options }, (res) => {
+            const chunks = [];
+            res.on("data", (c) => chunks.push(c));
+            res.on("end", () => {
+                const body = Buffer.concat(chunks).toString();
+                resolve({ status: res.statusCode, body, headers: res.headers });
+            });
+        });
+        req.on("error", reject);
+        req.on("timeout", () => { req.destroy(); reject(new Error("Request timed out")); });
+    });
+}
+
+function httpsPost(url, data, options = {}) {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const body = JSON.stringify(data);
+        const req = https.request(
+            {
+                hostname: parsed.hostname,
+                port: parsed.port || 443,
+                path: parsed.pathname + parsed.search,
+                method: "POST",
+                rejectUnauthorized: false,
+                headers: {
+                    "Content-Type": "application/json",
+                    "Content-Length": Buffer.byteLength(body),
+                    ...options.headers,
+                },
+                timeout: 15_000,
+            },
+            (res) => {
+                const chunks = [];
+                res.on("data", (c) => chunks.push(c));
+                res.on("end", () => {
+                    resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() });
+                });
+            },
+        );
+        req.on("error", reject);
+        req.on("timeout", () => { req.destroy(); reject(new Error("Request timed out")); });
+        req.write(body);
+        req.end();
+    });
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API
+// ---------------------------------------------------------------------------
+
+async function githubGet(path) {
+    const token = process.env.GITHUB_TOKEN;
+    const res = await httpsGet(`https://api.github.com${path}`, {
+        headers: {
+            "Authorization": `Bearer ${token}`,
+            "User-Agent": "rtc-reward-action/1.0",
+            "Accept": "application/vnd.github+json",
+        },
+    });
+    return JSON.parse(res.body);
+}
+
+async function postPRComment(repo, prNumber, body) {
+    const token = process.env.GITHUB_TOKEN;
+    const url = `https://api.github.com/repos/${repo}/issues/${prNumber}/comments`;
+    const parsed = new URL(url);
+    return new Promise((resolve, reject) => {
+        const bodyStr = JSON.stringify({ body });
+        const req = https.request(
+            {
+                hostname: parsed.hostname,
+                port: 443,
+                path: parsed.pathname,
+                method: "POST",
+                rejectUnauthorized: false,
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "User-Agent": "rtc-reward-action/1.0",
+                    "Accept": "application/vnd.github+json",
+                    "Content-Type": "application/json",
+                    "Content-Length": Buffer.byteLength(bodyStr),
+                },
+            },
+            (res) => {
+                const chunks = [];
+                res.on("data", (c) => chunks.push(c));
+                res.on("end", () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }));
+            },
+        );
+        req.on("error", reject);
+        req.write(bodyStr);
+        req.end();
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Wallet extraction
+// ---------------------------------------------------------------------------
+
+function extractWalletFromBody(prBody, pattern) {
+    if (!prBody) return null;
+    try {
+        const re = new RegExp(pattern, "im");
+        const m = prBody.match(re);
+        return m ? m[1].trim() : null;
+    } catch (e) {
+        warn(`Invalid wallet-pattern regex: ${e.message}`);
+        return null;
+    }
+}
+
+function extractWalletFromFile() {
+    const candidates = [
+        path.join(process.env.GITHUB_WORKSPACE || ".", ".rtc-wallet"),
+        path.join(process.env.GITHUB_WORKSPACE || ".", ".rtc-wallet.txt"),
+    ];
+    for (const f of candidates) {
+        if (fs.existsSync(f)) {
+            const content = fs.readFileSync(f, "utf-8").trim();
+            if (content) {
+                info(`Found wallet in ${f}: ${content}`);
+                return content;
+            }
+        }
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// RustChain API
+// ---------------------------------------------------------------------------
+
+async function checkNodeHealth(nodeUrl) {
+    const res = await httpsGet(`${nodeUrl}/health`);
+    const data = JSON.parse(res.body);
+    return data.ok === true;
+}
+
+async function transferRTC(nodeUrl, fromWallet, toWallet, amount, adminKey) {
+    const res = await httpsPost(
+        `${nodeUrl}/wallet/transfer`,
+        {
+            from_wallet: fromWallet,
+            to_wallet: toWallet,
+            amount_rtc: amount,
+            admin_key: adminKey,
+        },
+    );
+    if (res.status < 200 || res.status >= 300) {
+        throw new Error(`Transfer failed (HTTP ${res.status}): ${res.body}`);
+    }
+    const data = JSON.parse(res.body);
+    return data.tx_id || data.transaction_id || "unknown";
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function run() {
+    // Read inputs
+    const nodeUrl = getInput("node-url") || "https://50.28.86.131";
+    const amount = parseFloat(getInput("amount") || "5");
+    const walletFrom = getInput("wallet-from");
+    const adminKey = getInput("admin-key");
+    const walletPattern = getInput("wallet-pattern") || "(?i)wallet[:\\s]+([a-zA-Z0-9_\\-\\.]{3,64})";
+    const dryRun = getInput("dry-run") === "true";
+    const commentOnPR = getInput("comment-on-pr") !== "false";
+    const requireLabel = getInput("require-label");
+
+    // Parse GitHub context
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (!eventPath || !fs.existsSync(eventPath)) {
+        setFailed("GITHUB_EVENT_PATH not set or missing — this action must run on pull_request events.");
+        return;
+    }
+    const event = JSON.parse(fs.readFileSync(eventPath, "utf-8"));
+    const pr = event.pull_request;
+    if (!pr) {
+        setFailed("No pull_request in event payload.");
+        return;
+    }
+
+    const repo = process.env.GITHUB_REPOSITORY;
+    const prNumber = pr.number;
+    const prAuthor = pr.user?.login || "unknown";
+    const prBody = pr.body || "";
+    const prLabels = (pr.labels || []).map((l) => l.name);
+    const merged = pr.merged === true;
+
+    info(`PR #${prNumber} by ${prAuthor} — merged: ${merged}`);
+
+    if (!merged) {
+        info("PR was not merged — skipping award.");
+        setOutput("awarded", "false");
+        setOutput("recipient-wallet", "");
+        setOutput("tx-id", "");
+        setOutput("amount-rtc", "0");
+        return;
+    }
+
+    // Check label requirement
+    if (requireLabel && !prLabels.includes(requireLabel)) {
+        info(`PR does not have required label "${requireLabel}" — skipping.`);
+        setOutput("awarded", "false");
+        setOutput("recipient-wallet", "");
+        setOutput("tx-id", "");
+        setOutput("amount-rtc", "0");
+        return;
+    }
+
+    // Determine recipient wallet
+    let recipientWallet = extractWalletFromBody(prBody, walletPattern);
+    if (!recipientWallet) {
+        recipientWallet = extractWalletFromFile();
+    }
+    if (!recipientWallet) {
+        recipientWallet = prAuthor; // fallback to GitHub username
+        warn(`No wallet found in PR body or .rtc-wallet — using GitHub username: ${recipientWallet}`);
+    }
+
+    info(`Recipient wallet: ${recipientWallet}`);
+    info(`Amount: ${amount} RTC`);
+    info(`Dry-run: ${dryRun}`);
+
+    setOutput("recipient-wallet", recipientWallet);
+    setOutput("amount-rtc", String(amount));
+
+    if (dryRun) {
+        info("DRY-RUN mode — no actual transfer made.");
+        setOutput("awarded", "false");
+        setOutput("tx-id", "");
+
+        if (commentOnPR) {
+            const msg = [
+                `### 🧪 RTC Reward Dry-Run`,
+                ``,
+                `**Would award:** ${amount} RTC → \`${recipientWallet}\``,
+                `**From:** \`${walletFrom}\``,
+                `**Node:** ${nodeUrl}`,
+                ``,
+                `_This was a dry-run. No actual transfer was made._`,
+            ].join("\n");
+            await postPRComment(repo, prNumber, msg);
+        }
+        return;
+    }
+
+    // Check node health
+    let nodeHealthy = false;
+    try {
+        nodeHealthy = await checkNodeHealth(nodeUrl);
+    } catch (e) {
+        warn(`Health check failed: ${e.message}`);
+    }
+    if (!nodeHealthy) {
+        setFailed(`RustChain node at ${nodeUrl} is not healthy. Cannot award RTC.`);
+        return;
+    }
+
+    // Transfer RTC
+    let txId;
+    try {
+        txId = await transferRTC(nodeUrl, walletFrom, recipientWallet, amount, adminKey);
+    } catch (e) {
+        setFailed(`RTC transfer failed: ${e.message}`);
+        return;
+    }
+
+    info(`✅ Awarded ${amount} RTC to ${recipientWallet} — tx: ${txId}`);
+    setOutput("awarded", "true");
+    setOutput("tx-id", txId);
+
+    if (commentOnPR) {
+        const msg = [
+            `### 🎉 RTC Reward Sent!`,
+            ``,
+            `**Awarded:** ${amount} RTC`,
+            `**Recipient:** \`${recipientWallet}\``,
+            `**Transaction:** \`${txId}\``,
+            `**Node:** ${nodeUrl}`,
+            ``,
+            `Thank you for contributing to this project! 🚀`,
+            ``,
+            `_Powered by [RustChain RTC Reward Action](https://github.com/Scottcjn/rustchain-bounties/tree/main/github-action)_`,
+        ].join("\n");
+        try {
+            await postPRComment(repo, prNumber, msg);
+        } catch (e) {
+            warn(`Failed to post PR comment: ${e.message}`);
+        }
+    }
+}
+
+run().catch((e) => setFailed(String(e)));


### PR DESCRIPTION
## Bounty

Closes #2864 — **20 RTC**

## What's included

A reusable GitHub Action (`github-action/`) that awards RTC tokens when a PR is merged. Any open-source project adds one YAML file and starts rewarding contributors with crypto automatically.

### How to use

```yaml
- uses: Scottcjn/rustchain-bounties/github-action@main
  with:
    amount: 5
    wallet-from: my-project-fund
    admin-key: ${{ secrets.RTC_ADMIN_KEY }}
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

### Wallet detection (priority order)

1. **PR body** — regex scan for `Wallet: <wallet-id>` (customizable pattern)
2. **`.rtc-wallet` file** in repo root
3. **GitHub username** fallback

### All required features

- [x] Configurable RTC amount per merge (`amount` input)
- [x] Reads contributor wallet from PR body or `.rtc-wallet` file
- [x] Posts confirmation comment on PR with transaction ID
- [x] Dry-run mode (`dry-run: true`) — simulates without real transfer
- [x] Label filtering (`require-label` input) — award only labelled PRs
- [x] Zero npm dependencies — pure Node.js built-ins, instant cold start
- [x] Works with self-signed TLS cert on default node

### Files

| File | Description |
|------|-------------|
| `github-action/action.yml` | Action definition with all inputs/outputs |
| `github-action/dist/index.js` | Bundled single-file entrypoint (node20) |
| `github-action/src/index.js` | Annotated source |
| `github-action/example-workflow.yml` | Copy-paste ready usage |
| `github-action/README.md` | Full documentation |

## Test plan

- [ ] Set `dry-run: true` — action runs, posts dry-run comment, no transfer
- [ ] Add `Wallet: test-wallet` to PR body — action extracts it correctly
- [ ] Create `.rtc-wallet` file — action reads it as fallback
- [ ] No wallet anywhere — falls back to GitHub username
- [ ] Unmerged PR close — action skips with `awarded: false`
- [ ] `require-label: bounty` — skips PRs without label

🤖 Wallet: 暖暖