### PR TITLE
docs: remove dead BCOS scan node URL example

### DIFF
--- a/.github/actions/bcos-scan/README.md
+++ b/.github/actions/bcos-scan/README.md
@@ -18,7 +18,6 @@ jobs:
         with:
           tier: L1
           reviewer: octocat
-          node-url: https://bcos.rustchain.org
           pr-number: ${{ github.event.pull_request.number }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
## Summary

- Remove the dead `https://bcos.rustchain.org` `node-url` override from the BCOS scan action README example.
- Let the example use the action's documented default `node-url` instead of pointing contributors at a non-resolving host.

## Validation

- `curl -L --max-time 12 --connect-timeout 6 https://bcos.rustchain.org` fails with DNS resolution error.
- `gh api repos/Scottcjn/rustchain-bounties/compare/main...galanime:codex/fix-bcos-scan-dead-node-url` shows a single-file, one-line docs-only change.
- Focused README check confirms `bcos.rustchain.org` is no longer present while the documented `node-url` input remains.

RTC wallet: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`
