### PR TITLE
Clarify miner monitor API base URL

### DIFF
--- a/submissions/miner-monitor-2849/README.md
+++ b/submissions/miner-monitor-2849/README.md
@@ -70,7 +70,7 @@ python3 miner_monitor.py
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `api_url` | string | `https://rustchain.org/api` | RustChain API endpoint |
+| `api_url` | string | `https://rustchain.org/api` | RustChain API base URL; the monitor appends endpoint paths such as `/miners` |
 | `poll_interval` | int | `600` | How often to check miners (seconds) |
 | `offline_threshold` | int | `2` | Epochs before alerting (1 epoch = 10 min) |
 | `alert_cooldown` | int | `3600` | Min time between alerts (seconds) |


### PR DESCRIPTION
## Summary
- clarify that `api_url` is the RustChain API base URL, not a standalone browsable endpoint
- note that the monitor appends endpoint paths such as `/miners`

## Bounty
- Scottcjn/rustchain-bounties#2178
- Wallet: RTC253255d034065a839cd421811ec589ae5b694ffc

## Validation
- `curl -I https://rustchain.org/api` returns `404 Not Found`, so describing it as a direct endpoint is confusing
- `curl -I https://rustchain.org/api/miners` returns `200 OK`
- `git diff --check -- submissions/miner-monitor-2849/README.md`