### PR TITLE
docs: fix BCOS compare docs URL

### DIFF
--- a/bcos/compare.html
+++ b/bcos/compare.html
@@ -500,7 +500,7 @@
                 <p>Free forever. Open source. On-chain proof.</p>
                 <a href="https://rustchain.org/bcos/" class="cta-btn">Verify Your Repo →</a>
                 <br><br>
-                <a href="https://docs.rustchain.org/bcos/" class="cta-btn" style="border-color: var(--amber-dim); color: var(--amber-dim);">Documentation</a>
+                <a href="https://rustchain.org/bcos/" class="cta-btn" style="border-color: var(--amber-dim); color: var(--amber-dim);">Documentation</a>
             </div>
             <div class="cta-card">
                 <h3>// Nucleus Verify //</h3>
@@ -514,7 +514,7 @@
             <div class="footer-links">
                 <a href="https://rustchain.org/bcos/">BCOS Home</a>
                 <a href="https://rustchain.org/bcos/verify/">Verify Page</a>
-                <a href="https://docs.rustchain.org/bcos/">Docs</a>
+                <a href="https://rustchain.org/bcos/">Docs</a>
                 <a href="https://github.com/Scottcjn/rustchain-bounties">GitHub</a>
             </div>
             <div>RustChain BCOS v2 · Comparison generated for bounty #2294 · MIT License</div>


### PR DESCRIPTION
Fixes one broken link for Scottcjn/rustchain-bounties#9018.\n\nWallet: RTC253255d034065a839cd421811ec589ae5b694ffc\n\n## Summary\n- Replace the dead https://docs.rustchain.org/bcos/ links in cos/compare.html with the live https://rustchain.org/bcos/ page.\n\n## Validation\n- Old URL https://docs.rustchain.org/bcos/ fails DNS resolution.\n- New URL https://rustchain.org/bcos/ returns HTTP 200.\n- git diff --check -- bcos/compare.html passed.