### PR TITLE
docs: fix mobile wallet API base URL

### DIFF
--- a/docs/api/mobile-wallet-api.md
+++ b/docs/api/mobile-wallet-api.md
@@ -5,7 +5,7 @@
 This API provides endpoints for interacting with a mobile wallet, enabling users to check balances, sign transactions, and view transaction history.
 
 ## Base URL
-`https://api.rustchain-bounties.com/v1`
+`https://rustchain.org`
 
 ## Authentication
 All endpoints require a valid JWT token in the `Authorization` header:


### PR DESCRIPTION
## Summary
- replace the non-resolving mobile wallet API base URL with the live RustChain host
- keep the change scoped to `docs/api/mobile-wallet-api.md`

## Validation
- `curl -L --max-time 12 -o /dev/null -s -w "%{http_code} %{url_effective}\n" https://api.rustchain-bounties.com/v1` -> `000 https://api.rustchain-bounties.com/v1`
- `curl -L --max-time 12 -o /dev/null -s -w "%{http_code} %{url_effective}\n" https://rustchain.org` -> `200 https://rustchain.org/`
- `curl -L --max-time 12 -o /dev/null -s -w "%{http_code} %{url_effective}\n" "https://rustchain.org/wallet/balance?miner_id=YOUR_MINER_ID"` -> `200 https://rustchain.org/wallet/balance?miner_id=YOUR_MINER_ID`
- `rg -n "api\.rustchain-bounties\.com|https://rustchain\.org" docs/api/mobile-wallet-api.md`
- `git diff --check`

Refs Scottcjn/rustchain-bounties#9018. Expected bounty path: 3 RTC after maintainer review, merge, and bounty acceptance; payout details handled outside this public PR.