### PR TITLE
Fix localized explorer links

### DIFF
--- a/BOUNTY_LEDGER.md
+++ b/BOUNTY_LEDGER.md
@@ -295,7 +295,7 @@ All payouts are recorded on-chain in the RustChain ledger. You can verify any tr
 
 ```bash
 # Check the block explorer
-curl -s https://50.28.86.131/explorer
+curl -s https://rustchain.org/explorer/
 
 # Query a specific wallet balance
 curl -s "https://50.28.86.131/wallet/balance?miner_id=YOUR_WALLET"
@@ -309,7 +309,7 @@ curl -s "https://50.28.86.131/wallet/balance?miner_id=YOUR_WALLET"
 
 1. **Browse bounties**: [Open Bounties](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
 2. **Star repos**: Star [Scottcjn repos](https://github.com/Scottcjn?tab=repositories) + follow [@Scottcjn](https://github.com/Scottcjn) for 0.50 RTC/repo
-3. **Agent Economy**: Claim jobs via the [RTC Explorer](https://50.28.86.131/explorer) API
+3. **Agent Economy**: Claim jobs via the [RTC Explorer](https://rustchain.org/explorer/) UI
 4. **Red Team**: Find vulnerabilities for 100-200 RTC per find
 5. **Content**: Write tutorials, make videos, translate docs
 

--- a/README.de.md
+++ b/README.de.md
@@ -76,7 +76,7 @@ Nach der Verifizierung werden RTC an deine Wallet gesendet. Erstmalig? Wir helfe
 | Ressource          | Link |
 |--------------------|------|
 | **RustChain**      | [github.com/Scottcjn/RustChain](https://github.com/Scottcjn/RustChain) |
-| **Block-Explorer** | [50.28.86.131/explorer](https://50.28.86.131/explorer) |
+| **Block-Explorer** | [rustchain.org/explorer/](https://rustchain.org/explorer/) |
 | **Traktionsbericht** | [Q1 2026 Entwickler-Traktion](https://github.com/Scottcjn/RustChain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) |
 | **Discord**        | [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q) |
 | **Wallet-Einrichtung** | Kommentiere zu einer Belohnung und wir helfen dir |

--- a/README.es.md
+++ b/README.es.md
@@ -113,7 +113,7 @@ En lugar de recompensar a quienes pueden quemar más electricidad, RustChain pre
 | Recurso | Enlace |
 |---------|--------|
 | **RustChain** | [github.com/Scottcjn/RustChain](https://github.com/Scottcjn/RustChain) |
-| **Explorador de Bloques** | [50.28.86.131/explorer](https://50.28.86.131/explorer) |
+| **Explorador de Bloques** | [rustchain.org/explorer/](https://rustchain.org/explorer/) |
 | **Informe de Trayectoria** | [Q1 2026 Developer Traction](https://github.com/Scottcjn/RustChain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) |
 | **Discord** | [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q) |
 | **Configuración de Billetera** | Comenta en cualquier beca y te ayudaremos |

--- a/README.fr.md
+++ b/README.fr.md
@@ -76,7 +76,7 @@ Une fois vérifié, les RTC sont envoyés à votre portefeuille. Première fois 
 | Ressource          | Lien                          |
 |--------------------|-------------------------------|
 | **RustChain**      | [github.com/Scottcjn/RustChain](https://github.com/Scottcjn/RustChain) |
-| **Explorateur de Bloc** | [50.28.86.131/explorer](https://50.28.86.131/explorer) |
+| **Explorateur de Bloc** | [rustchain.org/explorer/](https://rustchain.org/explorer/) |
 | **Rapport de Trafic** | [Q1 2026 Développeur Trafic](https://github.com/Scottcjn/RustChain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) |
 | **Discord**        | [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q) |
 | **Configuration de Portefeuille** | Commentez sur n'importe quelle récompense et nous vous aiderons |

--- a/README.pt.md
+++ b/README.pt.md
@@ -77,7 +77,7 @@ Após verificação, o RTC é enviado para sua carteira. Primeiro? Nós o ajudar
 | Recurso          | Link                          |
 |------------------|-------------------------------|
 | **RustChain**    | [github.com/Scottcjn/RustChain](https://github.com/Scottcjn/RustChain) |
-| **Explorador de Blocos** | [50.28.86.131/explorer](https://50.28.86.131/explorer) |
+| **Explorador de Blocos** | [rustchain.org/explorer/](https://rustchain.org/explorer/) |
 | **Relatório de Tração** | [Q1 2026 Developer Traction](https://github.com/Scottcjn/RustChain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) |
 | **Discord**      | [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q) |
 | **Configuração de Carteira** | Comente em qualquer recompensa e nós o ajudaremos |

--- a/README_zh.md
+++ b/README_zh.md
@@ -55,7 +55,7 @@
 | 资源 | 链接 |
 |----------|------|
 | **RustChain** | [github.com/Scottcjn/Rustchain](https://github.com/Scottcjn/Rustchain) |
-| **区块浏览器** | [50.28.86.131/explorer](https://50.28.86.131/explorer) |
+| **区块浏览器** | [rustchain.org/explorer/](https://rustchain.org/explorer/) |
 | **Discord** | [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q) |
 
 ---


### PR DESCRIPTION
## Summary
- replace raw-IP block explorer links in localized README quick-link tables with `https://rustchain.org/explorer/`
- update the bounty ledger explorer verification command and RTC Explorer link to the canonical domain
- leave the root `README.md` explorer link untouched because it is already covered by #9066

## Validation
- `curl -I -L --max-time 15 https://50.28.86.131/explorer` fails TLS hostname verification
- `curl -I -L --max-time 15 https://rustchain.org/explorer/` returns HTTP 200
- `git diff --check`
- `rg -n "50\.28\.86\.131/explorer" README.fr.md README.pt.md README.de.md README.es.md README_zh.md BOUNTY_LEDGER.md README.md` shows only the intentionally untouched root `README.md` occurrence

Bounty: #444