### PR TITLE
docs: fix miner notifications documentation link

### DIFF
--- a/miner-notifications/README.md
+++ b/miner-notifications/README.md
@@ -327,7 +327,7 @@ MIT License - See LICENSE file for details
 
 - **Issues**: https://github.com/Scottcjn/rustchain-bounties/issues
 - **Discord**: https://discord.gg/VqVVS2CW9Q
-- **Documentation**: https://rustchain.org/docs
+- **Documentation**: https://github.com/Scottcjn/rustchain-bounties/tree/main/docs
 
 ## Bounty Information
 


### PR DESCRIPTION
## Bounty Submission

**Bounty**: Closes #9018

**RTC Wallet**: RTC74b80ab40602e5ae31819912b2fca974484e5dab

## Changes

- Updated the `miner-notifications/README.md` Support documentation link.
- Replaced `https://rustchain.org/docs`, which currently returns HTTP 403, with the live repository docs directory on GitHub.

## Testing

- [x] `git diff --check -- miner-notifications/README.md`
- [x] Manual link checks:
  - `curl -L -I --max-time 10 --connect-timeout 5 https://rustchain.org/docs` -> HTTP 403
  - `curl -L -I --max-time 10 --connect-timeout 5 https://github.com/Scottcjn/rustchain-bounties/tree/main/docs` -> HTTP 200
- [x] Final newline preserved (`tail -c 1 miner-notifications/README.md | od -An -tx1` -> `0a`)

## Evidence

- Before: Support docs link points to a forbidden page.
- After: Support docs link points to the repository's accessible docs directory.

## Quality Gate Self-Score (0-5)

| Dimension | Score | Notes |
|---|---:|---|
| Impact | 2 | Keeps support documentation reachable from the miner notifications README. |
| Correctness | 5 | Replaces a 403 link with an accessible repository docs link. |
| Evidence | 5 | Includes old/new HTTP checks and diff check. |
| Craft | 5 | Single-file, one-line docs-only fix. |

## Checklist

- [x] All acceptance criteria from the bounty issue are met
- [x] Code is tested
- [x] No secrets or credentials committed
- [x] Submission does not match any global disqualifier
