### PR TITLE
docs: fix broken wallet link in applicant guide

### DIFF
--- a/GIG_APPLICANTS.md
+++ b/GIG_APPLICANTS.md
@@ -57,7 +57,7 @@ Expected delivery: <date or "PR linked below">
 ## Wallets & payouts
 
 - You don't need to set up a wallet before claiming. Your GitHub handle works as a wallet identifier by default.
-- If you want a specific RTC address (RTC + 40-char hex), generate one via [rustchain-wallet](https://github.com/Scottcjn/rustchain-wallet) or just tell us the string you want in your first claim.
+- If you want a specific RTC address (RTC + 40-char hex), generate one via the [`clawrtc`](https://pypi.org/project/clawrtc/) wallet CLI or just tell us the string you want in your first claim.
 - Payouts land within 24h of a maintainer confirming the deliverable. Same-day in most cases.
 - Track your balance: `curl https://rustchain.org/wallet/balance?miner=<your_wallet>`
 


### PR DESCRIPTION
## Summary
- Replaces a broken `rustchain-wallet` GitHub link in `GIG_APPLICANTS.md`
- Points contributors to the published `clawrtc` wallet CLI instead

## Verification
- `https://github.com/Scottcjn/rustchain-wallet` returns 404
- `https://pypi.org/project/clawrtc/` returns 200
- `git diff --check` passes

## Bounty
For Scottcjn/rustchain-bounties#444.

RTC wallet: `RTC10abd00d5739e910c0eb93cc3ab7cc9cdcc23cf5`
