### PR TITLE
docs: remove dead ugig link

### DIFF
--- a/GIG_APPLICANTS.md
+++ b/GIG_APPLICANTS.md
@@ -1,6 +1,6 @@
 # Welcome, ugig Applicants
 
-If you found us through a [ugig](https://ugig.io) posting for **RustChain Open Bounties** or any similar Elyan Labs gig — read this first.
+If you found us through a ugig posting for **RustChain Open Bounties** or any similar Elyan Labs gig — read this first.
 
 ## Two things you need to know
 


### PR DESCRIPTION
## Summary
- Removes the dead `https://ugig.io` hyperlink from `GIG_APPLICANTS.md`
- Keeps the text reference while avoiding a link that fails DNS resolution

## Verification
- `https://ugig.io` fails with DNS resolution error
- `git diff --check` passes

## Bounty
For Scottcjn/rustchain-bounties#444.

RTC wallet: `RTC10abd00d5739e910c0eb93cc3ab7cc9cdcc23cf5`
