### PR TITLE
feat: RTC Telegram Bot — read-only RustChain query bot (#2869)

### DIFF
--- a/rtc-telegram-bot/README.md
+++ b/rtc-telegram-bot/README.md
@@ -1,0 +1,97 @@
+# RustChain Telegram Bot
+
+A **read-only** Telegram bot that queries the RustChain blockchain API.
+No transfer, no wallet private keys, no sending functionality — purely informational.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/balance <wallet>` | Query a wallet's RTC balance |
+| `/epoch` | Current epoch information |
+| `/miners` | Miner status overview |
+| `/price` | RTC price info |
+| `/help` | Show help message |
+
+## Prerequisites
+
+- Python 3.10+
+- A Telegram Bot Token (from [@BotFather](https://t.me/BotFather))
+
+## Quick Start
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/legendhy/rustchain-bounties.git
+cd rustchain-bounties/rtc-telegram-bot
+
+# 2. Install dependencies
+pip install -r requirements.txt
+
+# 3. Set your bot token
+export RTC_BOT_TOKEN="your-telegram-bot-token"
+
+# 4. Run the bot
+python bot.py
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `RTC_BOT_TOKEN` | *(required)* | Telegram Bot API token |
+| `RTC_API_BASE` | `https://rustchain.org` | RustChain API base URL |
+| `RTC_API_TIMEOUT` | `10` | API request timeout in seconds |
+
+## Deployment (systemd)
+
+Create `/etc/systemd/system/rtc-telegram-bot.service`:
+
+```ini
+[Unit]
+Description=RustChain Telegram Bot
+After=network.target
+
+[Service]
+Type=simple
+User=rtcbot
+WorkingDirectory=/opt/rtc-telegram-bot
+ExecStart=/usr/bin/python3 bot.py
+Environment=RTC_BOT_TOKEN=your-token-here
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable --now rtc-telegram-bot
+```
+
+## Deployment (Docker)
+
+```dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY bot.py .
+CMD ["python", "bot.py"]
+```
+
+```bash
+docker build -t rtc-telegram-bot .
+docker run -d --name rtc-bot -e RTC_BOT_TOKEN=your-token rtc-telegram-bot
+```
+
+## Security
+
+This bot is **strictly read-only**. It only performs GET requests to the RustChain API.
+- ❌ No wallet private keys
+- ❌ No transfer/send functionality
+- ❌ No write operations of any kind
+
+## License
+
+MIT

--- a/rtc-telegram-bot/bot.py
+++ b/rtc-telegram-bot/bot.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+RustChain Telegram Bot — READ-ONLY query bot for RustChain blockchain data.
+No transfer/send functionality. Query-only.
+
+Commands:
+    /balance <wallet>  — Query wallet RTC balance
+    /epoch             — Query current epoch info
+    /miners            — Query miner status
+    /price             — Query RTC price
+    /help              — Show help message
+"""
+
+import json
+import logging
+import os
+import urllib.request
+import urllib.error
+
+from telegram import Update
+from telegram.ext import Application, CommandHandler, ContextTypes
+
+# ── Configuration ──────────────────────────────────────────────────────────
+BOT_TOKEN = os.environ.get("RTC_BOT_TOKEN", "")
+API_BASE = os.environ.get("RTC_API_BASE", "https://rustchain.org")
+TIMEOUT = int(os.environ.get("RTC_API_TIMEOUT", "10"))
+
+# ── Logging ────────────────────────────────────────────────────────────────
+logging.basicConfig(
+    format="%(asctime)s [%(levelname)s] %(message)s", level=logging.INFO
+)
+logger = logging.getLogger(__name__)
+
+# ── API helper (GET only, read-only) ──────────────────────────────────────
+
+def _api_get(path: str, params: dict | None = None) -> dict | list | None:
+    """Perform a read-only GET request to the RustChain API."""
+    url = f"{API_BASE}{path}"
+    if params:
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        url = f"{url}?{qs}"
+    logger.info("GET %s", url)
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        logger.error("HTTP %s for %s", exc.code, url)
+        return None
+    except Exception as exc:
+        logger.error("Request error: %s", exc)
+        return None
+
+
+# ── Command handlers ──────────────────────────────────────────────────────
+
+async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Show available commands."""
+    text = (
+        "⛓ *RustChain Query Bot* ⛓\n"
+        "_Read-only — no transfers, no keys needed._\n\n"
+        "Commands:\n"
+        "/balance <wallet> — Query wallet RTC balance\n"
+        "/epoch — Current epoch information\n"
+        "/miners — Miner status overview\n"
+        "/price — RTC price info\n"
+        "/help — This message\n"
+    )
+    await update.message.reply_text(text, parse_mode="Markdown")
+
+
+async def balance_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Query a wallet's RTC balance."""
+    if not context.args:
+        await update.message.reply_text(
+            "Usage: /balance <wallet_id>\nExample: /balance bai-su"
+        )
+        return
+
+    wallet = " ".join(context.args).strip()
+    data = _api_get("/wallet/balance", {"miner_id": wallet})
+    if data is None:
+        await update.message.reply_text(f"❌ Could not fetch balance for `{wallet}`.")
+        return
+
+    amount = data.get("amount_rtc", "N/A")
+    await update.message.reply_text(
+        f"💰 Wallet: `{wallet}`\n💎 Balance: *{amount} RTC*",
+        parse_mode="Markdown",
+    )
+
+
+async def epoch_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Query current epoch information."""
+    data = _api_get("/epoch")
+    if data is None:
+        await update.message.reply_text("❌ Could not fetch epoch info.")
+        return
+
+    text = (
+        f"📊 *Epoch Info*\n"
+        f"• Epoch: *{data.get('epoch', 'N/A')}*\n"
+        f"• Slot: {data.get('slot', 'N/A')}\n"
+        f"• Blocks per Epoch: {data.get('blocks_per_epoch', 'N/A')}\n"
+        f"• Enrolled Miners: {data.get('enrolled_miners', 'N/A')}\n"
+        f"• Epoch Pot: {data.get('epoch_pot', 'N/A')} RTC\n"
+        f"• Total Supply: {data.get('total_supply_rtc', 'N/A')} RTC"
+    )
+    await update.message.reply_text(text, parse_mode="Markdown")
+
+
+async def miners_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Query miner status overview."""
+    data = _api_get("/miners")
+    if data is None:
+        await update.message.reply_text(
+            "❌ Could not fetch miner data. The endpoint may be temporarily unavailable."
+        )
+        return
+
+    if isinstance(data, list):
+        text = f"⛏ *Miners ({len(data)} total)*\n"
+        for m in data[:20]:
+            mid = m.get("miner_id", "?")
+            bal = m.get("balance_rtc", m.get("amount_rtc", "?"))
+            status = m.get("status", "?")
+            text += f"• {mid} — {bal} RTC [{status}]\n"
+        if len(data) > 20:
+            text += f"_…and {len(data) - 20} more_"
+    else:
+        text = f"⛏ *Miners*\n{json.dumps(data, indent=2)[:4000]}"
+    await update.message.reply_text(text, parse_mode="Markdown")
+
+
+async def price_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Query RTC price information."""
+    data = _api_get("/price")
+    if data is None:
+        await update.message.reply_text(
+            "❌ Could not fetch price info. The endpoint may be temporarily unavailable."
+        )
+        return
+
+    text = f"💲 *RTC Price*\n{json.dumps(data, indent=2)[:4000]}"
+    await update.message.reply_text(text, parse_mode="Markdown")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    if not BOT_TOKEN:
+        raise SystemExit("Error: RTC_BOT_TOKEN env var is required.")
+    app = Application.builder().token(BOT_TOKEN).build()
+    app.add_handler(CommandHandler("start", help_cmd))
+    app.add_handler(CommandHandler("help", help_cmd))
+    app.add_handler(CommandHandler("balance", balance_cmd))
+    app.add_handler(CommandHandler("epoch", epoch_cmd))
+    app.add_handler(CommandHandler("miners", miners_cmd))
+    app.add_handler(CommandHandler("price", price_cmd))
+    logger.info("RustChain Telegram Bot starting…")
+    app.run_polling(allowed_updates=Update.ALL_TYPES)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtc-telegram-bot/requirements.txt
+++ b/rtc-telegram-bot/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot>=20.0,<22.0


### PR DESCRIPTION
## RTC Telegram Bot — Read-Only RustChain Query Bot

Closes #2869

### Features (all read-only)
- `/balance <wallet>` — Query wallet RTC balance via `GET /wallet/balance`
- `/epoch` — Current epoch info via `GET /epoch`
- `/miners` — Miner status via `GET /miners`
- `/price` — RTC price via `GET /price`
- `/help` — Help message

### Security
- ❌ No transfers, no sends, no write operations
- ✅ Only GET requests to RustChain API
- ✅ No wallet private keys handled

### Files
- `rtc-telegram-bot/bot.py` — Main bot using python-telegram-bot
- `rtc-telegram-bot/requirements.txt` — Dependencies
- `rtc-telegram-bot/README.md` — Deployment docs (pip, systemd, Docker)

### Wallet for bounty
`bai-su`

### Tested
- `/epoch` API confirmed working
- `/balance` API confirmed working
- `/miners` and `/price` endpoints included with graceful fallback for 404