### PR TITLE
docs: fix BCOS badge docs URL

### DIFF
--- a/bcos/badge-generator.html
+++ b/bcos/badge-generator.html
@@ -480,7 +480,7 @@
             <div class="footer-links">
                 <a href="https://rustchain.org/bcos/">BCOS Home</a>
                 <a href="https://rustchain.org/bcos/verify/">Verify Page</a>
-                <a href="https://docs.rustchain.org/bcos/">Docs</a>
+                <a href="https://rustchain.org/bcos/">Docs</a>
                 <a href="https://github.com/Scottcjn/rustchain-bounties">GitHub</a>
             </div>
             <div>RustChain BCOS Badge Generator · Bounty #2292 · MIT License</div>


### PR DESCRIPTION
Fixes one broken link for Scottcjn/rustchain-bounties#9018.

Wallet: RTC253255d034065a839cd421811ec589ae5b694ffc

## Summary
- Replace the dead `https://docs.rustchain.org/bcos/` docs link in `bcos/badge-generator.html` with the live `https://rustchain.org/bcos/` page.

## Validation
- Old URL `https://docs.rustchain.org/bcos/` fails DNS resolution.
- New URL `https://rustchain.org/bcos/` returns HTTP 200.
- `git diff --check -- bcos/badge-generator.html` passed.