### PR TITLE
docs: fix HACL showcase links

### DIFF
--- a/bounties/elyanlabs-showcase/contributions.html
+++ b/bounties/elyanlabs-showcase/contributions.html
@@ -138,12 +138,12 @@
 
     <div class="card">
       <div class="card-header">
-        <a class="project-name" href="https://github.com/FStarLang/hacl-star" target="_blank" rel="noopener">HACL★ (Microsoft)</a>
+        <a class="project-name" href="https://github.com/hacl-star/hacl-star" target="_blank" rel="noopener">HACL★ (Microsoft)</a>
         <span class="stars">Formal Crypto</span>
       </div>
       <p class="impact">AltiVec SIMD fix in Microsoft's formally-verified cryptographic library. Corrected vectorized implementation ensuring provable security guarantees hold on PowerPC platforms, not just x86.</p>
       <div class="prs">
-        <a class="pr-link" href="https://github.com/FStarLang/hacl-star/pull/1068" target="_blank" rel="noopener">#1068</a>
+        <a class="pr-link" href="https://github.com/hacl-star/hacl-star/pull/1068" target="_blank" rel="noopener">#1068</a>
         <span class="status-merged">✓ Merged</span>
         <span class="domain-tag">🔐 Formal Verification</span>
       </div>


### PR DESCRIPTION
## Summary
- update the HACL project link in `bounties/elyanlabs-showcase/contributions.html` from the moved `FStarLang/hacl-star` repo to `hacl-star/hacl-star`
- update the related PR #1068 link to the live HACL repository URL

## Validation
- `curl -L -I https://github.com/FStarLang/hacl-star` -> HTTP 404
- `curl -L -I https://github.com/FStarLang/hacl-star/pull/1068` -> HTTP 404
- `curl -L -I https://github.com/hacl-star/hacl-star` -> HTTP 200
- `curl -L -I https://github.com/hacl-star/hacl-star/pull/1068` -> HTTP 200
- `rg -n "FStarLang/hacl-star|hacl-star/hacl-star" bounties/elyanlabs-showcase/contributions.html`
- `git diff --check`

## Bounty
- Source: Scottcjn/rustchain-bounties#9018
- Expected payout: 3 RTC if accepted
- RTC receive address: `RTC991843db74121688c427d42ad7799a21e9d8adc2`
- Remaining blocker: maintainer review, merge, and bounty acceptance
