### PR TITLE
Fix formally verified wording in showcase

### DIFF
--- a/submissions/2958-elyanlabs-upstream-showcase/index.html
+++ b/submissions/2958-elyanlabs-upstream-showcase/index.html
@@ -135,7 +135,7 @@
           <h3>HACL*</h3>
           <span class="badge badge-merged">Merged</span>
         </div>
-        <p>Microsoft formal-verified crypto library — AltiVec fix bringing HACL* to vintage PowerPC platforms with hardware acceleration.</p>
+        <p>Microsoft formally verified crypto library — AltiVec fix bringing HACL* to vintage PowerPC platforms with hardware acceleration.</p>
         <a class="pr-link" href="https://github.com/project-everest/hacl-star/pull/1068" target="_blank">PR #1068 ↗</a>
         <div style="margin-top:0.75rem">
           <span class="tag">Cryptography</span><span class="tag">AltiVec</span><span class="tag">Formal Verification</span>


### PR DESCRIPTION
## Summary
- fix the HACL* showcase wording from "formal-verified" to "formally verified"
- keep the change scoped to submissions/2958-elyanlabs-upstream-showcase/index.html

## Validation
- git diff --check
- rg -n "formal-verified|formally verified|Microsoft|HACL" submissions/2958-elyanlabs-upstream-showcase/index.html

Bounty: Scottcjn/rustchain-bounties#2178