### PR TITLE
feat: add 3 hybrid haiku submissions (lwl2005)

### DIFF
--- a/submissions/haikus/lwl2005-1.txt
+++ b/submissions/haikus/lwl2005-1.txt
@@ -1,0 +1,7 @@
+Pentium Four hums
+Blue screen glows in the dark room
+Old coins slowly rise
+
+archetype: retro_x86
+hardware: Intel Pentium 4 630 3.0GHz HT (Prescott, 2005)
+wallet: RTC24f319a3dc4ecda8927b59af074d05d8350159d0

--- a/submissions/haikus/lwl2005-2.txt
+++ b/submissions/haikus/lwl2005-2.txt
@@ -1,0 +1,7 @@
+PowerPC wakes
+Fan spins stories of the past
+Gentle profits come
+
+archetype: vintage_powerpc
+hardware: Apple PowerBook G4 1.67GHz (7447A, 2005)
+wallet: RTC24f319a3dc4ecda8927b59af074d05d8350159d0

--- a/submissions/haikus/lwl2005-3.txt
+++ b/submissions/haikus/lwl2005-3.txt
@@ -1,0 +1,7 @@
+Small board works all night
+Pi mines coins while the world sleeps
+Tiny, yet it earns
+
+archetype: modern_arm
+hardware: Raspberry Pi 4 Model B 1.5GHz Cortex-A72 (Broadcom BCM2711)
+wallet: RTC24f319a3dc4ecda8927b59af074d05d8350159d0


### PR DESCRIPTION
## What
Add 3 hybrid haiku submissions per #2844:

1. **lwl2005-1** — etro_x86 (Intel Pentium 4 630 3.0GHz HT, Prescott 2005)
2. **lwl2005-2** — intage_powerpc (Apple PowerBook G4 1.67GHz, 7447A 2005)
3. **lwl2005-3** — modern_arm (Raspberry Pi 4 Model B 1.5GHz Cortex-A72)

All haiku follow 5-7-5 syllable structure with valid archetype enum and hardware fields.

## Checklist
- [x] Valid 5-7-5 syllable count
- [x] References real hardware (specific models)
- [x] Original work
- [x] archetype field present and valid
- [x] hardware field is concrete
- [x] wallet format correct (RTC + 40 hex chars)

Closes #2844

**Wallet:** `RTC24f319a3dc4ecda8927b59af074d05d8350159d0`
**GitHub:** lwl2005