### PR TITLE
docs: fix multiplier viz API link

### DIFF
--- a/submissions/multiplier-viz-2850/index.html
+++ b/submissions/multiplier-viz-2850/index.html
@@ -145,7 +145,7 @@
 
         <!-- Footer -->
         <footer class="footer">
-            <p>Data provided by <a href="https://rustchain.org/api" target="_blank">RustChain API</a></p>
+            <p>Data provided by <a href="https://rustchain.org/api/miners" target="_blank">RustChain API</a></p>
             <p>Created by 小米粒 (Xiaomili) 🌾 | <a href="https://github.com/zhaog100/xiaomili-skills" target="_blank">GitHub</a></p>
         </footer>
     </div>


### PR DESCRIPTION
## Summary
- update the multiplier visualization footer API link from the dead `https://rustchain.org/api` URL to the live `https://rustchain.org/api/miners` endpoint
- keep the change scoped to `submissions/multiplier-viz-2850/index.html`

## Validation
- `curl -L --max-time 12 -o /dev/null -s -w "%{http_code} %{url_effective}\n" https://rustchain.org/api` -> `404 https://rustchain.org/api`
- `curl -L --max-time 12 -o /dev/null -s -w "%{http_code} %{url_effective}\n" https://rustchain.org/api/miners` -> `200 https://rustchain.org/api/miners`
- `rg -n "https://rustchain\.org/api(\b|/miners)" submissions/multiplier-viz-2850/index.html`
- `git diff --check`

Refs Scottcjn/rustchain-bounties#9018. Expected bounty path: 3 RTC after maintainer review, merge, and bounty acceptance; payout details handled outside this public PR.