### PR TITLE
Fix multiplier API docs link

### DIFF
--- a/submissions/multiplier-viz-2850/README.md
+++ b/submissions/multiplier-viz-2850/README.md
@@ -225,7 +225,7 @@ MIT License - See LICENSE file for details
 - Bounty Issue: #2850
 - Reward: 40 RTC
 - RustChain: https://rustchain.org
-- API Docs: https://rustchain.org/api
+- API status endpoint: https://rustchain.org/api/miners
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the broken bare API docs link in `submissions/multiplier-viz-2850/README.md`
- point readers to the live miner API status endpoint instead

## Bounty
- Scottcjn/rustchain-bounties#2178
- Wallet: RTC253255d034065a839cd421811ec589ae5b694ffc

## Validation
- `curl -I https://rustchain.org/api` returns `404 Not Found`
- `curl -I https://rustchain.org/api/miners` returns `200 OK`
- `git diff --check -- submissions/multiplier-viz-2850/README.md`