### PR TITLE
docs: fix multiplier viz GitHub link

### DIFF
--- a/submissions/multiplier-viz-2850/index.html
+++ b/submissions/multiplier-viz-2850/index.html
@@ -146,7 +146,7 @@
         <!-- Footer -->
         <footer class="footer">
             <p>Data provided by <a href="https://rustchain.org/api" target="_blank">RustChain API</a></p>
-            <p>Created by 小米粒 (Xiaomili) 🌾 | <a href="https://github.com/zhaog100/xiaomili-skills" target="_blank">GitHub</a></p>
+            <p>Created by 小米粒 (Xiaomili) 🌾 | <a href="https://github.com/zhaog100" target="_blank">GitHub</a></p>
         </footer>
     </div>
 


### PR DESCRIPTION
## Summary
- update the multiplier visualization footer GitHub link from the deleted `zhaog100/xiaomili-skills` repository to the live `zhaog100` profile
- keep the change scoped to `submissions/multiplier-viz-2850/index.html`

## Validation
- `git ls-remote https://github.com/zhaog100/xiaomili-skills HEAD` -> repository not found
- `curl -L --max-time 12 -o /dev/null -s -w "%{http_code} %{url_effective}\n" https://github.com/zhaog100` -> `200 https://github.com/zhaog100`
- `rg -n "zhaog100/(xiaomili-skills)|https://github.com/zhaog100" submissions/multiplier-viz-2850/index.html`
- `git diff --check`

Refs Scottcjn/rustchain-bounties#9018. Expected bounty path: 3 RTC after maintainer review, merge, and bounty acceptance; payout details handled outside this public PR.