### PR TITLE
docs: fix RustChain capitalization in CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ Closes #<issue_number>
 
 ## 🎯 Good First Issues
 
-New to Rustchain? Start with issues labeled [`good first issue`](https://github.com/Scottcjn/Rustchain/labels/good%20first%20issue). These are specifically designed for newcomers.
+New to RustChain? Start with issues labeled [`good first issue`](https://github.com/Scottcjn/Rustchain/labels/good%20first%20issue). These are specifically designed for newcomers.
 
 ## ⚖️ Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Rustchain Bounties
+# Contributing to RustChain Bounties
 
-Thank you for your interest in contributing to Rustchain bounties! This guide explains how to participate in the bounty program, claim tasks, submit proofs, and earn RTC tokens.
+Thank you for your interest in contributing to RustChain bounties! This guide explains how to participate in the bounty program, claim tasks, submit proofs, and earn RTC tokens.
 
 ## 🚀 Quick Start
 
@@ -188,4 +188,4 @@ By contributing, you agree that your contributions will be licensed under the sa
 
 ---
 
-**Happy contributing! Every PR brings Rustchain closer to its vision.** 🦀⛓️
+**Happy contributing! Every PR brings RustChain closer to its vision.** 🦀⛓️


### PR DESCRIPTION
## Bounty Claim\n- Issue: https://github.com/Scottcjn/rustchain-bounties/issues/2178\n- Scope: docs typo/fix for brand consistency\n- Changes: 3-line capitalization fix in CONTRIBUTING.md\n\n### Validation\n- docs-only, minimal scope\n- only 3-line diff\n- commit: aeb7aeb\n- no code changes\n\n### Wallet\n- cashflow-demo-wallet