### PR TITLE
docs: replace stale explorer links with live endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Once verified, RTC is sent to your wallet. First time? We will help you set one 
 | Resource | Link |
 |----------|------|
 | **RustChain** | [github.com/Scottcjn/RustChain](https://github.com/Scottcjn/RustChain) |
-| **Block Explorer** | [50.28.86.131/explorer](https://50.28.86.131/explorer) |
+| **Block Explorer** | [rustchain.org/explorer](https://rustchain.org/explorer) |
 | **Traction Report** | [Q1 2026 Developer Traction](https://github.com/Scottcjn/RustChain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) |
 | **Discord** | [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q) |
 | **Wallet Setup** | Comment on any bounty and we will help |

--- a/STAR_FUNNEL_EXPLAINER.md
+++ b/STAR_FUNNEL_EXPLAINER.md
@@ -162,6 +162,6 @@ Every star is a person who walked through the door. What they do after that is u
 
 *Elyan Labs — Every CPU Has a Voice*
 
-*Explorer: https://50.28.86.131/explorer*
+*Explorer: https://explorer.rustchain.org*
 *Bounties: https://github.com/Scottcjn/rustchain-bounties*
 *Stats generated: March 6, 2026*


### PR DESCRIPTION
/closes #2178

## Summary
Fix two stale explorer links in docs:

- `README.md`: replace dead `https://50.28.86.131/explorer` with `https://rustchain.org/explorer`
- `STAR_FUNNEL_EXPLAINER.md`: replace stale `https://50.28.86.131/explorer` with `https://explorer.rustchain.org`

## Validation
- `curl -L` check confirms old URL is unreachable (`000`)
- `curl -L` check confirms new URLs return `200`
- `git diff --check` passes

This is a docs-only, low-risk fix.
