### PR TITLE
docs: fix OpenAPI server host

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://opensource.org/licenses/MIT
 
 servers:
-  - url: https://50.28.86.131
+  - url: https://rustchain.org
     description: Production node
 
 paths:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -13,10 +13,8 @@ info:
     url: https://opensource.org/licenses/MIT
 
 servers:
-  - url: https://api.rustchain.org/v1
-    description: Production server
-  - url: https://testnet-api.rustchain.org/v1
-    description: Testnet server
+  - url: https://50.28.86.131
+    description: Production node
 
 paths:
   /health:


### PR DESCRIPTION
## Bounty Submission

**Bounty**: Closes #9018

**RTC Wallet**: RTC74b80ab40602e5ae31819912b2fca974484e5dab

## Changes

- Updated `docs/openapi.yaml` to use the documented live RustChain node `https://50.28.86.131` as the OpenAPI server.
- Removed the two non-resolving OpenAPI server hosts from this spec:
  - `https://api.rustchain.org/v1`
  - `https://testnet-api.rustchain.org/v1`

## Testing

- [x] `ruby -e 'require "yaml"; YAML.load_file("docs/openapi.yaml")'`
- [x] `git diff --check -- docs/openapi.yaml`
- [x] Manual link checks:
  - `curl -k -L -I --max-time 10 --connect-timeout 5 https://api.rustchain.org/v1` -> DNS resolution failure
  - `curl -k -L -I --max-time 10 --connect-timeout 5 https://testnet-api.rustchain.org/v1` -> DNS resolution failure
  - `curl -k -L -I --max-time 10 --connect-timeout 5 https://50.28.86.131/health` -> HTTP 200

## Evidence

- The repository's own submission guide says the real RustChain node lives at `https://50.28.86.131` and warns against made-up API hosts.
- Before: OpenAPI clients generated from `docs/openapi.yaml` would point at DNS-dead server URLs.
- After: OpenAPI clients default to the reachable documented production node.

## Quality Gate Self-Score (0-5)

| Dimension | Score | Notes |
|---|---:|---|
| Impact | 3 | Prevents clients generated from the public OpenAPI spec from using dead hosts. |
| Correctness | 5 | Uses the repo-documented live node and validates old/new URLs. |
| Evidence | 5 | Includes DNS failure checks, live-node check, YAML parse, and diff check. |
| Craft | 5 | Single-file, minimal docs-only change. |

## Checklist

- [x] All acceptance criteria from the bounty issue are met
- [x] Code is tested
- [x] No secrets or credentials committed
- [x] Submission does not match any global disqualifier
