### PR TITLE
fix: Update Easy Bounties link to use correct 'easy' label

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 [![Total Paid](https://img.shields.io/badge/Total%20Paid-22%2C756%20RTC-gold)](BOUNTY_LEDGER.md)
 
-[Browse All Bounties](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty) · [Easy Bounties](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · [Red Team](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Ared-team) · [**How to Submit →**](docs/HOW_TO_SUBMIT_A_BOUNTY.md) · [Payout Ledger](BOUNTY_LEDGER.md) · [What is RustChain?](https://github.com/Scottcjn/RustChain)
+[Browse All Bounties](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty) · [Easy Bounties](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Aeasy) · [Red Team](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Ared-team) · [**How to Submit →**](docs/HOW_TO_SUBMIT_A_BOUNTY.md) · [Payout Ledger](BOUNTY_LEDGER.md) · [What is RustChain?](https://github.com/Scottcjn/RustChain)
 
 </div>
 


### PR DESCRIPTION
## Summary

The "Easy Bounties" link in the README was pointing to the good first issue label, but the actual easy bounties use the asy label. This PR fixes the link to point to the correct label.

## Changes

- Updated the Easy Bounties URL from label:"good first issue" to label:easy
- This ensures users can find the actual easy bounties (like #1109, #2960, #1555, etc.)

## Why this matters

New contributors looking for easy bounties were being directed to the wrong label. The asy label has 20+ active bounties with clear instructions, while good first issue may not have the same selection.

**Wallet:** RTC24f319a3dc4ecda8927b59af074d05d8350159d0
**GitHub:** lwl2005