### PR TITLE
Fix SECURITY.md conflict markers

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 | Version | Supported          |
 | ------- | ------------------ |
 | latest  | :white_check_mark: |
-| < latest | :x:               |
+| &lt; latest | :x:               |
 
 ## Reporting a Vulnerability
 
@@ -71,10 +71,7 @@ The following are in scope for security reports:
 
 ## Disclosure Policy
 
-<<<<<<< HEAD
 We follow a 90-day coordinated disclosure policy. After a fix is deployed, we will publish a security advisory crediting the reporter.
-=======
-
 
 ## Payment-Authority Impersonation
 
@@ -104,4 +101,3 @@ A legitimate RustChain bounty payout notice includes the amount, recipient walle
 3. Screenshot the impersonating comment — it may later be edited or deleted.
 
 No retaliation against good-faith reporters. See Safe Harbor above.
->>>>>>> 7a8dbb2 (docs(security): add Payment-Authority Impersonation appendix)


### PR DESCRIPTION
## Summary

Fixes the unresolved merge conflict markers in `SECURITY.md` and preserves both intended sections:

- the 90-day disclosure policy sentence
- the Payment-Authority Impersonation contributor-protection appendix

Also escapes the `< latest` supported-version table cell as `&lt; latest` so Markdown renders it as literal text rather than interpreting it as an HTML tag.

## Validation

- Confirmed `SECURITY.md` currently contains `<<<<<<<`, `=======`, and `>>>>>>>` merge conflict markers.
- Confirmed this PR changes only `SECURITY.md`.
- Verified the updated text has no conflict markers.
- Verified the supported-version row uses `&lt; latest`.

Bounty reference: Scottcjn/rustchain-bounties#444

Payout wallet: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`
