### PR TITLE
docs: fix Show HN docs URL

### DIFF
--- a/marketing/show-hn-draft.md
+++ b/marketing/show-hn-draft.md
@@ -59,7 +59,7 @@ I'd love feedback on:
 
 Website: https://rustchain.org
 GitHub: https://github.com/Scottcjn/Rustchain
-Docs: https://docs.rustchain.org
+Docs: https://rustchain.org
 
 Happy to answer technical questions about the implementation, the hardware verification process, or why your old iMac might be worth mining with.
 


### PR DESCRIPTION
## Summary
- replace the stale `https://docs.rustchain.org` URL in the Show HN draft with the working `https://rustchain.org` site URL

## Bounty
- Scottcjn/rustchain-bounties#9018
- Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`

## Validation
- `https://docs.rustchain.org` -> DNS resolution failure
- `https://rustchain.org` -> HTTP 200
- `git diff --check -- marketing/show-hn-draft.md` -> passed
