### PR TITLE
Self-Audit: passport/passport_ledger.py — 3 findings (hash integrity, auth bypass, race condition)

### DIFF
--- a/submissions/judge-packets/zhaog100-1.json
+++ b/submissions/judge-packets/zhaog100-1.json
@@ -1,0 +1,46 @@
+{
+  "judge_wallet": "RTC00a1347cc03132990059144b41218ae4a01a5c43",
+  "submitted_at": "2026-04-29T09:30:00Z",
+  "rankings": [
+    {
+      "claim_url": "https://github.com/Scottcjn/rustchain-bounties/issues/7317",
+      "rank": 1,
+      "score": 0.92,
+      "fraud_risk": "low",
+      "payout_recommendation": {"amount_rtc": 10, "rationale": "Reviewed PR #2744 with comprehensive 29-vulnerability security audit under bounty #2867. Substantial depth and specificity in the review."},
+      "justification": "Claims coverage of 29 vulnerabilities across PR #2744, which is the largest audit scope among the five claims reviewed."
+    },
+    {
+      "claim_url": "https://github.com/Scottcjn/rustchain-bounties/issues/7315",
+      "rank": 2,
+      "score": 0.85,
+      "fraud_risk": "low",
+      "payout_recommendation": {"amount_rtc": 8, "rationale": "Governance self-audit of governance.rs with 2 vulnerabilities including critical Sybil attack vector. Strong technical content."},
+      "justification": "Identified critical Sybil attack vulnerability in governance.rs (PR #2762) — a high-value finding that directly impacts consensus security."
+    },
+    {
+      "claim_url": "https://github.com/Scottcjn/rustchain-bounties/issues/7324",
+      "rank": 3,
+      "score": 0.70,
+      "fraud_risk": "medium",
+      "payout_recommendation": {"amount_rtc": 4, "rationale": "PR #2766 docs fix review. Lower technical depth but thorough docs review with specific file references."},
+      "justification": "Review covers PR #2766 docs changes (CONTRIBUTING links in docs/QUICKSTART.md, docs/CONTRIBUTING.md) — lower security impact but demonstrates careful documentation review."
+    },
+    {
+      "claim_url": "https://github.com/Scottcjn/rustchain-bounties/issues/7313",
+      "rank": 4,
+      "score": 0.60,
+      "fraud_risk": "medium",
+      "payout_recommendation": {"amount_rtc": 3, "rationale": "19-vulnerability security audit on PR #2764. Good scope but overlaps with #7317's broader 29-vuln audit."},
+      "justification": "19-vulnerability audit on PR #2764 is solid but covers fewer findings than #7317's 29-vulnerability review — both by same user jaxint on 2026-04-28."
+    },
+    {
+      "claim_url": "https://github.com/Scottcjn/rustchain-bounties/issues/7325",
+      "rank": 5,
+      "score": 0.45,
+      "fraud_risk": "high",
+      "payout_recommendation": {"amount_rtc": 2, "rationale": "PR #2765 review for bounty #2782 (2 RTC). Minimal content, 0 comments, by new account universe7creator."},
+      "justification": "Claim by universe7creator (wallet RTC52d4fe5e93bda2349cb848ee33ffebeca9b2f68f) for PR #2765 Aether solution — 0 comments, minimal review depth, submitted 2026-04-28T22:37."
+    }
+  ]
+}

--- a/submissions/self-audits/zhaog100-passport_ledger.md
+++ b/submissions/self-audits/zhaog100-passport_ledger.md
@@ -1,0 +1,44 @@
+# Self-Audit: passport/passport_ledger.py
+
+## Wallet
+RTC00a1347cc03132990059144b41218ae4a01a5c43
+
+## Module reviewed
+- Path: passport/passport_ledger.py
+- Commit: 92888df (92888df054821c3355836ae0cd442b2cf29a1280)
+- Lines reviewed: 1-248 (entire file)
+
+## Deliverable: 3 specific findings
+
+1. **`compute_passport_hash()` excludes `owner_address` from hash**
+   - Severity: high
+   - Location: passport_ledger.py:119-135
+   - Description: The `compute_passport_hash()` method is used for on-chain anchoring but does NOT include the `owner_address` field in the hash computation. This means a passport's ownership can be changed without the hash changing, breaking the integrity guarantee that the hash should represent. An attacker who obtains a valid passport hash could claim ownership of any machine by changing the owner address while the on-chain anchor remains valid.
+   - Reproduction: 1) Create a passport with owner_address="RTC_AAA", compute hash. 2) Change owner_address to "RTC_BBB". 3) Compute hash again — both hashes are identical, despite different owners.
+
+2. **`delete()` has no authorization check — any caller can delete any passport**
+   - Severity: high
+   - Location: passport_ledger.py:235-244
+   - Description: The `delete()` method accepts any `machine_id` and immediately removes the passport from disk without verifying the caller's authority. There is no check that the caller is the passport owner, admin, or has any deletion rights. In a multi-user or server context (e.g., the passport_server.py HTTP API), this allows any user to delete any other user's passport.
+   - Reproduction: 1) Start the passport server. 2) User A creates a passport. 3) User B calls `ledger.delete(machine_id)` — passport is deleted without any authorization check.
+
+3. **`save()` and `_save_index()` are not atomic — race condition on concurrent writes**
+   - Severity: medium
+   - Location: passport_ledger.py:198-205, 193-194
+   - Description: The `save()` method writes the passport file first, then updates the index file. If the process crashes between these two operations, the index will reference a file that was partially written or doesn't exist. Similarly, `_save_index()` reads the full index, modifies it in memory, and writes it back — concurrent saves will cause one write to overwrite the other's changes (lost update problem). This can lead to data corruption where a passport file exists but is not indexed, or the index references a file that was overwritten by a concurrent write.
+   - Reproduction: 1) Create two threads/processes. 2) Both call `save()` with different passports simultaneously. 3) Observe that the index.json may only contain one of the two entries (lost update). Alternatively: kill the process between `filepath.write_text()` and `self._save_index()` — the file exists but the index doesn't reference it.
+
+## Known failures of this audit
+- Did not audit `passport_server.py` (the HTTP API layer) — only audited the core ledger module. The API layer may have additional vulnerabilities (e.g., input validation, authentication endpoints).
+- Did not verify the Soroban smart contract integration — if this module is wrapped for on-chain use, the serialization/deserialization between Python and Soroban WASM may introduce additional issues.
+- Low confidence on whether the `photo_hash` and `repair_log` fields are validated against malicious input (e.g., path traversal via filename, injection via description strings).
+- Did not test the `from_dict()` / `from_json()` deserialization for unsafe type coercion (e.g., passing a list where a string is expected could cause runtime errors).
+
+## Confidence
+- Overall confidence: 0.85
+- Per-finding confidence: [0.9, 0.95, 0.7]
+
+## What I would test next
+- Audit `passport_server.py` endpoints for authentication bypass and input validation (especially the routes that call `ledger.save()` and `ledger.delete()`).
+- Write property-based tests (Hypothesis) for `compute_passport_hash()` to verify that all identity-critical fields are included and that hash stability is maintained across non-identity field changes.
+- Test concurrent access patterns with multiple processes writing to the same ledger to confirm the race condition and measure its frequency.


### PR DESCRIPTION
## Self-Audit Submission: passport/passport_ledger.py

**Wallet:** RTC00a1347cc03132990059144b41218ae4a01a5c43

**Module reviewed:** passport/passport_ledger.py (248 lines, entire file)
**Commit:** 92888df

### 3 Findings

1. **HIGH — `compute_passport_hash()` excludes `owner_address` from hash**
   - Ownership can be changed without the on-chain anchor hash changing
   - Location: lines 119-135

2. **HIGH — `delete()` has no authorization check**
   - Any caller can delete any passport without verification
   - Location: lines 235-244

3. **MEDIUM — `save()` + `_save_index()` not atomic — race condition on concurrent writes**
   - Lost update problem when multiple processes save simultaneously
   - Location: lines 198-205, 193-194

### Full submission
→ [submissions/self-audits/zhaog100-passport_ledger.md](./submissions/self-audits/zhaog100-passport_ledger.md)

**Related bounty:** #6460