### PR TITLE
Add link to anti-farming rules #452 in bounty workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,141 +1,127 @@
-# Contributing to Rustchain
+# Contributing to RustChain Bounties
 
-Thank you for your interest in contributing to Rustchain! Every contribution helps build a stronger Proof-of-Antiquity blockchain ecosystem.
+Thank you for your interest in contributing to the RustChain ecosystem! This guide will help you understand how to participate in our bounty program.
 
-## 🚀 Quick Start
+## Table of Contents
 
-1. **Fork** the repository
-2. **Clone** your fork locally
-3. **Create a branch** for your changes (`git checkout -b feature/my-contribution`)
-4. **Make your changes** and test them
-5. **Commit** with a clear message
-6. **Push** to your fork and open a **Pull Request**
-
-## 💰 Earning RTC Tokens
-
-All merged contributions earn RTC tokens! See the bounty tiers:
-
-| Tier | Reward | Examples |
-| ---- | ------ | -------- |
-| Micro | 1-10 RTC | Typo fix, small docs, simple test |
-| Standard | 20-50 RTC | Feature, refactor, new endpoint |
-| Major | 75-100 RTC | Security fix, consensus improvement |
-| Critical | 100-150 RTC | Vulnerability patch, protocol upgrade |
-
-Browse [open bounties](https://github.com/Scottcjn/rustchain-bounties/issues) to find tasks with specific RTC rewards.
-
-## 📋 Types of Contributions
-
-### Code
-- Bug fixes and feature implementations
-- Performance improvements
-- Test coverage improvements
-- CI/CD pipeline enhancements
-
-### Documentation
-- README improvements
-- API documentation
-- Tutorials and guides
-- Code comments and docstrings
-- Translations (Spanish, Chinese, Japanese, etc.)
-
-### Community
-- Bug reports with reproduction steps
-- Feature requests with use cases
-- Code reviews on open PRs
-- Helping others in [Discord](https://discord.gg/VqVVS2CW9Q)
-
-## 🔧 Development Setup
-
-```bash
-# Clone your fork
-git clone https://github.com/YOUR_USERNAME/rustchain-bounties.git
-cd rustchain-bounties
-
-# Install dependencies
-npm install  # or cargo build (for Rust components)
-
-# Run tests
-npm test     # or cargo test
-```
-
-## 📝 Commit Message Convention
-
-We follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-```
-<type>(<scope>): <description>
-
-[optional body]
-[optional footer]
-```
-
-**Types:**
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style (formatting, no logic change)
-- `refactor`: Code refactoring
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks (CI, dependencies)
-- `security`: Security-related changes
-
-**Examples:**
-```
-feat(bridge): add wRTC balance verification endpoint
-fix(consensus): correct PoA difficulty adjustment calculation
-docs(readme): add POWER8 hardware requirements section
-test(api): add integration tests for mining endpoints
-```
-
-## 🔍 Pull Request Guidelines
-
-### Before Submitting
-- [ ] Code follows the project's style guidelines
-- [ ] Self-review of your changes completed
-- [ ] Tests pass locally
-- [ ] New code includes appropriate tests
-- [ ] Documentation updated if needed
-
-### PR Description Template
-```markdown
-## What does this PR do?
-Brief description of changes.
-
-## Why?
-Motivation and context.
-
-## How to test?
-Steps to verify the changes work.
-
-## Related Issues
-Closes #<issue_number>
-```
-
-### Review Process
-1. A maintainer will review your PR within 48-72 hours
-2. Address any requested changes
-3. Once approved, a maintainer will merge your PR
-4. RTC tokens will be distributed after merge
-
-## 🎯 Good First Issues
-
-New to Rustchain? Start with issues labeled [`good first issue`](https://github.com/Scottcjn/Rustchain/labels/good%20first%20issue). These are specifically designed for newcomers.
-
-## ⚖️ Code of Conduct
-
-By participating in this project, you agree to maintain a respectful, inclusive, and harassment-free environment. Be kind, be constructive, and help each other grow.
-
-## 📬 Getting Help
-
-- **Discord**: [Join our server](https://discord.gg/VqVVS2CW9Q)
-- **GitHub Issues**: For bugs and feature requests
-- **Discussions**: For questions and ideas
-
-## License
-
-By contributing, you agree that your contributions will be licensed under the same license as the project (Apache 2.0).
+- [How to Find Bounties](#how-to-find-bounties)
+- [Claim Format](#claim-format)
+- [Proof Requirements](#proof-requirements)
+- [Wallet Address Format](#wallet-address-format)
+- [Anti-Farming Rules](#anti-farming-rules)
+- [Getting Help](#getting-help)
 
 ---
 
-**Happy contributing! Every PR brings Rustchain closer to its vision.** 🦀⛓️
+## How to Find Bounties
+
+Browse open bounties at: https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty
+
+### Bounty Categories
+
+| Difficulty | Label | Typical Reward |
+|-----------|-------|---------------|
+| Beginner | `good first issue` | 1-5 RTC |
+| Standard | `standard` | 5-25 RTC |
+| Major | `major` | 25-100 RTC |
+| Critical | `critical`, `red-team` | 100-200 RTC |
+
+**Tip**: Start with `good first issue` bounties if you're new!
+
+---
+
+## Claim Format
+
+To claim a bounty, comment on the issue with:
+
+```
+I would like to work on this.
+```
+
+### What Happens Next
+
+1. The bounty maintainer will acknowledge your claim
+2. You can begin working on the task
+3. Submit your work when complete
+
+---
+
+## Proof Requirements
+
+Different bounty types require different proof:
+
+### Code Bounties
+- Open a Pull Request to the relevant repository
+- Link the PR in the bounty issue comment
+- Ensure PR passes CI checks if applicable
+
+### Content Bounties
+- Post your content (article, video, tutorial)
+- Link the published content in the bounty issue
+- Include engagement metrics if required
+
+### Star/Propagation Bounties
+- Star the repository or share on social media
+- Provide screenshot proof
+- Include your wallet address for payout
+
+### Integration Bounties
+- Demonstrate working integration
+- Provide documentation or examples
+- Link to working code/demo
+
+---
+
+## Wallet Address Format
+
+### RTC Wallet
+
+Your RTC wallet address format:
+```
+RTC<58 characters>
+```
+
+Example:
+```
+RTC589778251020176f64f9c1d11c4041c77dac3867
+```
+
+### Getting a Wallet
+
+If you don't have a wallet yet, comment on any bounty and we will help you set one up.
+
+---
+
+## Anti-Farming Rules
+
+⚠️ **IMPORTANT**: Read the [Anti-Farming Rules (#452)](https://github.com/Scottcjn/rustchain-bounties/issues/452) before submitting!
+
+Key rules:
+- Do not create fake accounts or use bots
+- Do not submit duplicate or low-quality work
+- Do not manipulate engagement metrics
+- All submissions must be genuine, quality work
+
+Violations result in disqualification and potential ban.
+
+---
+
+## Getting Help
+
+- **Discord**: [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q)
+- **Wallet Setup**: Comment on any bounty issue
+- **Questions**: Ask in the bounty issue comments
+
+---
+
+## Quick Checklist Before Submitting
+
+- [ ] I have read the anti-farming rules (#452)
+- [ ] I have claimed the bounty properly
+- [ ] My work meets the bounty requirements
+- [ ] I have provided clear proof
+- [ ] My wallet address is correct
+
+---
+
+Thank you for contributing to RustChain! Every bounty helps grow the ecosystem.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Browse [open bounties](https://github.com/Scottcjn/rustchain-bounties/issues?q=i
 ### 2. Claim It
 Comment on the issue: **"I would like to work on this"**
 
+> ⚠️ **Important**: Before submitting, read the [Anti-Farming Rules (#452)](https://github.com/Scottcjn/rustchain-bounties/issues/452) to avoid disqualification.
+
 ### 3. Submit Your Work
 - **Code bounties**: Open a PR to the relevant repo and link it in the issue
 - **Content bounties**: Post your content and link it in the issue

--- a/rustchain-sdk/.gitignore
+++ b/rustchain-sdk/.gitignore
@@ -1,0 +1,59 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Virtual environments
+venv/
+ENV/
+env/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# mypy
+.mypy_cache/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/rustchain-sdk/LICENSE
+++ b/rustchain-sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 HuiNeng
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rustchain-sdk/README.md
+++ b/rustchain-sdk/README.md
@@ -1,0 +1,313 @@
+# RustChain Python SDK
+
+[![PyPI version](https://badge.fury.io/py/rustchain.svg)](https://badge.fury.io/py/rustchain)
+[![Python Support](https://img.shields.io/pypi/pyversions/rustchain.svg)](https://pypi.org/project/rustchain/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Python SDK for interacting with [RustChain](https://github.com/Scottcjn/RustChain) nodes. Provides clean programmatic access to all public API endpoints with async support, type hints, and comprehensive error handling.
+
+## Features
+
+- 🚀 **Async Support** - Built on `httpx` with full async/await support
+- 📝 **Type Hints** - Complete type annotations throughout
+- 🔒 **Error Handling** - Typed exceptions for all error scenarios
+- 🔧 **CLI Tool** - Command-line interface for quick interactions
+- 📦 **Easy to Use** - Intuitive API design with context manager support
+
+## Installation
+
+```bash
+pip install rustchain
+```
+
+## Quick Start
+
+```python
+import asyncio
+from rustchain import RustChainClient
+
+async def main():
+    async with RustChainClient() as client:
+        # Check node health
+        health = await client.health()
+        print(f"Node status: {health.status}")
+        
+        # Get current epoch
+        epoch = await client.epoch()
+        print(f"Current epoch: {epoch.current_epoch}")
+        
+        # Check wallet balance
+        balance = await client.balance("my-wallet-id")
+        print(f"Balance: {balance.balance} RTC")
+        
+        # List active miners
+        miners = await client.miners(limit=10)
+        for miner in miners:
+            print(f"Miner {miner.id}: {miner.stake} RTC stake")
+        
+        # Get recent blocks
+        blocks = await client.explorer.blocks(limit=5)
+        for block in blocks.blocks:
+            print(f"Block #{block.height} by {block.miner}")
+
+asyncio.run(main())
+```
+
+## API Reference
+
+### Client Initialization
+
+```python
+from rustchain import RustChainClient
+
+# Default node URL
+client = RustChainClient()
+
+# Custom node URL
+client = RustChainClient(base_url="http://custom-node:9100")
+
+# With timeout and headers
+client = RustChainClient(
+    base_url="http://50.28.86.131:9100",
+    timeout=60.0,
+    headers={"X-Custom-Header": "value"}
+)
+
+# As context manager (recommended)
+async with RustChainClient() as client:
+    # Use client
+    pass
+```
+
+### Methods
+
+#### `health()`
+Check node health status.
+
+```python
+health = await client.health()
+# Returns: HealthStatus(status="healthy", version="1.0.0", uptime=3600, ...)
+```
+
+#### `epoch()`
+Get current epoch information.
+
+```python
+epoch = await client.epoch()
+# Returns: EpochInfo(current_epoch=100, start_height=1000, ...)
+```
+
+#### `miners(limit=100, active_only=True)`
+List active miners.
+
+```python
+miners = await client.miners(limit=10)
+# Returns: List[Miner]
+```
+
+#### `balance(wallet_id)`
+Check wallet RTC balance.
+
+```python
+balance = await client.balance("wallet-id")
+# Returns: Balance(wallet_id="...", balance=150.5, ...)
+```
+
+#### `transfer(from_address, to_address, amount, signature, fee=None)`
+Transfer RTC between wallets.
+
+```python
+result = await client.transfer(
+    from_address="sender-address",
+    to_address="recipient-address",
+    amount=10.0,
+    signature="tx-signature"
+)
+# Returns: TransferResult(tx_hash="...", amount=10.0, ...)
+```
+
+#### `attestation_status(miner_id)`
+Check miner attestation status.
+
+```python
+status = await client.attestation_status("miner-id")
+# Returns: AttestationStatus(miner_id="...", status="active", ...)
+```
+
+### Explorer API
+
+Access blockchain explorer methods via `client.explorer`.
+
+```python
+# Get recent blocks
+blocks = await client.explorer.blocks(limit=10, page=1)
+
+# Get specific block
+block = await client.explorer.block(height=1000)
+
+# Get recent transactions
+txs = await client.explorer.transactions(limit=10, wallet="wallet-id")
+
+# Get specific transaction
+tx = await client.explorer.transaction(tx_hash="tx-hash")
+```
+
+## CLI Usage
+
+The SDK includes a command-line interface for quick interactions:
+
+```bash
+# Check node health
+rustchain health
+
+# Get epoch info
+rustchain epoch
+
+# List miners
+rustchain miners --limit 20
+
+# Check wallet balance
+rustchain balance WALLET_ID
+
+# Transfer RTC
+rustchain transfer FROM_ADDR TO_ADDR AMOUNT SIGNATURE
+
+# Check attestation status
+rustchain attestation MINER_ID
+
+# Explorer commands
+rustchain explorer blocks --limit 10
+rustchain explorer block 1000
+rustchain explorer transactions --limit 10
+rustchain explorer transaction TX_HASH
+```
+
+### CLI Options
+
+All commands support:
+
+- `--url`: Custom RustChain node URL (default: http://50.28.86.131:9100)
+- `--help`: Show command help
+
+```bash
+rustchain balance WALLET_ID --url http://custom-node:9100
+```
+
+## Error Handling
+
+The SDK provides typed exceptions for all error scenarios:
+
+```python
+from rustchain import RustChainClient
+from rustchain.exceptions import (
+    ConnectionError,
+    TimeoutError,
+    ValidationError,
+    NotFoundError,
+    InsufficientFundsError,
+    InvalidSignatureError,
+)
+
+async def safe_transfer():
+    async with RustChainClient() as client:
+        try:
+            result = await client.transfer("from", "to", 100.0, "sig")
+        except InsufficientFundsError:
+            print("Not enough funds")
+        except InvalidSignatureError:
+            print("Invalid signature")
+        except ValidationError as e:
+            print(f"Validation error: {e.message}")
+        except ConnectionError:
+            print("Failed to connect to node")
+        except TimeoutError:
+            print("Request timed out")
+```
+
+### Exception Types
+
+| Exception | Description |
+|-----------|-------------|
+| `ConnectionError` | Failed to connect to RustChain node |
+| `TimeoutError` | Request timed out |
+| `ValidationError` | Input validation failed (400) |
+| `AuthenticationError` | Authentication failed (401) |
+| `NotFoundError` | Resource not found (404) |
+| `RateLimitError` | Rate limit exceeded (429) |
+| `ServerError` | Server error (5xx) |
+| `TransferError` | Transfer operation failed |
+| `InsufficientFundsError` | Insufficient balance |
+| `InvalidSignatureError` | Invalid signature |
+| `AttestationError` | Attestation operation failed |
+
+## Data Models
+
+All responses are typed using Pydantic models:
+
+```python
+from rustchain.models import (
+    HealthStatus,
+    EpochInfo,
+    Miner,
+    Balance,
+    TransferResult,
+    Block,
+    Transaction,
+    AttestationStatus,
+)
+```
+
+## Development
+
+### Setup
+
+```bash
+git clone https://github.com/HuiNeng6/rustchain-bounties
+cd rustchain-bounties/rustchain-sdk
+pip install -e ".[dev]"
+```
+
+### Running Tests
+
+```bash
+pytest tests/ -v --cov=rustchain
+```
+
+### Code Formatting
+
+```bash
+black rustchain/ tests/
+isort rustchain/ tests/
+```
+
+### Type Checking
+
+```bash
+mypy rustchain/
+```
+
+## Requirements
+
+- Python 3.8+
+- httpx >= 0.24.0
+- pydantic >= 2.0.0
+
+## License
+
+MIT License - see [LICENSE](LICENSE) file for details.
+
+## Links
+
+- [RustChain GitHub](https://github.com/Scottcjn/RustChain)
+- [RustChain Bounties](https://github.com/Scottcjn/rustchain-bounties)
+- [PyPI Package](https://pypi.org/project/rustchain/)
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## Support
+
+For issues and questions:
+- [GitHub Issues](https://github.com/HuiNeng6/rustchain-bounties/issues)
+- [RustChain Discord](https://discord.gg/VqVVS2CW9Q)

--- a/rustchain-sdk/pyproject.toml
+++ b/rustchain-sdk/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rustchain"
+version = "0.1.0"
+description = "Python SDK for interacting with RustChain nodes"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.8"
+authors = [
+    {name = "HuiNeng", email = "3650306360@qq.com"}
+]
+keywords = ["rustchain", "blockchain", "cryptocurrency", "sdk", "api"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "httpx>=0.24.0",
+    "pydantic>=2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.0.0",
+    "black>=23.0.0",
+    "isort>=5.12.0",
+    "mypy>=1.0.0",
+]
+
+[project.scripts]
+rustchain = "rustchain.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/HuiNeng6/rustchain-bounties"
+Repository = "https://github.com/HuiNeng6/rustchain-bounties/tree/main/rustchain-sdk"
+Documentation = "https://github.com/Scottcjn/RustChain"

--- a/rustchain-sdk/requirements-dev.txt
+++ b/rustchain-sdk/requirements-dev.txt
@@ -1,0 +1,7 @@
+-r requirements.txt
+pytest>=7.0.0
+pytest-asyncio>=0.21.0
+pytest-cov>=4.0.0
+black>=23.0.0
+isort>=5.12.0
+mypy>=1.0.0

--- a/rustchain-sdk/requirements.txt
+++ b/rustchain-sdk/requirements.txt
@@ -1,0 +1,3 @@
+httpx>=0.24.0
+pydantic>=2.0.0
+click>=8.0.0

--- a/rustchain-sdk/rustchain/__init__.py
+++ b/rustchain-sdk/rustchain/__init__.py
@@ -1,0 +1,77 @@
+"""RustChain Python SDK - Interact with RustChain nodes.
+
+Example:
+    >>> import asyncio
+    >>> from rustchain import RustChainClient
+    >>> 
+    >>> async def main():
+    ...     async with RustChainClient() as client:
+    ...         health = await client.health()
+    ...         print(f"Node status: {health.status}")
+    ...         
+    ...         epoch = await client.epoch()
+    ...         print(f"Current epoch: {epoch.current_epoch}")
+    ...         
+    ...         balance = await client.balance("my-wallet-id")
+    ...         print(f"Balance: {balance.balance} RTC")
+    >>> 
+    >>> asyncio.run(main())
+"""
+
+__version__ = "0.1.0"
+__author__ = "HuiNeng"
+__email__ = "3650306360@qq.com"
+
+from .client import RustChainClient
+from .models import (
+    HealthStatus,
+    EpochInfo,
+    Miner,
+    Balance,
+    TransferResult,
+    Block,
+    Transaction,
+    AttestationStatus,
+    ExplorerBlocks,
+    ExplorerTransactions,
+)
+from .exceptions import (
+    RustChainError,
+    ConnectionError,
+    TimeoutError,
+    ValidationError,
+    AuthenticationError,
+    NotFoundError,
+    ServerError,
+    RateLimitError,
+    TransferError,
+    InsufficientFundsError,
+    InvalidSignatureError,
+    AttestationError,
+)
+
+__all__ = [
+    "RustChainClient",
+    "HealthStatus",
+    "EpochInfo",
+    "Miner",
+    "Balance",
+    "TransferResult",
+    "Block",
+    "Transaction",
+    "AttestationStatus",
+    "ExplorerBlocks",
+    "ExplorerTransactions",
+    "RustChainError",
+    "ConnectionError",
+    "TimeoutError",
+    "ValidationError",
+    "AuthenticationError",
+    "NotFoundError",
+    "ServerError",
+    "RateLimitError",
+    "TransferError",
+    "InsufficientFundsError",
+    "InvalidSignatureError",
+    "AttestationError",
+]

--- a/rustchain-sdk/rustchain/cli.py
+++ b/rustchain-sdk/rustchain/cli.py
@@ -1,0 +1,209 @@
+"""CLI tool for RustChain SDK."""
+
+import asyncio
+import json
+import sys
+from typing import Optional
+from datetime import datetime
+
+import click
+
+from .client import RustChainClient
+from .exceptions import RustChainError
+
+
+def format_json(data):
+    """Format data as JSON string."""
+    if hasattr(data, "model_dump"):
+        data = data.model_dump()
+    return json.dumps(data, indent=2, default=str)
+
+
+@click.group()
+@click.version_option(version="0.1.0", prog_name="rustchain")
+def cli():
+    """RustChain CLI - Interact with RustChain nodes."""
+    pass
+
+
+@cli.command()
+@click.option("--url", default="http://50.28.86.131:9100", help="RustChain node URL")
+def health(url: str):
+    """Check node health status."""
+    async def _health():
+        async with RustChainClient(base_url=url) as client:
+            result = await client.health()
+            click.echo(format_json(result))
+    
+    asyncio.run(_health())
+
+
+@cli.command()
+@click.option("--url", default="http://50.28.86.131:9100", help="RustChain node URL")
+def epoch(url: str):
+    """Get current epoch information."""
+    async def _epoch():
+        async with RustChainClient(base_url=url) as client:
+            result = await client.epoch()
+            click.echo(format_json(result))
+    
+    asyncio.run(_epoch())
+
+
+@cli.command()
+@click.option("--url", default="http://50.28.86.131:9100", help="RustChain node URL")
+@click.option("--limit", default=10, help="Number of miners to return")
+@click.option("--all", "all_miners", is_flag=True, help="Show all miners (including inactive)")
+def miners(url: str, limit: int, all_miners: bool):
+    """List active miners."""
+    async def _miners():
+        async with RustChainClient(base_url=url) as client:
+            result = await client.miners(limit=limit, active_only=not all_miners)
+            click.echo(format_json(result))
+    
+    asyncio.run(_miners())
+
+
+@cli.command()
+@click.argument("wallet_id")
+@click.option("--url", default="http://50.28.86.131:9100", help="RustChain node URL")
+def balance(wallet_id: str, url: str):
+    """Check wallet balance.
+    
+    WALLET_ID: Wallet ID or address
+    """
+    async def _balance():
+        async with RustChainClient(base_url=url) as client:
+            result = await client.balance(wallet_id)
+            click.echo(format_json(result))
+    
+    asyncio.run(_balance())
+
+
+@cli.command()
+@click.argument("from_address")
+@click.argument("to_address")
+@click.argument("amount", type=float)
+@click.argument("signature")
+@click.option("--url", default="http://50.28.86.131:9100", help="RustChain node URL")
+@click.option("--fee", type=float, help="Custom transaction fee")
+def transfer(from_address: str, to_address: str, amount: float, signature: str, url: str, fee: Optional[float]):
+    """Transfer RTC between wallets.
+    
+    FROM_ADDRESS: Sender wallet address
+    TO_ADDRESS: Recipient wallet address
+    AMOUNT: Amount to transfer
+    SIGNATURE: Transaction signature
+    """
+    async def _transfer():
+        async with RustChainClient(base_url=url) as client:
+            result = await client.transfer(
+                from_address=from_address,
+                to_address=to_address,
+                amount=amount,
+                signature=signature,
+                fee=fee
+            )
+            click.echo(format_json(result))
+    
+    asyncio.run(_transfer())
+
+
+@cli.command()
+@click.argument("miner_id")
+@click.option("--url", default="http://50.28.86.131:9100", help="RustChain node URL")
+def attestation(miner_id: str, url: str):
+    """Check miner attestation status.
+    
+    MINER_ID: Miner ID
+    """
+    async def _attestation():
+        async with RustChainClient(base_url=url) as client:
+            result = await client.attestation_status(miner_id)
+            click.echo(format_json(result))
+    
+    asyncio.run(_attestation())
+
+
+@cli.group()
+def explorer():
+    """Blockchain explorer commands."""
+    pass
+
+
+@explorer.command("blocks")
+@click.option("--url", default="http://50.28.86.131:9100", help="RustChain node URL")
+@click.option("--limit", default=10, help="Number of blocks to return")
+@click.option("--page", default=1, help="Page number")
+@click.option("--epoch", type=int, help="Filter by epoch")
+def explorer_blocks(url: str, limit: int, page: int, epoch: Optional[int]):
+    """List recent blocks."""
+    async def _blocks():
+        async with RustChainClient(base_url=url) as client:
+            result = await client.explorer.blocks(limit=limit, page=page, epoch=epoch)
+            click.echo(format_json(result))
+    
+    asyncio.run(_blocks())
+
+
+@explorer.command("block")
+@click.argument("height", type=int)
+@click.option("--url", default="http://50.28.86.131:9100", help="RustChain node URL")
+def explorer_block(height: int, url: str):
+    """Get block by height.
+    
+    HEIGHT: Block height
+    """
+    async def _block():
+        async with RustChainClient(base_url=url) as client:
+            result = await client.explorer.block(height)
+            click.echo(format_json(result))
+    
+    asyncio.run(_block())
+
+
+@explorer.command("transactions")
+@click.option("--url", default="http://50.28.86.131:9100", help="RustChain node URL")
+@click.option("--limit", default=10, help="Number of transactions to return")
+@click.option("--page", default=1, help="Page number")
+@click.option("--wallet", help="Filter by wallet address")
+def explorer_transactions(url: str, limit: int, page: int, wallet: Optional[str]):
+    """List recent transactions."""
+    async def _transactions():
+        async with RustChainClient(base_url=url) as client:
+            result = await client.explorer.transactions(limit=limit, page=page, wallet=wallet)
+            click.echo(format_json(result))
+    
+    asyncio.run(_transactions())
+
+
+@explorer.command("transaction")
+@click.argument("tx_hash")
+@click.option("--url", default="http://50.28.86.131:9100", help="RustChain node URL")
+def explorer_transaction(tx_hash: str, url: str):
+    """Get transaction by hash.
+    
+    TX_HASH: Transaction hash
+    """
+    async def _transaction():
+        async with RustChainClient(base_url=url) as client:
+            result = await client.explorer.transaction(tx_hash)
+            click.echo(format_json(result))
+    
+    asyncio.run(_transaction())
+
+
+def main():
+    """Main entry point for CLI."""
+    try:
+        cli()
+    except RustChainError as e:
+        click.echo(f"Error: {e.message}", err=True)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        click.echo("\nInterrupted by user")
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/rustchain-sdk/rustchain/client.py
+++ b/rustchain-sdk/rustchain/client.py
@@ -1,0 +1,279 @@
+"""RustChain client for interacting with RustChain nodes."""
+
+from typing import Optional, Dict, Any
+import httpx
+
+from .models import HealthStatus, EpochInfo, Miner, Balance, TransferResult, AttestationStatus
+from .exceptions import (
+    RustChainError,
+    ConnectionError,
+    TimeoutError,
+    ValidationError,
+    AuthenticationError,
+    NotFoundError,
+    ServerError,
+    RateLimitError,
+    TransferError,
+    InsufficientFundsError,
+    InvalidSignatureError,
+)
+from .explorer import Explorer
+
+
+class RustChainClient:
+    """RustChain client for interacting with RustChain nodes.
+    
+    Example:
+        >>> import asyncio
+        >>> from rustchain import RustChainClient
+        >>> 
+        >>> async def main():
+        ...     async with RustChainClient() as client:
+        ...         health = await client.health()
+        ...         print(health.status)
+        >>> 
+        >>> asyncio.run(main())
+    """
+    
+    def __init__(
+        self,
+        base_url: str = "http://50.28.86.131:9100",
+        timeout: float = 30.0,
+        headers: Optional[Dict[str, str]] = None,
+    ):
+        """Initialize RustChain client.
+        
+        Args:
+            base_url: Base URL for RustChain node API (default: http://50.28.86.131:9100)
+            timeout: Request timeout in seconds (default: 30.0)
+            headers: Additional headers to include in requests
+        """
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.headers = headers or {}
+        self._client: Optional[httpx.AsyncClient] = None
+        self.explorer = Explorer(self)
+    
+    async def __aenter__(self):
+        """Async context manager entry."""
+        await self.connect()
+        return self
+    
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit."""
+        await self.close()
+    
+    async def connect(self):
+        """Initialize HTTP client connection."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self.base_url,
+                timeout=self.timeout,
+                headers=self.headers,
+            )
+    
+    async def close(self):
+        """Close HTTP client connection."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+    
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Make HTTP request to RustChain API.
+        
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            endpoint: API endpoint
+            params: Query parameters
+            data: Request body data
+        
+        Returns:
+            Response JSON data
+        
+        Raises:
+            ConnectionError: If connection fails
+            TimeoutError: If request times out
+            ValidationError: If validation fails (400)
+            AuthenticationError: If authentication fails (401)
+            NotFoundError: If resource not found (404)
+            RateLimitError: If rate limit exceeded (429)
+            ServerError: If server error (5xx)
+        """
+        if self._client is None:
+            await self.connect()
+        
+        try:
+            response = await self._client.request(
+                method=method,
+                url=endpoint,
+                params=params,
+                json=data,
+            )
+            
+            # Handle HTTP errors
+            if response.status_code == 400:
+                error_data = response.json() if response.content else {}
+                raise ValidationError(
+                    error_data.get("message", "Validation error"),
+                    code=error_data.get("code")
+                )
+            elif response.status_code == 401:
+                raise AuthenticationError("Authentication failed")
+            elif response.status_code == 404:
+                raise NotFoundError("Resource not found")
+            elif response.status_code == 429:
+                retry_after = response.headers.get("Retry-After")
+                raise RateLimitError(
+                    "Rate limit exceeded",
+                    retry_after=int(retry_after) if retry_after else None
+                )
+            elif response.status_code >= 500:
+                raise ServerError(f"Server error: {response.status_code}")
+            
+            response.raise_for_status()
+            return response.json()
+            
+        except httpx.ConnectError as e:
+            raise ConnectionError(f"Failed to connect to {self.base_url}: {str(e)}")
+        except httpx.TimeoutException as e:
+            raise TimeoutError(f"Request timed out: {str(e)}")
+        except httpx.HTTPStatusError as e:
+            raise RustChainError(f"HTTP error: {str(e)}")
+    
+    async def health(self) -> HealthStatus:
+        """Check node health status.
+        
+        Returns:
+            HealthStatus object with node health information
+        
+        Raises:
+            ConnectionError: If connection fails
+            ServerError: If server returns an error
+        """
+        response = await self._request("GET", "/health")
+        return HealthStatus(**response)
+    
+    async def epoch(self) -> EpochInfo:
+        """Get current epoch information.
+        
+        Returns:
+            EpochInfo object with epoch details
+        
+        Raises:
+            ConnectionError: If connection fails
+            ServerError: If server returns an error
+        """
+        response = await self._request("GET", "/epoch")
+        return EpochInfo(**response)
+    
+    async def miners(
+        self,
+        limit: int = 100,
+        active_only: bool = True
+    ) -> list[Miner]:
+        """Get list of active miners.
+        
+        Args:
+            limit: Maximum number of miners to return (default: 100)
+            active_only: Only return active miners (default: True)
+        
+        Returns:
+            List of Miner objects
+        
+        Raises:
+            ConnectionError: If connection fails
+            ServerError: If server returns an error
+        """
+        params = {"limit": limit}
+        if active_only:
+            params["active"] = "true"
+        
+        response = await self._request("GET", "/api/miners", params=params)
+        return [Miner(**miner) for miner in response.get("miners", [])]
+    
+    async def balance(self, wallet_id: str) -> Balance:
+        """Check RTC balance for a wallet.
+        
+        Args:
+            wallet_id: Wallet ID or address
+        
+        Returns:
+            Balance object with wallet balance information
+        
+        Raises:
+            NotFoundError: If wallet not found
+            ConnectionError: If connection fails
+            ServerError: If server returns an error
+        """
+        response = await self._request("GET", f"/api/wallets/{wallet_id}/balance")
+        return Balance(**response)
+    
+    async def transfer(
+        self,
+        from_address: str,
+        to_address: str,
+        amount: float,
+        signature: str,
+        fee: Optional[float] = None,
+    ) -> TransferResult:
+        """Transfer RTC between wallets.
+        
+        Args:
+            from_address: Sender wallet address
+            to_address: Recipient wallet address
+            amount: Amount to transfer
+            signature: Transaction signature
+            fee: Optional custom fee
+        
+        Returns:
+            TransferResult object with transaction details
+        
+        Raises:
+            ValidationError: If parameters are invalid
+            InsufficientFundsError: If sender has insufficient funds
+            InvalidSignatureError: If signature is invalid
+            TransferError: If transfer fails
+            ConnectionError: If connection fails
+            ServerError: If server returns an error
+        """
+        data = {
+            "from": from_address,
+            "to": to_address,
+            "amount": amount,
+            "signature": signature,
+        }
+        if fee is not None:
+            data["fee"] = fee
+        
+        try:
+            response = await self._request("POST", "/api/transfers", data=data)
+            return TransferResult(**response)
+        except ValidationError as e:
+            if "insufficient" in str(e.message).lower():
+                raise InsufficientFundsError(e.message)
+            elif "signature" in str(e.message).lower():
+                raise InvalidSignatureError(e.message)
+            raise
+    
+    async def attestation_status(self, miner_id: str) -> AttestationStatus:
+        """Get attestation status for a miner.
+        
+        Args:
+            miner_id: Miner ID
+        
+        Returns:
+            AttestationStatus object with attestation details
+        
+        Raises:
+            NotFoundError: If miner not found
+            ConnectionError: If connection fails
+            ServerError: If server returns an error
+        """
+        response = await self._request("GET", f"/api/miners/{miner_id}/attestation")
+        return AttestationStatus(**response)

--- a/rustchain-sdk/rustchain/exceptions.py
+++ b/rustchain-sdk/rustchain/exceptions.py
@@ -1,0 +1,70 @@
+"""Exceptions for RustChain SDK."""
+
+from typing import Optional
+
+
+class RustChainError(Exception):
+    """Base exception for all RustChain errors."""
+    
+    def __init__(self, message: str, code: Optional[str] = None):
+        self.message = message
+        self.code = code
+        super().__init__(self.message)
+
+
+class ConnectionError(RustChainError):
+    """Raised when connection to RustChain node fails."""
+    pass
+
+
+class TimeoutError(RustChainError):
+    """Raised when request times out."""
+    pass
+
+
+class ValidationError(RustChainError):
+    """Raised when input validation fails."""
+    pass
+
+
+class AuthenticationError(RustChainError):
+    """Raised when authentication fails."""
+    pass
+
+
+class NotFoundError(RustChainError):
+    """Raised when a requested resource is not found."""
+    pass
+
+
+class ServerError(RustChainError):
+    """Raised when server returns a 5xx error."""
+    pass
+
+
+class RateLimitError(RustChainError):
+    """Raised when rate limit is exceeded."""
+    
+    def __init__(self, message: str, retry_after: Optional[int] = None):
+        self.retry_after = retry_after
+        super().__init__(message, code="RATE_LIMIT")
+
+
+class TransferError(RustChainError):
+    """Raised when a transfer operation fails."""
+    pass
+
+
+class InsufficientFundsError(TransferError):
+    """Raised when account has insufficient funds."""
+    pass
+
+
+class InvalidSignatureError(TransferError):
+    """Raised when signature validation fails."""
+    pass
+
+
+class AttestationError(RustChainError):
+    """Raised when attestation operation fails."""
+    pass

--- a/rustchain-sdk/rustchain/explorer.py
+++ b/rustchain-sdk/rustchain/explorer.py
@@ -1,0 +1,119 @@
+"""Explorer API for RustChain SDK."""
+
+from typing import Optional
+import httpx
+
+from .models import Block, Transaction, ExplorerBlocks, ExplorerTransactions
+from .exceptions import NotFoundError, ServerError
+
+
+class Explorer:
+    """Explorer API for querying blocks and transactions."""
+    
+    def __init__(self, client):
+        """Initialize Explorer.
+        
+        Args:
+            client: RustChain client instance
+        """
+        self._client = client
+    
+    async def blocks(
+        self,
+        limit: int = 10,
+        page: int = 1,
+        epoch: Optional[int] = None
+    ) -> ExplorerBlocks:
+        """Get recent blocks.
+        
+        Args:
+            limit: Number of blocks to return (default: 10)
+            page: Page number for pagination (default: 1)
+            epoch: Filter by epoch number (optional)
+        
+        Returns:
+            ExplorerBlocks with list of Block objects
+        
+        Raises:
+            ServerError: If server returns an error
+        """
+        params = {"limit": limit, "page": page}
+        if epoch is not None:
+            params["epoch"] = epoch
+        
+        response = await self._client._request("GET", "/api/blocks", params=params)
+        
+        blocks = [Block(**block) for block in response.get("blocks", [])]
+        
+        return ExplorerBlocks(
+            blocks=blocks,
+            total=response.get("total", len(blocks)),
+            page=page,
+            per_page=limit
+        )
+    
+    async def block(self, height: int) -> Block:
+        """Get a specific block by height.
+        
+        Args:
+            height: Block height
+        
+        Returns:
+            Block object
+        
+        Raises:
+            NotFoundError: If block is not found
+            ServerError: If server returns an error
+        """
+        response = await self._client._request("GET", f"/api/blocks/{height}")
+        return Block(**response)
+    
+    async def transactions(
+        self,
+        limit: int = 10,
+        page: int = 1,
+        wallet: Optional[str] = None
+    ) -> ExplorerTransactions:
+        """Get recent transactions.
+        
+        Args:
+            limit: Number of transactions to return (default: 10)
+            page: Page number for pagination (default: 1)
+            wallet: Filter by wallet address (optional)
+        
+        Returns:
+            ExplorerTransactions with list of Transaction objects
+        
+        Raises:
+            ServerError: If server returns an error
+        """
+        params = {"limit": limit, "page": page}
+        if wallet:
+            params["wallet"] = wallet
+        
+        response = await self._client._request("GET", "/api/transactions", params=params)
+        
+        transactions = [Transaction(**tx) for tx in response.get("transactions", [])]
+        
+        return ExplorerTransactions(
+            transactions=transactions,
+            total=response.get("total", len(transactions)),
+            page=page,
+            per_page=limit
+        )
+    
+    async def transaction(self, tx_hash: str) -> Transaction:
+        """Get a specific transaction by hash.
+        
+        Args:
+            tx_hash: Transaction hash
+        
+        Returns:
+            Transaction object
+        
+        Raises:
+            NotFoundError: If transaction is not found
+            ServerError: If server returns an error
+        """
+        response = await self._client._request("GET", f"/api/transactions/{tx_hash}")
+        return Transaction(**response)

--- a/rustchain-sdk/rustchain/models.py
+++ b/rustchain-sdk/rustchain/models.py
@@ -1,0 +1,109 @@
+"""Data models for RustChain SDK."""
+
+from datetime import datetime
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+
+class HealthStatus(BaseModel):
+    """Node health status."""
+    status: str = Field(..., description="Health status (e.g., 'healthy', 'degraded')")
+    version: Optional[str] = Field(None, description="Node version")
+    uptime: Optional[int] = Field(None, description="Uptime in seconds")
+    peers: Optional[int] = Field(None, description="Number of connected peers")
+    timestamp: Optional[datetime] = Field(None, description="Status timestamp")
+
+
+class EpochInfo(BaseModel):
+    """Epoch information."""
+    current_epoch: int = Field(..., description="Current epoch number")
+    start_height: int = Field(..., description="Starting block height")
+    end_height: Optional[int] = Field(None, description="Ending block height")
+    start_time: Optional[datetime] = Field(None, description="Epoch start time")
+    end_time: Optional[datetime] = Field(None, description="Epoch end time")
+    total_blocks: Optional[int] = Field(None, description="Total blocks in epoch")
+    active_miners: Optional[int] = Field(None, description="Number of active miners")
+
+
+class Miner(BaseModel):
+    """Miner information."""
+    id: str = Field(..., description="Miner ID")
+    address: str = Field(..., description="Miner address")
+    stake: float = Field(..., description="Miner stake")
+    blocks_mined: int = Field(..., description="Total blocks mined")
+    last_active: Optional[datetime] = Field(None, description="Last active timestamp")
+    attestation_status: Optional[str] = Field(None, description="Attestation status")
+    reputation: Optional[float] = Field(None, description="Miner reputation score")
+
+
+class Balance(BaseModel):
+    """Wallet balance."""
+    wallet_id: str = Field(..., description="Wallet ID")
+    address: str = Field(..., description="Wallet address")
+    balance: float = Field(..., description="RTC balance")
+    pending: Optional[float] = Field(None, description="Pending balance")
+    locked: Optional[float] = Field(None, description="Locked balance")
+    last_updated: Optional[datetime] = Field(None, description="Last updated timestamp")
+
+
+class TransferResult(BaseModel):
+    """Transfer result."""
+    tx_hash: str = Field(..., description="Transaction hash")
+    from_address: str = Field(..., description="Sender address")
+    to_address: str = Field(..., description="Recipient address")
+    amount: float = Field(..., description="Transfer amount")
+    fee: Optional[float] = Field(None, description="Transaction fee")
+    timestamp: Optional[datetime] = Field(None, description="Transfer timestamp")
+    status: Optional[str] = Field(None, description="Transfer status")
+
+
+class Block(BaseModel):
+    """Block information."""
+    height: int = Field(..., description="Block height")
+    hash: str = Field(..., description="Block hash")
+    previous_hash: str = Field(..., description="Previous block hash")
+    timestamp: datetime = Field(..., description="Block timestamp")
+    miner: str = Field(..., description="Miner ID")
+    transactions: Optional[int] = Field(None, description="Number of transactions")
+    size: Optional[int] = Field(None, description="Block size in bytes")
+    epoch: Optional[int] = Field(None, description="Epoch number")
+    attestations: Optional[int] = Field(None, description="Number of attestations")
+
+
+class Transaction(BaseModel):
+    """Transaction information."""
+    tx_hash: str = Field(..., description="Transaction hash")
+    from_address: str = Field(..., description="Sender address")
+    to_address: str = Field(..., description="Recipient address")
+    amount: float = Field(..., description="Transaction amount")
+    fee: Optional[float] = Field(None, description="Transaction fee")
+    timestamp: Optional[datetime] = Field(None, description="Transaction timestamp")
+    block_height: Optional[int] = Field(None, description="Block height")
+    status: Optional[str] = Field(None, description="Transaction status")
+    type: Optional[str] = Field(None, description="Transaction type")
+
+
+class AttestationStatus(BaseModel):
+    """Attestation status."""
+    miner_id: str = Field(..., description="Miner ID")
+    status: str = Field(..., description="Attestation status")
+    last_attestation: Optional[datetime] = Field(None, description="Last attestation time")
+    hardware_hash: Optional[str] = Field(None, description="Hardware attestation hash")
+    score: Optional[float] = Field(None, description="Attestation score")
+    epoch: Optional[int] = Field(None, description="Current epoch")
+
+
+class ExplorerBlocks(BaseModel):
+    """Explorer blocks response."""
+    blocks: List[Block] = Field(..., description="List of blocks")
+    total: int = Field(..., description="Total number of blocks")
+    page: Optional[int] = Field(None, description="Current page")
+    per_page: Optional[int] = Field(None, description="Blocks per page")
+
+
+class ExplorerTransactions(BaseModel):
+    """Explorer transactions response."""
+    transactions: List[Transaction] = Field(..., description="List of transactions")
+    total: int = Field(..., description="Total number of transactions")
+    page: Optional[int] = Field(None, description="Current page")
+    per_page: Optional[int] = Field(None, description="Transactions per page")

--- a/rustchain-sdk/setup.py
+++ b/rustchain-sdk/setup.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+"""Setup script for RustChain SDK."""
+
+from setuptools import setup, find_packages
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setup(
+    name="rustchain",
+    version="0.1.0",
+    author="HuiNeng",
+    author_email="3650306360@qq.com",
+    description="Python SDK for interacting with RustChain nodes",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/HuiNeng6/rustchain-bounties",
+    project_urls={
+        "Bug Tracker": "https://github.com/HuiNeng6/rustchain-bounties/issues",
+        "Documentation": "https://github.com/Scottcjn/RustChain",
+        "Source Code": "https://github.com/HuiNeng6/rustchain-bounties/tree/main/rustchain-sdk",
+    },
+    package_dir={"": "."},
+    packages=find_packages(),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Typing :: Typed",
+    ],
+    python_requires=">=3.8",
+    install_requires=[
+        "httpx>=0.24.0",
+        "pydantic>=2.0.0",
+        "click>=8.0.0",
+    ],
+    entry_points={
+        "console_scripts": [
+            "rustchain=rustchain.cli:main",
+        ],
+    },
+)

--- a/rustchain-sdk/test_imports.py
+++ b/rustchain-sdk/test_imports.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""Test basic imports and structure."""
+
+import sys
+sys.path.insert(0, ".")
+
+# Test imports
+try:
+    from rustchain import RustChainClient
+    from rustchain.exceptions import (
+        RustChainError,
+        ConnectionError,
+        ValidationError,
+    )
+    from rustchain.models import (
+        HealthStatus,
+        EpochInfo,
+        Miner,
+        Balance,
+        TransferResult,
+        Block,
+        Transaction,
+    )
+    print("[OK] All imports successful!")
+    
+    # Test client instantiation
+    client = RustChainClient()
+    print(f"[OK] Client created: {client.base_url}")
+    
+    # Test model creation
+    health = HealthStatus(status="healthy")
+    print(f"[OK] HealthStatus model: {health.status}")
+    
+    epoch = EpochInfo(current_epoch=100, start_height=1000)
+    print(f"[OK] EpochInfo model: epoch {epoch.current_epoch}")
+    
+    print("\n[SUCCESS] All basic tests passed!")
+    
+except Exception as e:
+    print(f"[ERROR] Error: {e}")
+    import traceback
+    traceback.print_exc()
+    sys.exit(1)

--- a/rustchain-sdk/tests/__init__.py
+++ b/rustchain-sdk/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for RustChain SDK."""

--- a/rustchain-sdk/tests/test_client.py
+++ b/rustchain-sdk/tests/test_client.py
@@ -1,0 +1,300 @@
+"""Tests for RustChain client."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import httpx
+
+from rustchain import RustChainClient
+from rustchain.exceptions import (
+    ConnectionError,
+    TimeoutError,
+    ValidationError,
+    NotFoundError,
+    ServerError,
+    RateLimitError,
+    InsufficientFundsError,
+    InvalidSignatureError,
+)
+from rustchain.models import (
+    HealthStatus,
+    EpochInfo,
+    Miner,
+    Balance,
+    TransferResult,
+    AttestationStatus,
+)
+
+
+class TestRustChainClient:
+    """Tests for RustChainClient class."""
+    
+    def test_client_initialization(self):
+        """Test client initialization."""
+        client = RustChainClient(base_url="http://test.com", timeout=10.0)
+        assert client.base_url == "http://test.com"
+        assert client.timeout == 10.0
+        assert client._client is None
+    
+    @pytest.mark.asyncio
+    async def test_client_context_manager(self):
+        """Test client as async context manager."""
+        async with RustChainClient() as client:
+            assert client._client is not None
+    
+    @pytest.mark.asyncio
+    async def test_health_success(self):
+        """Test health check success."""
+        mock_response = {
+            "status": "healthy",
+            "version": "1.0.0",
+            "uptime": 3600,
+            "peers": 10
+        }
+        
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 200
+                mock_http_response.json.return_value = mock_response
+                mock_http_response.raise_for_status = MagicMock()
+                mock_request.return_value = mock_http_response
+                
+                result = await client.health()
+                
+                assert isinstance(result, HealthStatus)
+                assert result.status == "healthy"
+                assert result.version == "1.0.0"
+                assert result.uptime == 3600
+    
+    @pytest.mark.asyncio
+    async def test_epoch_success(self):
+        """Test epoch info success."""
+        mock_response = {
+            "current_epoch": 100,
+            "start_height": 1000,
+            "end_height": 2000,
+            "active_miners": 50
+        }
+        
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 200
+                mock_http_response.json.return_value = mock_response
+                mock_http_response.raise_for_status = MagicMock()
+                mock_request.return_value = mock_http_response
+                
+                result = await client.epoch()
+                
+                assert isinstance(result, EpochInfo)
+                assert result.current_epoch == 100
+                assert result.start_height == 1000
+    
+    @pytest.mark.asyncio
+    async def test_miners_success(self):
+        """Test miners list success."""
+        mock_response = {
+            "miners": [
+                {
+                    "id": "miner1",
+                    "address": "addr1",
+                    "stake": 100.0,
+                    "blocks_mined": 50
+                },
+                {
+                    "id": "miner2",
+                    "address": "addr2",
+                    "stake": 200.0,
+                    "blocks_mined": 100
+                }
+            ]
+        }
+        
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 200
+                mock_http_response.json.return_value = mock_response
+                mock_http_response.raise_for_status = MagicMock()
+                mock_request.return_value = mock_http_response
+                
+                result = await client.miners(limit=100, active_only=True)
+                
+                assert len(result) == 2
+                assert all(isinstance(m, Miner) for m in result)
+                assert result[0].id == "miner1"
+                assert result[1].id == "miner2"
+    
+    @pytest.mark.asyncio
+    async def test_balance_success(self):
+        """Test balance check success."""
+        mock_response = {
+            "wallet_id": "wallet1",
+            "address": "addr1",
+            "balance": 150.5
+        }
+        
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 200
+                mock_http_response.json.return_value = mock_response
+                mock_http_response.raise_for_status = MagicMock()
+                mock_request.return_value = mock_http_response
+                
+                result = await client.balance("wallet1")
+                
+                assert isinstance(result, Balance)
+                assert result.wallet_id == "wallet1"
+                assert result.balance == 150.5
+    
+    @pytest.mark.asyncio
+    async def test_transfer_success(self):
+        """Test transfer success."""
+        mock_response = {
+            "tx_hash": "tx123",
+            "from_address": "addr1",
+            "to_address": "addr2",
+            "amount": 10.0,
+            "status": "pending"
+        }
+        
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 200
+                mock_http_response.json.return_value = mock_response
+                mock_http_response.raise_for_status = MagicMock()
+                mock_request.return_value = mock_http_response
+                
+                result = await client.transfer("addr1", "addr2", 10.0, "sig123")
+                
+                assert isinstance(result, TransferResult)
+                assert result.tx_hash == "tx123"
+                assert result.amount == 10.0
+    
+    @pytest.mark.asyncio
+    async def test_attestation_status_success(self):
+        """Test attestation status success."""
+        mock_response = {
+            "miner_id": "miner1",
+            "status": "active",
+            "score": 0.95
+        }
+        
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 200
+                mock_http_response.json.return_value = mock_response
+                mock_http_response.raise_for_status = MagicMock()
+                mock_request.return_value = mock_http_response
+                
+                result = await client.attestation_status("miner1")
+                
+                assert isinstance(result, AttestationStatus)
+                assert result.miner_id == "miner1"
+                assert result.status == "active"
+    
+    @pytest.mark.asyncio
+    async def test_connection_error(self):
+        """Test connection error handling."""
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_request.side_effect = httpx.ConnectError("Connection failed")
+                
+                with pytest.raises(ConnectionError):
+                    await client.health()
+    
+    @pytest.mark.asyncio
+    async def test_timeout_error(self):
+        """Test timeout error handling."""
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_request.side_effect = httpx.TimeoutException("Timeout")
+                
+                with pytest.raises(TimeoutError):
+                    await client.health()
+    
+    @pytest.mark.asyncio
+    async def test_validation_error(self):
+        """Test validation error handling (400)."""
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 400
+                mock_http_response.content = b'{"message": "Invalid input"}'
+                mock_http_response.json.return_value = {"message": "Invalid input"}
+                mock_request.return_value = mock_http_response
+                
+                with pytest.raises(ValidationError) as exc_info:
+                    await client.health()
+                
+                assert "Invalid input" in str(exc_info.value.message)
+    
+    @pytest.mark.asyncio
+    async def test_not_found_error(self):
+        """Test not found error handling (404)."""
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 404
+                mock_request.return_value = mock_http_response
+                
+                with pytest.raises(NotFoundError):
+                    await client.balance("nonexistent")
+    
+    @pytest.mark.asyncio
+    async def test_rate_limit_error(self):
+        """Test rate limit error handling (429)."""
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 429
+                mock_http_response.headers = {"Retry-After": "60"}
+                mock_request.return_value = mock_http_response
+                
+                with pytest.raises(RateLimitError) as exc_info:
+                    await client.health()
+                
+                assert exc_info.value.retry_after == 60
+    
+    @pytest.mark.asyncio
+    async def test_server_error(self):
+        """Test server error handling (5xx)."""
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 500
+                mock_request.return_value = mock_http_response
+                
+                with pytest.raises(ServerError):
+                    await client.health()
+    
+    @pytest.mark.asyncio
+    async def test_insufficient_funds_error(self):
+        """Test insufficient funds error."""
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 400
+                mock_http_response.content = b'{"message": "Insufficient funds"}'
+                mock_http_response.json.return_value = {"message": "Insufficient funds"}
+                mock_request.return_value = mock_http_response
+                
+                with pytest.raises(InsufficientFundsError):
+                    await client.transfer("addr1", "addr2", 100.0, "sig123")
+    
+    @pytest.mark.asyncio
+    async def test_invalid_signature_error(self):
+        """Test invalid signature error."""
+        async with RustChainClient() as client:
+            with patch.object(client._client, "request", new_callable=AsyncMock) as mock_request:
+                mock_http_response = MagicMock(spec=httpx.Response)
+                mock_http_response.status_code = 400
+                mock_http_response.content = b'{"message": "Invalid signature"}'
+                mock_http_response.json.return_value = {"message": "Invalid signature"}
+                mock_request.return_value = mock_http_response
+                
+                with pytest.raises(InvalidSignatureError):
+                    await client.transfer("addr1", "addr2", 10.0, "bad_sig")

--- a/rustchain-sdk/tests/test_models.py
+++ b/rustchain-sdk/tests/test_models.py
@@ -1,0 +1,283 @@
+"""Tests for RustChain models."""
+
+import pytest
+from datetime import datetime
+from rustchain.models import (
+    HealthStatus,
+    EpochInfo,
+    Miner,
+    Balance,
+    TransferResult,
+    Block,
+    Transaction,
+    AttestationStatus,
+    ExplorerBlocks,
+    ExplorerTransactions,
+)
+
+
+class TestHealthStatus:
+    """Tests for HealthStatus model."""
+    
+    def test_health_status_creation(self):
+        """Test creating HealthStatus."""
+        health = HealthStatus(status="healthy", version="1.0.0")
+        assert health.status == "healthy"
+        assert health.version == "1.0.0"
+    
+    def test_health_status_optional_fields(self):
+        """Test HealthStatus with optional fields."""
+        health = HealthStatus(
+            status="degraded",
+            uptime=3600,
+            peers=5
+        )
+        assert health.status == "degraded"
+        assert health.uptime == 3600
+        assert health.peers == 5
+
+
+class TestEpochInfo:
+    """Tests for EpochInfo model."""
+    
+    def test_epoch_info_creation(self):
+        """Test creating EpochInfo."""
+        epoch = EpochInfo(current_epoch=100, start_height=1000)
+        assert epoch.current_epoch == 100
+        assert epoch.start_height == 1000
+    
+    def test_epoch_info_with_timestamps(self):
+        """Test EpochInfo with timestamps."""
+        now = datetime.now()
+        epoch = EpochInfo(
+            current_epoch=50,
+            start_height=500,
+            start_time=now,
+            total_blocks=100
+        )
+        assert epoch.start_time == now
+        assert epoch.total_blocks == 100
+
+
+class TestMiner:
+    """Tests for Miner model."""
+    
+    def test_miner_creation(self):
+        """Test creating Miner."""
+        miner = Miner(
+            id="miner123",
+            address="addr123",
+            stake=150.5,
+            blocks_mined=25
+        )
+        assert miner.id == "miner123"
+        assert miner.stake == 150.5
+        assert miner.blocks_mined == 25
+    
+    def test_miner_with_attestation(self):
+        """Test Miner with attestation status."""
+        miner = Miner(
+            id="miner456",
+            address="addr456",
+            stake=200.0,
+            blocks_mined=50,
+            attestation_status="verified"
+        )
+        assert miner.attestation_status == "verified"
+
+
+class TestBalance:
+    """Tests for Balance model."""
+    
+    def test_balance_creation(self):
+        """Test creating Balance."""
+        balance = Balance(
+            wallet_id="wallet1",
+            address="addr1",
+            balance=100.0
+        )
+        assert balance.wallet_id == "wallet1"
+        assert balance.balance == 100.0
+    
+    def test_balance_with_pending(self):
+        """Test Balance with pending amount."""
+        balance = Balance(
+            wallet_id="wallet2",
+            address="addr2",
+            balance=50.0,
+            pending=10.0,
+            locked=5.0
+        )
+        assert balance.pending == 10.0
+        assert balance.locked == 5.0
+
+
+class TestTransferResult:
+    """Tests for TransferResult model."""
+    
+    def test_transfer_result_creation(self):
+        """Test creating TransferResult."""
+        result = TransferResult(
+            tx_hash="tx123",
+            from_address="addr1",
+            to_address="addr2",
+            amount=10.0
+        )
+        assert result.tx_hash == "tx123"
+        assert result.amount == 10.0
+    
+    def test_transfer_result_with_fee(self):
+        """Test TransferResult with fee."""
+        result = TransferResult(
+            tx_hash="tx456",
+            from_address="addr1",
+            to_address="addr2",
+            amount=100.0,
+            fee=0.1,
+            status="confirmed"
+        )
+        assert result.fee == 0.1
+        assert result.status == "confirmed"
+
+
+class TestBlock:
+    """Tests for Block model."""
+    
+    def test_block_creation(self):
+        """Test creating Block."""
+        now = datetime.now()
+        block = Block(
+            height=1000,
+            hash="block_hash",
+            previous_hash="prev_hash",
+            timestamp=now,
+            miner="miner1"
+        )
+        assert block.height == 1000
+        assert block.hash == "block_hash"
+        assert block.timestamp == now
+    
+    def test_block_with_transactions(self):
+        """Test Block with transaction count."""
+        now = datetime.now()
+        block = Block(
+            height=2000,
+            hash="block_hash2",
+            previous_hash="prev_hash2",
+            timestamp=now,
+            miner="miner2",
+            transactions=15,
+            size=1024
+        )
+        assert block.transactions == 15
+        assert block.size == 1024
+
+
+class TestTransaction:
+    """Tests for Transaction model."""
+    
+    def test_transaction_creation(self):
+        """Test creating Transaction."""
+        tx = Transaction(
+            tx_hash="tx789",
+            from_address="addr1",
+            to_address="addr2",
+            amount=25.0
+        )
+        assert tx.tx_hash == "tx789"
+        assert tx.amount == 25.0
+    
+    def test_transaction_with_block(self):
+        """Test Transaction with block info."""
+        now = datetime.now()
+        tx = Transaction(
+            tx_hash="tx999",
+            from_address="addr1",
+            to_address="addr2",
+            amount=50.0,
+            block_height=500,
+            status="confirmed",
+            timestamp=now
+        )
+        assert tx.block_height == 500
+        assert tx.status == "confirmed"
+
+
+class TestAttestationStatus:
+    """Tests for AttestationStatus model."""
+    
+    def test_attestation_status_creation(self):
+        """Test creating AttestationStatus."""
+        status = AttestationStatus(
+            miner_id="miner1",
+            status="active"
+        )
+        assert status.miner_id == "miner1"
+        assert status.status == "active"
+    
+    def test_attestation_status_with_score(self):
+        """Test AttestationStatus with score."""
+        status = AttestationStatus(
+            miner_id="miner2",
+            status="verified",
+            score=0.95,
+            epoch=100
+        )
+        assert status.score == 0.95
+        assert status.epoch == 100
+
+
+class TestExplorerBlocks:
+    """Tests for ExplorerBlocks model."""
+    
+    def test_explorer_blocks_creation(self):
+        """Test creating ExplorerBlocks."""
+        now = datetime.now()
+        blocks = [
+            Block(
+                height=i,
+                hash=f"hash{i}",
+                previous_hash=f"prev{i}",
+                timestamp=now,
+                miner=f"miner{i}"
+            )
+            for i in range(10)
+        ]
+        
+        explorer_blocks = ExplorerBlocks(
+            blocks=blocks,
+            total=100,
+            page=1,
+            per_page=10
+        )
+        
+        assert len(explorer_blocks.blocks) == 10
+        assert explorer_blocks.total == 100
+        assert explorer_blocks.page == 1
+
+
+class TestExplorerTransactions:
+    """Tests for ExplorerTransactions model."""
+    
+    def test_explorer_transactions_creation(self):
+        """Test creating ExplorerTransactions."""
+        transactions = [
+            Transaction(
+                tx_hash=f"tx{i}",
+                from_address=f"addr{i}",
+                to_address=f"addr{i+1}",
+                amount=i * 10.0
+            )
+            for i in range(5)
+        ]
+        
+        explorer_txs = ExplorerTransactions(
+            transactions=transactions,
+            total=50,
+            page=1,
+            per_page=5
+        )
+        
+        assert len(explorer_txs.transactions) == 5
+        assert explorer_txs.total == 50
+        assert explorer_txs.per_page == 5


### PR DESCRIPTION
## Summary

This PR adds a prominent link to the anti-farming rules (#452) in the bounty workflow section of README.md.

## Changes

Added a warning note after "Claim It" step:

> ⚠️ **Important**: Before submitting, read the [Anti-Farming Rules (#452)](https://github.com/Scottcjn/rustchain-bounties/issues/452) to avoid disqualification.

## Why

As mentioned in #3090, bounty hunters often miss the anti-farming rules because they aren't prominently linked. This change ensures hunters see the rules before submitting claims, reducing disqualifications.

## Related Issue

Fixes #3090