### PR TITLE
docs: fix RustChain miner link

### DIFF
--- a/awesome-rustchain.md
+++ b/awesome-rustchain.md
@@ -15,7 +15,7 @@ A curated list of RustChain resources, tools, and community contributions.
 - [LangChain RustChain Tool](https://github.com/zhaog100/langchain-rustchain) - AI agent toolkit
 
 ## Mining
-- [RustChain Miner](https://github.com/Scottcjn/Rustchain/tree/main/miner) - Official miner
+- [RustChain Miner](https://github.com/Scottcjn/Rustchain/tree/main/miners) - Official miner
 - [Docker RustChain Miner](https://hub.docker.com/r/rustchain/miner) - One-command mining
 - [Mining Hardware Guide](https://github.com/Scottcjn/rustchain-bounties/issues/2870) - Hardware reports
 


### PR DESCRIPTION
## Summary\n- Fixes the broken RustChain Miner link in wesome-rustchain.md from /tree/main/miner to /tree/main/miners.\n\n## Bounty\n- Related bounty: Scottcjn/rustchain-bounties#9018\n- RTC wallet: RTC253255d034065a839cd421811ec589ae5b694ffc\n\n## Validation\n- gh api repos/Scottcjn/Rustchain/contents/miner?ref=main --silent -> 404 / old link broken\n- gh api repos/Scottcjn/Rustchain/contents/miners?ref=main --silent -> resolves\n- git diff --check -- awesome-rustchain.md -> passed