### PR TITLE
fix: verify TLS in ops scripts

### DIFF
--- a/scripts/node_miner_weekly_scan.py
+++ b/scripts/node_miner_weekly_scan.py
@@ -65,7 +65,7 @@ def _request_json(
     url: str,
     timeout_s: int = DEFAULT_TIMEOUT_SECONDS,
     headers: Optional[Dict[str, str]] = None,
-    verify_tls: bool = False,
+    verify_tls: bool = True,
 ) -> Tuple[Optional[Any], Optional[str]]:
     req = urllib.request.Request(url)
     req.add_header("Accept", "application/json")
@@ -74,9 +74,7 @@ def _request_json(
         if v:
             req.add_header(k, v)
 
-    context = None
-    if url.startswith("https://") and not verify_tls:
-        context = ssl._create_unverified_context()
+    context = ssl.create_default_context() if url.startswith("https://") else None
 
     try:
         with urllib.request.urlopen(req, timeout=timeout_s, context=context) as resp:
@@ -100,7 +98,7 @@ def fetch_json(
     path: str,
     timeout_s: int = DEFAULT_TIMEOUT_SECONDS,
     headers: Optional[Dict[str, str]] = None,
-    verify_tls: bool = False,
+    verify_tls: bool = True,
 ) -> Tuple[Optional[Any], Optional[str]]:
     url = f"{base_url.rstrip('/')}{path}"
     return _request_json(url, timeout_s=timeout_s, headers=headers, verify_tls=verify_tls)
@@ -560,7 +558,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--verify-tls",
         action="store_true",
-        help="Verify TLS certs (off by default because official node uses self-signed TLS)",
+        help="Deprecated compatibility flag. TLS certificates are always verified.",
     )
     p.add_argument(
         "--admin-key",
@@ -569,6 +567,7 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument("--out-json", default="", help="Write machine-readable JSON report to this path")
     p.add_argument("--out-md", default="", help="Write markdown report to this path")
+    p.set_defaults(verify_tls=True)
     return p.parse_args()
 
 

--- a/scripts/prometheus_exporter.py
+++ b/scripts/prometheus_exporter.py
@@ -53,12 +53,10 @@ LATENCY_BUCKETS = (0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0)
 def _request_json(
     url: str,
     timeout_s: int = DEFAULT_POLL_TIMEOUT,
-    verify_tls: bool = False,
+    verify_tls: bool = True,
 ) -> Tuple[Optional[Any], Optional[str], float]:
     """Fetch JSON from *url*.  Returns (data, error_string, elapsed_seconds)."""
-    ctx = None
-    if url.startswith("https://") and not verify_tls:
-        ctx = ssl._create_unverified_context()
+    ctx = ssl.create_default_context() if url.startswith("https://") else None
 
     req = urllib.request.Request(url)
     req.add_header("Accept", "application/json")
@@ -87,7 +85,7 @@ def fetch_endpoint(
     base_url: str,
     path: str,
     timeout_s: int = DEFAULT_POLL_TIMEOUT,
-    verify_tls: bool = False,
+    verify_tls: bool = True,
 ) -> Tuple[Optional[Any], Optional[str], float]:
     """Fetch a RustChain API endpoint.  Thin wrapper around _request_json."""
     url = f"{base_url.rstrip('/')}{path}"
@@ -98,7 +96,7 @@ def fetch_wallet_balance(
     base_url: str,
     miner_id: str,
     timeout_s: int = DEFAULT_POLL_TIMEOUT,
-    verify_tls: bool = False,
+    verify_tls: bool = True,
 ) -> Tuple[Optional[Dict[str, Any]], Optional[str], float]:
     """Fetch balance for a single wallet."""
     encoded = urllib.parse.quote(miner_id, safe="")
@@ -127,7 +125,7 @@ class RustChainCollector:
         self,
         node_url: str = DEFAULT_NODE_URL,
         poll_timeout: int = DEFAULT_POLL_TIMEOUT,
-        verify_tls: bool = False,
+        verify_tls: bool = True,
         tracked_wallets: Optional[List[str]] = None,
     ) -> None:
         self.node_url = node_url.rstrip("/")
@@ -428,7 +426,7 @@ def parse_args(argv: Optional[list] = None) -> argparse.Namespace:
     p.add_argument(
         "--verify-tls",
         action="store_true",
-        help="Verify TLS certificates (off by default — official node uses self-signed TLS)",
+        help="Deprecated compatibility flag. TLS certificates are always verified.",
     )
     p.add_argument(
         "--log-level",
@@ -436,6 +434,7 @@ def parse_args(argv: Optional[list] = None) -> argparse.Namespace:
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         help="Logging level",
     )
+    p.set_defaults(verify_tls=True)
     return p.parse_args(argv)
 
 

--- a/scripts/sophia_scheduler.py
+++ b/scripts/sophia_scheduler.py
@@ -111,10 +111,11 @@ def fetch_node_json(
     base_url: str,
     path: str,
     timeout: int = 15,
+    verify_tls: bool = True,
 ) -> Optional[Any]:
     """Fetch JSON from the RustChain node API."""
     url = f"{base_url.rstrip('/')}{path}"
-    ctx = ssl._create_unverified_context() if url.startswith("https://") else None
+    ctx = ssl.create_default_context() if url.startswith("https://") else None
 
     req = urllib.request.Request(url)
     req.add_header("Accept", "application/json")
@@ -128,9 +129,9 @@ def fetch_node_json(
         return None
 
 
-def fetch_active_miners(node_url: str) -> List[Dict[str, Any]]:
+def fetch_active_miners(node_url: str, verify_tls: bool = True) -> List[Dict[str, Any]]:
     """Fetch the list of active miners from the node."""
-    data = fetch_node_json(node_url, "/api/miners")
+    data = fetch_node_json(node_url, "/api/miners", verify_tls=verify_tls)
     if isinstance(data, list):
         return data
     if isinstance(data, dict) and "miners" in data:
@@ -139,9 +140,9 @@ def fetch_active_miners(node_url: str) -> List[Dict[str, Any]]:
     return []
 
 
-def fetch_epoch(node_url: str) -> Optional[int]:
+def fetch_epoch(node_url: str, verify_tls: bool = True) -> Optional[int]:
     """Fetch the current epoch number."""
-    data = fetch_node_json(node_url, "/epoch")
+    data = fetch_node_json(node_url, "/epoch", verify_tls=verify_tls)
     if isinstance(data, dict):
         return data.get("epoch")
     return None
@@ -207,6 +208,7 @@ def batch_inspect(
     sophia_url: str,
     delay: float = DEFAULT_DELAY,
     skip_recent: bool = True,
+    verify_tls: bool = True,
 ) -> Dict[str, Any]:
     """Inspect all active miners in a batch.
 
@@ -222,11 +224,11 @@ def batch_inspect(
     logger.info("Starting batch inspection...")
 
     # Fetch current epoch
-    epoch = fetch_epoch(node_url)
+    epoch = fetch_epoch(node_url, verify_tls=verify_tls)
     logger.info("Current epoch: %s", epoch)
 
     # Fetch all active miners
-    miners = fetch_active_miners(node_url)
+    miners = fetch_active_miners(node_url, verify_tls=verify_tls)
     logger.info("Found %d active miners", len(miners))
 
     if not miners:
@@ -296,6 +298,7 @@ def run_daemon(
     sophia_url: str,
     interval: int = DEFAULT_INTERVAL,
     delay: float = DEFAULT_DELAY,
+    verify_tls: bool = True,
 ) -> None:
     """Run the scheduler as a daemon, performing batch inspections periodically."""
     lock = SchedulerLock()
@@ -310,7 +313,7 @@ def run_daemon(
             try:
                 results = batch_inspect(
                     node_url, sophia_url,
-                    delay=delay, skip_recent=True,
+                    delay=delay, skip_recent=True, verify_tls=verify_tls,
                 )
                 logger.info("Batch result: %s", json.dumps(results, indent=2))
             except Exception as e:

--- a/tests/test_tls_verification_defaults.py
+++ b/tests/test_tls_verification_defaults.py
@@ -1,0 +1,71 @@
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "scripts")
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import node_miner_weekly_scan as weekly_scan
+import prometheus_exporter
+import sophia_scheduler
+
+
+def _json_response(payload):
+    response = MagicMock()
+    response.read.return_value = json.dumps(payload).encode("utf-8")
+    response.__enter__ = MagicMock(return_value=response)
+    response.__exit__ = MagicMock(return_value=False)
+    return response
+
+
+def test_prometheus_exporter_verifies_tls_by_default():
+    default_ctx = object()
+    with patch("prometheus_exporter.ssl.create_default_context", return_value=default_ctx) as create_ctx, \
+         patch("prometheus_exporter.ssl._create_unverified_context") as insecure_ctx, \
+         patch("prometheus_exporter.urllib.request.urlopen", return_value=_json_response({"ok": True})) as urlopen:
+        data, err, _elapsed = prometheus_exporter._request_json("https://example.test/health")
+
+    assert data == {"ok": True}
+    assert err is None
+    create_ctx.assert_called_once_with()
+    insecure_ctx.assert_not_called()
+    assert urlopen.call_args.kwargs["context"] is default_ctx
+
+
+def test_weekly_scan_verifies_tls_by_default():
+    default_ctx = object()
+    with patch("node_miner_weekly_scan.ssl.create_default_context", return_value=default_ctx) as create_ctx, \
+         patch("node_miner_weekly_scan.ssl._create_unverified_context") as insecure_ctx, \
+         patch("node_miner_weekly_scan.urllib.request.urlopen", return_value=_json_response({"ok": True})) as urlopen:
+        data, err = weekly_scan._request_json("https://example.test/health")
+
+    assert data == {"ok": True}
+    assert err is None
+    create_ctx.assert_called_once_with()
+    insecure_ctx.assert_not_called()
+    assert urlopen.call_args.kwargs["context"] is default_ctx
+
+
+def test_sophia_scheduler_verifies_tls_by_default():
+    default_ctx = object()
+    with patch("sophia_scheduler.ssl.create_default_context", return_value=default_ctx) as create_ctx, \
+         patch("sophia_scheduler.ssl._create_unverified_context") as insecure_ctx, \
+         patch("sophia_scheduler.urllib.request.urlopen", return_value=_json_response({"epoch": 1})) as urlopen:
+        data = sophia_scheduler.fetch_node_json("https://example.test", "/epoch")
+
+    assert data == {"epoch": 1}
+    create_ctx.assert_called_once_with()
+    insecure_ctx.assert_not_called()
+    assert urlopen.call_args.kwargs["context"] is default_ctx
+
+
+def test_cli_verify_tls_flags_remain_accepted():
+    assert prometheus_exporter.parse_args([]).verify_tls is True
+    assert prometheus_exporter.parse_args(["--verify-tls"]).verify_tls is True
+    with patch.object(sys, "argv", ["node_miner_weekly_scan.py"]):
+        assert weekly_scan.parse_args().verify_tls is True
+    with patch.object(sys, "argv", ["node_miner_weekly_scan.py", "--verify-tls"]):
+        assert weekly_scan.parse_args().verify_tls is True


### PR DESCRIPTION
## Summary
- replace unverified TLS contexts in the Sophia scheduler, Prometheus exporter, and weekly node/miner scan helpers with `ssl.create_default_context()` for HTTPS requests
- keep existing `--verify-tls` compatibility flags accepted while making verification the default behavior
- add focused regression tests that assert the HTTPS helpers use verified default contexts and do not call `_create_unverified_context()`

Closes #9068

## Validation
- `python -m pytest tests\test_tls_verification_defaults.py tests\test_prometheus_exporter.py -q` -> 20 passed
- `python -m py_compile scripts\sophia_scheduler.py scripts\prometheus_exporter.py scripts\node_miner_weekly_scan.py tests\test_tls_verification_defaults.py`
- `git diff --check`
- `rg -n "_create_unverified_context|insecure-tls|off by default" scripts\sophia_scheduler.py scripts\prometheus_exporter.py scripts\node_miner_weekly_scan.py tests\test_tls_verification_defaults.py` -> no script-side insecure TLS references remain

Wallet/miner ID for 10 RTC bounty credit: `RTC253255d034065a839cd421811ec589ae5b694ffc`
