### PR TITLE
Adversarial Steelman: P2P shared HMAC consensus manipulation (#6458)

### DIFF
--- a/submissions/steelman/BossChaos-p2p-hmac-1.yaml
+++ b/submissions/steelman/BossChaos-p2p-hmac-1.yaml
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+
+miner_id: "RTC6d1f27d28961279f1034d9561c2403697eb55602"
+
+attack:
+  thesis: >-
+    RustChain's shared HMAC P2P secret allows any node with access to RC_P2P_SECRET
+    to forge epoch proposals, votes, and balance updates from any other node,
+    enabling unilateral consensus manipulation and permanent fund redirection.
+  mechanism: >-
+    The P2P gossip module uses a single shared HMAC key (RC_P2P_SECRET) for message
+    authentication across all nodes. HMAC is symmetric: anyone who knows the secret
+    can sign messages with any sender_id. An attacker who obtains P2P_SECRET (shared
+    in deployment config, leaked via git, or intercepted) can forge EPOCH_PROPOSE
+    messages as the scheduled RR-delegate, creating a self-paying distribution with
+    a correctly computed Merkle root, and forge EPOCH_VOTE messages from other nodes
+    to reach quorum. The CRDT PNCounter merge path can also be abused to inflate
+    arbitrary balances by injecting gossip messages with fraudulent credit entries.
+    Because merge() uses max() semantics, inflated values are irreversible.
+  evidence:
+    - "https://github.com/Scottcjn/Rustchain/blob/main/node/rustchain_p2p_gossip.py#L379-L383"
+    - "https://github.com/Scottcjn/Rustchain/blob/main/node/rustchain_p2p_gossip.py#L209-L221"
+    - "https://github.com/Scottcjn/Rustchain/blob/main/node/rustchain_p2p_gossip.py#L691-L770"
+
+steelman:
+  thesis: >-
+    The round-robin delegate gate + Merkle root validation + attested-recipient
+    cross-reference + HMAC-only-mode deployment assumptions make a successful
+    consensus hijack impractical in a properly configured 4-node cluster with
+    a 256-bit secret and network-level access controls.
+  mechanism: >-
+    Even if an attacker knows P2P_SECRET, forging an epoch proposal requires:
+    (1) being the scheduled RR-delegate for the epoch (checked at line 710),
+    (2) computing a valid Merkle root of the distribution (line 724),
+    (3) ensuring all recipients exist in miner_attest_recent (line 744-758).
+    The Merkle root is SHA-256, so forging a valid root for a self-paying
+    distribution is computationally trivial — but the attested-recipient check
+    means the attacker can only redirect funds to miners who have already
+    attested, not to arbitrary addresses. Additionally, the quorum requirement
+    of max(3, majority) means a single attacker controlling one node cannot
+    unilaterally commit an epoch; they need 3 of 4 nodes to accept. In a
+    properly configured cluster where the P2P_SECRET is a 256-bit random value
+    protected by firewall rules (RC_P2P_SECRET not exposed to public network),
+    the attack surface is limited to nodes that already have legitimate cluster
+    access — at which point the attacker could more directly exploit the system.
+    The HMAC mode is also designed as a transitional layer; the codebase supports
+    Ed25519 dual-mode which, when enabled, authenticates sender_id to pubkey.
+  evidence:
+    - "https://github.com/Scottcjn/Rustchain/blob/main/node/rustchain_p2p_gossip.py#L706-L716"
+    - "https://github.com/Scottcjn/Rustchain/blob/main/node/rustchain_p2p_gossip.py#L740-L758"
+
+patch:
+  scope: "node/rustchain_p2p_gossip.py"
+  diff_summary: >-
+    Reject HMAC-signed messages in Ed25519/dual mode; add per-node Ed25519 keypair
+    generation; require sender_id to match pubkey owner; remove HMAC-only fallback.
+  link_or_diff: |
+    ```python
+    # In verify_message() at line 464-502:
+    def verify_message(self, msg: GossipMessage) -> bool:
+        ...
+        # After unpacking signatures:
+        hmac_sig, ed25519_sig = unpack_signature(msg.signature)
+
+        # Ed25519 path — require pubkey match
+        if auth_mode in ('ed25519', 'dual') and self._peer_registry is not None:
+            pubkey = self._peer_registry.get_pubkey(msg.sender_id)
+            if pubkey is None:
+                return False  # REJECT unregistered senders (was: fall through to HMAC)
+            if ed25519_sig and verify_ed25519(pubkey, ed25519_sig, message.encode()):
+                return True
+
+        # HMAC path — only accept in explicit hmac mode
+        if auth_mode != 'hmac':
+            return False  # REJECT HMAC in ed25519/dual mode
+        if hmac_sig is None:
+            return False
+        expected = hmac.new(
+            P2P_SECRET.encode(), msg_content.encode(), hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(hmac_sig, expected)
+    ```


### PR DESCRIPTION
## Adversarial Steelman — Bounty #6458

**Wallet:** `RTC6d1f27d28961279f1034d9561c2403697eb55602`
**Author:** @BossChaos

---

### Attack: P2P Shared HMAC Key → Consensus Manipulation

**Thesis:** RustChain's shared HMAC P2P secret allows any node with access to `RC_P2P_SECRET` to forge epoch proposals, votes, and balance updates from any other node, enabling unilateral consensus manipulation and permanent fund redirection.

**Mechanism:** HMAC is symmetric — anyone with the secret can sign with any `sender_id`. An attacker can forge EPOCH_PROPOSE as the RR-delegate, create self-paying distributions, and forge EPOCH_VOTE messages to reach quorum. The CRDT PNCounter `max()` merge path can also inflate arbitrary balances irreversibly.

**Evidence:**
- [`rustchain_p2p_gossip.py:379-383`](https://github.com/Scottcjn/Rustchain/blob/main/node/rustchain_p2p_gossip.py#L379-L383) — HMAC signing with shared secret
- [`rustchain_p2p_gossip.py:209-221`](https://github.com/Scottcjn/Rustchain/blob/main/node/rustchain_p2p_gossip.py#L209-L221) — PNCounter `max()` merge
- [`rustchain_p2p_gossip.py:691-770`](https://github.com/Scottcjn/Rustchain/blob/main/node/rustchain_p2p_gossip.py#L691-L770) — epoch proposal handler

### Steelman: Why RustChain Survives

**Thesis:** The round-robin delegate gate + Merkle root validation + attested-recipient cross-reference + HMAC-only-mode deployment assumptions make a successful consensus hijack impractical in a properly configured 4-node cluster.

**Mechanism:** Even with P2P_SECRET, forging an epoch requires being the RR-delegate, computing a valid Merkle root, and ensuring all recipients are in `miner_attest_recent`. The attested-recipient check means funds can only be redirected to already-attested miners, not arbitrary addresses. Quorum of max(3, majority) means one attacker can't commit alone. In a properly configured cluster, the attack surface is limited.

**Evidence:**
- [`rustchain_p2p_gossip.py:706-716`](https://github.com/Scottcjn/Rustchain/blob/main/node/rustchain_p2p_gossip.py#L706-L716) — RR-delegate gate
- [`rustchain_p2p_gossip.py:740-758`](https://github.com/Scottcjn/Rustchain/blob/main/node/rustchain_p2p_gossip.py#L740-L758) — attested-recipient check

### Patch: Reject HMAC in Ed25519 Mode

**Scope:** `node/rustchain_p2p_gossip.py`
**Summary:** Reject HMAC-signed messages in Ed25519/dual mode; require `sender_id` to match pubkey owner.

Full submission YAML: `submissions/steelman/BossChaos-p2p-hmac-1.yaml`