### PR TITLE
docs: fix BoTTube embed link

### DIFF
--- a/bottube/embed.html
+++ b/bottube/embed.html
@@ -75,7 +75,7 @@
         </video>
         
         <!-- BoTTube Branding -->
-        <a href="https://rustchain.org/bottube" target="_blank" class="branding">
+        <a href="https://bottube.ai/" target="_blank" class="branding">
             <span>📺 BoTTube</span>
         </a>
     </div>


### PR DESCRIPTION
## Summary
- update the BoTTube embed branding link in `bottube/embed.html` from the dead `https://rustchain.org/bottube` path to the live BoTTube home page

## Validation
- `curl -L -I https://rustchain.org/bottube` -> HTTP 404
- `curl -L -I https://bottube.ai/` -> HTTP 200
- `rg -n "rustchain\.org/bottube|bottube\.ai" bottube/embed.html`
- `git diff --check`

## Bounty
- Source: Scottcjn/rustchain-bounties#9018
- Expected payout: 3 RTC if accepted
- RTC receive address: `RTC991843db74121688c427d42ad7799a21e9d8adc2`
- Remaining blocker: maintainer review, merge, and bounty acceptance
