### PR TITLE
[BOUNTY #2860] /rtc-balance Claude Code Slash Command — fixed miner_id param (15 RTC)

### DIFF
--- a/.claude/skills/rtc-balance.md
+++ b/.claude/skills/rtc-balance.md
@@ -1,0 +1,87 @@
+# /rtc-balance
+
+Check a RustChain wallet balance and network status from within Claude Code.
+
+## Usage
+
+```
+/rtc-balance <wallet_id>
+```
+
+## Examples
+
+```
+/rtc-balance my-wallet
+/rtc-balance developer-wallet
+```
+
+## What it does
+
+When invoked, this skill:
+1. Queries the RustChain node at `https://50.28.86.131/wallet/balance?wallet_id=<wallet_id>`
+2. Queries current epoch info from `https://50.28.86.131/epoch`
+3. Displays balance in RTC and USD (at $0.10/RTC)
+4. Shows epoch number and active miner count
+5. Handles errors gracefully (wallet not found, node offline)
+
+## Implementation
+
+Run this Python script with the wallet ID as argument:
+
+```bash
+python3 claude-slash-command/check_balance.py <wallet_id>
+```
+
+Or use inline:
+
+```python
+import urllib.request, json, ssl
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+NODE = "https://50.28.86.131"
+
+def rtc_balance(wallet_id):
+    try:
+        r = urllib.request.urlopen(
+            f"{NODE}/wallet/balance?wallet_id={wallet_id}",
+            context=ctx, timeout=8
+        )
+        data = json.loads(r.read())
+        balance = float(data.get("balance", 0))
+        usd = balance * 0.10
+        
+        epoch_r = urllib.request.urlopen(f"{NODE}/epoch", context=ctx, timeout=8)
+        epoch = json.loads(epoch_r.read())
+        
+        print(f"Wallet:  {wallet_id}")
+        print(f"Balance: {balance:.2f} RTC (${usd:.2f} USD)")
+        print(f"Epoch:   {epoch.get('epoch', '?')} | Miners online: {epoch.get('miners_online', '?')}")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            print(f"Wallet '{wallet_id}' not found on RustChain.")
+        else:
+            print(f"Node error: HTTP {e.code}")
+    except Exception as e:
+        print(f"Node offline or unreachable: {e}")
+```
+
+## Expected output
+
+```
+Wallet:  my-wallet
+Balance: 42.50 RTC ($4.25 USD)
+Epoch:   1847 | Miners online: 14
+```
+
+## Error output
+
+```
+Wallet 'unknown-wallet' not found on RustChain.
+```
+
+```
+Node offline or unreachable: [Errno 111] Connection refused
+```

--- a/.claude/skills/rtc-balance.md
+++ b/.claude/skills/rtc-balance.md
@@ -1,35 +1,35 @@
 # /rtc-balance
 
-Check a RustChain wallet balance and network status from within Claude Code.
+Check a RustChain miner balance and network status from within Claude Code.
 
 ## Usage
 
 ```
-/rtc-balance <wallet_id>
+/rtc-balance <miner_id>
 ```
 
 ## Examples
 
 ```
-/rtc-balance my-wallet
-/rtc-balance developer-wallet
+/rtc-balance my-miner
+/rtc-balance developer-node
 ```
 
 ## What it does
 
 When invoked, this skill:
-1. Queries the RustChain node at `https://50.28.86.131/wallet/balance?wallet_id=<wallet_id>`
+1. Queries the RustChain node at `https://50.28.86.131/wallet/balance?miner_id=<miner_id>`
 2. Queries current epoch info from `https://50.28.86.131/epoch`
 3. Displays balance in RTC and USD (at $0.10/RTC)
 4. Shows epoch number and active miner count
-5. Handles errors gracefully (wallet not found, node offline)
+5. Handles errors gracefully (miner not found, node offline)
 
 ## Implementation
 
-Run this Python script with the wallet ID as argument:
+Run this Python script with the miner ID as argument:
 
 ```bash
-python3 claude-slash-command/check_balance.py <wallet_id>
+python3 claude-slash-command/check_balance.py <miner_id>
 ```
 
 Or use inline:
@@ -43,27 +43,27 @@ ctx.verify_mode = ssl.CERT_NONE
 
 NODE = "https://50.28.86.131"
 
-def rtc_balance(wallet_id):
+def rtc_balance(miner_id):
     try:
         r = urllib.request.urlopen(
-            f"{NODE}/wallet/balance?wallet_id={wallet_id}",
+            f"{NODE}/wallet/balance?miner_id={miner_id}",
             context=ctx, timeout=8
         )
         data = json.loads(r.read())
-        balance = float(data.get("balance", 0))
+        if not data.get("ok", True) and data.get("error"):
+            print(f"Error: {data['error']}")
+            return
+        balance = float(data.get("amount_rtc", 0))
         usd = balance * 0.10
-        
+
         epoch_r = urllib.request.urlopen(f"{NODE}/epoch", context=ctx, timeout=8)
         epoch = json.loads(epoch_r.read())
-        
-        print(f"Wallet:  {wallet_id}")
+
+        print(f"Miner:   {miner_id}")
         print(f"Balance: {balance:.2f} RTC (${usd:.2f} USD)")
-        print(f"Epoch:   {epoch.get('epoch', '?')} | Miners online: {epoch.get('miners_online', '?')}")
+        print(f"Epoch:   {epoch.get('epoch', '?')} | Miners online: {epoch.get('enrolled_miners', '?')}")
     except urllib.error.HTTPError as e:
-        if e.code == 404:
-            print(f"Wallet '{wallet_id}' not found on RustChain.")
-        else:
-            print(f"Node error: HTTP {e.code}")
+        print(f"Node error: HTTP {e.code}")
     except Exception as e:
         print(f"Node offline or unreachable: {e}")
 ```
@@ -71,7 +71,7 @@ def rtc_balance(wallet_id):
 ## Expected output
 
 ```
-Wallet:  my-wallet
+Miner:   my-miner
 Balance: 42.50 RTC ($4.25 USD)
 Epoch:   1847 | Miners online: 14
 ```
@@ -79,7 +79,7 @@ Epoch:   1847 | Miners online: 14
 ## Error output
 
 ```
-Wallet 'unknown-wallet' not found on RustChain.
+Error: miner_id or address required
 ```
 
 ```

--- a/claude-slash-command/README.md
+++ b/claude-slash-command/README.md
@@ -1,0 +1,55 @@
+# /rtc-balance — Claude Code Slash Command
+
+Check your RustChain wallet balance without leaving the terminal.
+
+## Install
+
+Copy the skill file to your project:
+
+```bash
+mkdir -p .claude/skills
+cp rtc-balance.md .claude/skills/rtc-balance.md
+```
+
+Or add the content to your project's `CLAUDE.md`.
+
+## Use in Claude Code
+
+```
+/rtc-balance my-wallet
+```
+
+Output:
+```
+Wallet:  my-wallet
+Balance: 42.50 RTC ($4.25 USD)
+Epoch:   1847 | Miners online: 14
+```
+
+## Use standalone
+
+```bash
+python3 check_balance.py my-wallet
+```
+
+## Requirements
+
+- Python 3.8+
+- No external dependencies (stdlib only)
+- Network access to `50.28.86.131`
+
+## Error handling
+
+| Situation | Output |
+|-----------|--------|
+| Wallet not found | `Wallet 'x' not found on RustChain.` |
+| Node offline | `Node offline or unreachable: ...` |
+| HTTP error | `Node error: HTTP 500` |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `.claude/skills/rtc-balance.md` | Claude Code skill definition |
+| `claude-slash-command/check_balance.py` | Standalone Python script |
+| `claude-slash-command/README.md` | This file |

--- a/claude-slash-command/README.md
+++ b/claude-slash-command/README.md
@@ -1,6 +1,6 @@
 # /rtc-balance — Claude Code Slash Command
 
-Check your RustChain wallet balance without leaving the terminal.
+Check your RustChain miner balance without leaving the terminal.
 
 ## Install
 
@@ -16,12 +16,12 @@ Or add the content to your project's `CLAUDE.md`.
 ## Use in Claude Code
 
 ```
-/rtc-balance my-wallet
+/rtc-balance my-miner
 ```
 
 Output:
 ```
-Wallet:  my-wallet
+Miner:   my-miner
 Balance: 42.50 RTC ($4.25 USD)
 Epoch:   1847 | Miners online: 14
 ```
@@ -29,7 +29,7 @@ Epoch:   1847 | Miners online: 14
 ## Use standalone
 
 ```bash
-python3 check_balance.py my-wallet
+python3 check_balance.py my-miner
 ```
 
 ## Requirements
@@ -42,7 +42,7 @@ python3 check_balance.py my-wallet
 
 | Situation | Output |
 |-----------|--------|
-| Wallet not found | `Wallet 'x' not found on RustChain.` |
+| Miner not found | `Error: miner_id or address required` |
 | Node offline | `Node offline or unreachable: ...` |
 | HTTP error | `Node error: HTTP 500` |
 

--- a/claude-slash-command/check_balance.py
+++ b/claude-slash-command/check_balance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 RustChain balance checker — Claude Code slash command helper.
-Usage: python3 check_balance.py <wallet_id>
+Usage: python3 check_balance.py <miner_id>
 """
 import sys
 import json
@@ -23,13 +23,13 @@ def fetch(path: str) -> dict:
     return json.loads(resp.read().decode())
 
 
-def check_balance(wallet_id: str) -> None:
-    # Wallet balance
+def check_balance(miner_id: str) -> None:
+    # Miner balance
     try:
-        data = fetch(f"/wallet/balance?wallet_id={wallet_id}")
+        data = fetch(f"/wallet/balance?miner_id={miner_id}")
     except urllib.error.HTTPError as e:
         if e.code == 404:
-            print(f"Wallet '{wallet_id}' not found on RustChain.")
+            print(f"Miner '{miner_id}' not found on RustChain.")
             return
         print(f"Node error: HTTP {e.code}")
         return
@@ -37,7 +37,11 @@ def check_balance(wallet_id: str) -> None:
         print(f"Node offline or unreachable: {e}")
         return
 
-    balance = float(data.get("balance", 0))
+    if not data.get("ok", True) and data.get("error"):
+        print(f"Error: {data['error']}")
+        return
+
+    balance = float(data.get("amount_rtc", 0))
     usd = balance * 0.10
 
     # Epoch info (best-effort, non-fatal)
@@ -46,27 +50,27 @@ def check_balance(wallet_id: str) -> None:
     try:
         epoch_data = fetch("/epoch")
         epoch_str = str(epoch_data.get("epoch", "?"))
-        miners_str = str(epoch_data.get("miners_online", "?"))
+        miners_str = str(epoch_data.get("enrolled_miners", "?"))
     except Exception:
         pass
 
-    print(f"Wallet:  {wallet_id}")
+    print(f"Miner:   {miner_id}")
     print(f"Balance: {balance:.2f} RTC (${usd:.2f} USD)")
     print(f"Epoch:   {epoch_str} | Miners online: {miners_str}")
 
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print("Usage: python3 check_balance.py <wallet_id>")
-        print("Example: python3 check_balance.py my-wallet")
+        print("Usage: python3 check_balance.py <miner_id>")
+        print("Example: python3 check_balance.py my-miner")
         sys.exit(1)
 
-    wallet_id = sys.argv[1].strip()
-    if not wallet_id:
-        print("Error: wallet_id cannot be empty.")
+    miner_id = sys.argv[1].strip()
+    if not miner_id:
+        print("Error: miner_id cannot be empty.")
         sys.exit(1)
 
-    check_balance(wallet_id)
+    check_balance(miner_id)
 
 
 if __name__ == "__main__":

--- a/claude-slash-command/check_balance.py
+++ b/claude-slash-command/check_balance.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+RustChain balance checker — Claude Code slash command helper.
+Usage: python3 check_balance.py <wallet_id>
+"""
+import sys
+import json
+import ssl
+import urllib.request
+import urllib.error
+
+NODE = "https://50.28.86.131"
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+
+def fetch(path: str) -> dict:
+    url = f"{NODE}{path}"
+    req = urllib.request.Request(url, headers={"User-Agent": "rtc-balance/1.0"})
+    resp = urllib.request.urlopen(req, context=ctx, timeout=8)
+    return json.loads(resp.read().decode())
+
+
+def check_balance(wallet_id: str) -> None:
+    # Wallet balance
+    try:
+        data = fetch(f"/wallet/balance?wallet_id={wallet_id}")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            print(f"Wallet '{wallet_id}' not found on RustChain.")
+            return
+        print(f"Node error: HTTP {e.code}")
+        return
+    except Exception as e:
+        print(f"Node offline or unreachable: {e}")
+        return
+
+    balance = float(data.get("balance", 0))
+    usd = balance * 0.10
+
+    # Epoch info (best-effort, non-fatal)
+    epoch_str = "?"
+    miners_str = "?"
+    try:
+        epoch_data = fetch("/epoch")
+        epoch_str = str(epoch_data.get("epoch", "?"))
+        miners_str = str(epoch_data.get("miners_online", "?"))
+    except Exception:
+        pass
+
+    print(f"Wallet:  {wallet_id}")
+    print(f"Balance: {balance:.2f} RTC (${usd:.2f} USD)")
+    print(f"Epoch:   {epoch_str} | Miners online: {miners_str}")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python3 check_balance.py <wallet_id>")
+        print("Example: python3 check_balance.py my-wallet")
+        sys.exit(1)
+
+    wallet_id = sys.argv[1].strip()
+    if not wallet_id:
+        print("Error: wallet_id cannot be empty.")
+        sys.exit(1)
+
+    check_balance(wallet_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Fix: miner_id param + amount_rtc field

Previous PR #2947 was closed for two issues. Both fixed:

### Issue 1: Wrong API parameter
- **Before:** `/wallet/balance?wallet_id=xxx` → `{"error":"miner_id or address required","ok":false}`  
- **After:** `/wallet/balance?miner_id=xxx` → `{"amount_rtc":0.0,"amount_i64":0,"miner_id":"xxx"}`

### Issue 2: Wrong response field
- **Before:** `data.get("balance", 0)` — key doesn't exist in real response
- **After:** `data.get("amount_rtc", 0)` — correct field from live API

### verify=False equivalent
SSL context already configured: `ctx.check_hostname = False` + `ctx.verify_mode = ssl.CERT_NONE`

## Test

```bash
python3 claude-slash-command/check_balance.py test-miner
# Miner:   test-miner
# Balance: 0.00 RTC ($0.00 USD)
# Epoch:   129 | Miners online: 17
```

Tested live against `https://50.28.86.131` — returns real epoch data.

## Files

- `.claude/skills/rtc-balance.md` — Claude Code slash command skill
- `claude-slash-command/check_balance.py` — standalone Python script  
- `claude-slash-command/README.md` — install + usage docs

## Wallet

暖暖