### PR TITLE
docs: fix dead awesome RustChain links

### DIFF
--- a/awesome-rustchain.md
+++ b/awesome-rustchain.md
@@ -9,14 +9,11 @@ A curated list of RustChain resources, tools, and community contributions.
 ## Tools and SDKs
 - [RustChain Python SDK](https://pypi.org/project/rustchain/) - pip install rustchain
 - [RustChain MCP Server](https://github.com/zhaog100/rustchain-mcp-server) - AI agent integration
-- [RustChain VS Code Extension](https://github.com/zhaog100/rustchain-vscode) - Wallet and miner dashboard
-- [RustChain GitHub Action](https://github.com/marketplace/actions/rustchain-rtc-reward) - Auto RTC rewards
-- [RustChain Telegram Bot](https://github.com/zhaog100/rustchain-tg-bot) - Balance and status checks
+- [RustChain Telegram Bot](https://github.com/Scottcjn/Rustchain/tree/main/telegram_bot) - Balance and status checks
 - [LangChain RustChain Tool](https://github.com/zhaog100/langchain-rustchain) - AI agent toolkit
 
 ## Mining
-- [RustChain Miner](https://github.com/Scottcjn/Rustchain/tree/main/miner) - Official miner
-- [Docker RustChain Miner](https://hub.docker.com/r/rustchain/miner) - One-command mining
+- [RustChain Miner](https://github.com/Scottcjn/Rustchain/tree/main/miners) - Official miner
 - [Mining Hardware Guide](https://github.com/Scottcjn/rustchain-bounties/issues/2870) - Hardware reports
 
 ## Security
@@ -27,7 +24,6 @@ A curated list of RustChain resources, tools, and community contributions.
 - [How AI Agents Earn Crypto on RustChain](https://dev.to/zhaog100) - Dev.to article
 
 ## Community
-- [Beacon Atlas](https://beacon.rustchain.io) - Identity registry
 - [AgentFolio](https://github.com/Scottcjn/beacon-skill) - Agent trust layer
 
 ---


### PR DESCRIPTION
## Summary
- remove stale Awesome RustChain entries whose public URLs now 404 or fail DNS
- update Telegram bot and miner links to verified paths in `Scottcjn/Rustchain`

## Verification
- confirmed old URLs fail:
  - `https://github.com/zhaog100/rustchain-vscode` -> 404
  - `https://github.com/marketplace/actions/rustchain-rtc-reward` -> 404
  - `https://github.com/zhaog100/rustchain-tg-bot` -> 404
  - `https://github.com/Scottcjn/Rustchain/tree/main/miner` -> 404
  - `https://hub.docker.com/r/rustchain/miner` -> 404
  - `https://beacon.rustchain.io` -> DNS resolution failure
- confirmed replacement URLs return 200:
  - `https://github.com/Scottcjn/Rustchain/tree/main/telegram_bot`
  - `https://github.com/Scottcjn/Rustchain/tree/main/miners`
- `git diff --check`

Bounty: Scottcjn/rustchain-bounties#444
Wallet: `RTC253255d034065a839cd421811ec589ae5b694ffc`