### PR TITLE
Fix Beacon tutorial repository link

### DIFF
--- a/submissions/beacon-tutorial/beacon-2.6-heartbeat.md
+++ b/submissions/beacon-tutorial/beacon-2.6-heartbeat.md
@@ -71,7 +71,7 @@ Atlas is the spatial layer of the protocol. It organizes agents into "Virtual Ci
 Beacon 2.6 is more than just a library; it is the nervous system of the decentralized AI economy. By implementing heartbeats, managing Mayday signals, and utilizing Contracts, you ensure your agents are reliable, transparent, and capable of operating at scale.
 
 ### Resources
-- GitHub: https://github.com/rustchain/beacon-skill
+- GitHub: https://github.com/Scottcjn/beacon-skill
 - PyPI: pip install beacon-skill
 - NPM: npm install beacon-skill
 - Network: RustChain Mainnet


### PR DESCRIPTION
## Summary

- fixes the Beacon tutorial resource link from the missing `rustchain/beacon-skill` repository to `Scottcjn/beacon-skill`
- leaves the submitted tutorial content otherwise unchanged

## Verification

- `https://github.com/rustchain/beacon-skill` returns `404`
- `https://github.com/Scottcjn/beacon-skill` returns `200`
- `git diff --check`

Related bounty: Scottcjn/rustchain-bounties#2178
