### PR TITLE
Add GitHub Action to auto-award RTC on PR merge (Issue #2864)

### DIFF
--- a/.github/actions/award-rtc/README.md
+++ b/.github/actions/award-rtc/README.md
@@ -1,0 +1,45 @@
+# Auto-Award RTC on PR Merge
+
+GitHub Action that automatically awards RTC tokens to contributors when their PR is merged.
+
+## Usage
+
+Add to `.github/workflows/award-rtc.yml`:
+
+```yaml
+name: Award RTC on PR Merge
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  award-rtc:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Award RTC
+        uses: Scottcjn/rustchain-bounties/.github/actions/award-rtc@main
+        with:
+          reward_rtc: '''10'''
+        env:
+          RUSTCHAIN_ADMIN_KEY: ${{ secrets.RUSTCHAIN_ADMIN_KEY }}
+```
+
+## Required Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `RUSTCHAIN_ADMIN_KEY` | Admin key for the RustChain node |
+
+## Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `reward_rtc` | `10` | Amount of RTC to award per merged PR |
+| `node_url` | `https://50.28.86.131` | RustChain node URL |
+
+## Bounty
+
+- **Issue**: [#2864](https://github.com/Scottcjn/rustchain-bounties/issues/2864)
+- **Reward**: 20 RTC (~.00 USD)
+- **Author**: 大鹏 (YPC0813)

--- a/.github/actions/award-rtc/action.yml
+++ b/.github/actions/award-rtc/action.yml
@@ -1,0 +1,31 @@
+name: 'Auto-Award RTC on PR Merge'
+description: 'Automatically awards RTC tokens to contributors when their PR is merged'
+author: '大鹏'
+
+inputs:
+  reward_rtc:
+    description: 'Amount of RTC to award (default: 10)'
+    required: false
+    default: '10'
+  node_url:
+    description: 'RustChain node URL'
+    required: false
+    default: 'https://50.28.86.131'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Award RTC to contributor
+      shell: bash
+      env:
+        RUSTCHAIN_NODE_URL: ${{ inputs.node_url }}
+        ADMIN_KEY: ${{ env.RUSTCHAIN_ADMIN_KEY }}
+        CONTRIBUTOR: ${{ github.event.pull_request.user.login }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REWARD_RTC: ${{ inputs.reward_rtc }}
+      run: |
+        python ${{ github.action_path }}/award_rtc.py
+
+branding:
+  icon: 'award'
+  color: 'orange'

--- a/.github/actions/award-rtc/award_rtc.py
+++ b/.github/actions/award-rtc/award_rtc.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+RustChain Auto-Award RTC GitHub Action
+Automatically awards RTC tokens to contributors when their PR is merged.
+Issue: https://github.com/Scottcjn/rustchain-bounties/issues/2864
+"""
+import json, os, sys, urllib.request, urllib.error
+
+def main():
+    node_url = os.environ.get('RUSTCHAIN_NODE_URL', 'https://50.28.86.131')
+    admin_key = os.environ.get('ADMIN_KEY', '')
+    contributor = os.environ.get('CONTRIBUTOR', '')
+    pr_number = os.environ.get('PR_NUMBER', '0')
+    reward_rtc = int(os.environ.get('REWARD_RTC', '10'))
+    
+    if not admin_key:
+        print('::error::ADMIN_KEY secret is required')
+        sys.exit(1)
+    if not contributor:
+        print('::warning::CONTRIBUTOR not set, skipping')
+        sys.exit(0)
+
+    transfer_data = {
+        'from_miner': 'rustchain-treasury',
+        'to_miner': contributor,
+        'amount_rtc': reward_rtc,
+        'reason': f'bounty_reward:PR#{pr_number}'
+    }
+
+    try:
+        url = f'{node_url}/wallet/transfer'
+        data = json.dumps(transfer_data).encode('utf-8')
+        req = urllib.request.Request(url, data=data, headers={
+            'Content-Type': 'application/json',
+            'X-Admin-Key': admin_key
+        }, method='POST')
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read().decode())
+            if result.get('ok'):
+                tx = result.get('tx_hash', 'unknown')
+                print(f'::notice::Awarded {reward_rtc} RTC to {contributor} (TX: {tx})')
+            else:
+                print(f'::warning::Transfer failed: {result.get("error", "unknown")}')
+    except urllib.error.HTTPError as e:
+        print(f'::error::HTTP {e.code}: {e.read().decode()[:200]}')
+    except Exception as e:
+        print(f'::warning::Error: {e}')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Adds a reusable GitHub Action that automatically awards RTC tokens to contributors when their PR is merged.

### Files Added

| File | Description |
|------|-------------|
| `.github/actions/award-rtc/action.yml` | Action definition |
| `.github/actions/award-rtc/award_rtc.py` | Award logic (calls RustChain node API) |
| `.github/actions/award-rtc/README.md` | Usage instructions |

### How It Works

1. Triggered when a PR is closed and merged
2. Calls RustChain node `/wallet/transfer` endpoint
3. Transfers reward RTC from treasury to contributor

### Usage

```yaml
jobs:
  award-rtc:
    if: github.event.pull_request.merged == true
    steps:
      - uses: Scottcjn/rustchain-bounties/.github/actions/award-rtc@main
        with:
          reward_rtc: "10"
        env:
          RUSTCHAIN_ADMIN_KEY: ${{ secrets.RUSTCHAIN_ADMIN_KEY }}
```

**Bounty**: 20 RTC (~$2.00 USD)
**Author**: 大鹏 (YPC0813)