### PR TITLE
Fix Prometheus bounty link

### DIFF
--- a/docs/PROMETHEUS_METRICS.md
+++ b/docs/PROMETHEUS_METRICS.md
@@ -2,7 +2,7 @@
 
 A standalone Prometheus exporter that polls your RustChain node's JSON APIs and re-exposes them as Prometheus-compatible metrics on `GET /metrics`.
 
-**Bounty:** [#765 — Prometheus Metrics Exporter — Observable RustChain](https://github.com/RustChainOrg/rustchain-bounties/issues/765)
+**Bounty:** [#765 — Prometheus Metrics Exporter — Observable RustChain](https://github.com/Scottcjn/rustchain-bounties/issues/765)
 
 ---
 


### PR DESCRIPTION
Summary:
- Update docs/PROMETHEUS_METRICS.md so the bounty #765 link points to the current Scottcjn/rustchain-bounties issue URL.
- Replace the stale RustChainOrg/rustchain-bounties namespace, which currently returns 404.

Validation:
- git diff --check
- git diff --cached --check
- curl old RustChainOrg URL -> 404
- curl replacement Scottcjn URL -> 200

RustChain bounty: Scottcjn/rustchain-bounties#2178