### PR TITLE
docs: fix wRTC onboarding docs URL

### DIFF
--- a/docs/wrtc-onboarding/README.md
+++ b/docs/wrtc-onboarding/README.md
@@ -185,7 +185,7 @@ Future features will include:
 - **Website:** https://bottube.ai/bridge/wrtc
 - **Twitter/X:** https://x.com/RustchainPOA
 - **GitHub:** https://github.com/Scottcjn/rustchain-bounties
-- **Documentation:** https://docs.rustchain.org (coming soon)
+- **Documentation:** https://rustchain.org
 
 ### Community
 


### PR DESCRIPTION
## Summary
- replace the stale `https://docs.rustchain.org` URL in the wRTC onboarding guide with the working `https://rustchain.org` site URL

## Bounty
- Scottcjn/rustchain-bounties#9018
- Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`

## Validation
- `https://docs.rustchain.org` -> DNS resolution failure
- `https://rustchain.org` -> HTTP 200
- `git diff --check -- docs/wrtc-onboarding/README.md` -> passed
