### PR TITLE
feat: RTC Balance Query GitHub Action (#2864)

### DIFF
--- a/rtc-github-action/.gitignore
+++ b/rtc-github-action/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/rtc-github-action/README.md
+++ b/rtc-github-action/README.md
@@ -1,0 +1,72 @@
+# RTC Balance Query — GitHub Action
+
+> **Read-only** GitHub Action that queries RustChain (RTC) wallet balance and posts the result as a PR comment.  
+> ⛔ **No transfer / send functionality.** This action will never move funds.
+
+## Features
+
+- 🔍 Queries wallet balance via RustChain API (`GET /wallet/balance?miner_id=WALLET`)
+- 💬 Posts a formatted comment on the PR with balance info
+- 📁 Reads wallet address from action input, `.rtc-wallet` file, or PR body
+- 🏷️ Supports **dry-run** mode (log only, no comment)
+- ⚙️ Fully configurable via `action.yml` inputs/outputs
+
+## Usage
+
+```yaml
+name: RTC Balance Check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  check-balance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Query RTC Balance
+        uses: legendhy/rustchain-bounties/rtc-github-action@main
+        with:
+          wallet-address: ''           # Optional: override auto-detection
+          query-amount: '20'           # Informational display amount
+          api-base-url: 'https://rustchain.org'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: 'false'             # Set true to skip posting comment
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `wallet-address` | Wallet to query (overrides auto-detection) | No | `''` |
+| `query-amount` | Informational RTC amount to display | No | `'20'` |
+| `api-base-url` | RustChain API base URL | No | `'https://rustchain.org'` |
+| `github-token` | Token for posting PR comments | Yes | — |
+| `dry-run` | Log results without posting comment | No | `'false'` |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `balance` | Wallet balance from RustChain API |
+| `wallet-address` | The wallet address that was queried |
+| `status` | `success` or `error` |
+
+## Wallet Address Resolution (priority order)
+
+1. **`wallet-address` input** — explicit parameter
+2. **`.rtc-wallet` file** — single-line file in repo root
+3. **PR body** — line matching `RTC Wallet: <address>` or `Wallet: <address>`
+
+## Security
+
+This action is **strictly read-only**. It:
+- ✅ Only calls `GET /wallet/balance`
+- ❌ Never calls any wallet/send/transfer API
+- ❌ Never possesses private keys or seed phrases
+
+## License
+
+MIT

--- a/rtc-github-action/action.yml
+++ b/rtc-github-action/action.yml
@@ -1,0 +1,40 @@
+name: 'RTC Balance Query'
+description: 'Query RustChain (RTC) wallet balance information from PR context. Read-only — no transfer/send functionality.'
+author: 'legendhy'
+
+inputs:
+  wallet-address:
+    description: 'RustChain wallet address to query (overrides PR body / .rtc-wallet file)'
+    required: false
+    default: ''
+  query-amount:
+    description: 'Expected RTC amount to display in the comment (informational only)'
+    required: false
+    default: '20'
+  api-base-url:
+    description: 'RustChain API base URL'
+    required: false
+    default: 'https://rustchain.org'
+  github-token:
+    description: 'GitHub token for posting PR comments'
+    required: true
+  dry-run:
+    description: 'If true, only log results without posting a PR comment'
+    required: false
+    default: 'false'
+
+outputs:
+  balance:
+    description: 'The wallet balance retrieved from RustChain API'
+  wallet-address:
+    description: 'The wallet address that was queried'
+  status:
+    description: 'Query status: success or error'
+
+runs:
+  using: 'node20'
+  main: 'index.js'
+
+branding:
+  icon: 'search'
+  color: 'green'

--- a/rtc-github-action/index.js
+++ b/rtc-github-action/index.js
@@ -1,0 +1,162 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const http = require('http');
+
+/**
+ * Resolve the wallet address from (in priority order):
+ *   1. action input `wallet-address`
+ *   2. `.rtc-wallet` file in the repo root
+ *   3. PR body — looks for "RTC Wallet:" or "Wallet:" line
+ */
+function resolveWalletAddress(inputWallet) {
+  // 1. Explicit input
+  if (inputWallet && inputWallet.trim().length > 0) {
+    core.info(`Wallet resolved from action input: ${inputWallet.trim()}`);
+    return inputWallet.trim();
+  }
+
+  // 2. .rtc-wallet file
+  const walletFile = path.join(process.env.GITHUB_WORKSPACE || '.', '.rtc-wallet');
+  if (fs.existsSync(walletFile)) {
+    const content = fs.readFileSync(walletFile, 'utf8').trim();
+    if (content.length > 0) {
+      core.info(`Wallet resolved from .rtc-wallet file: ${content}`);
+      return content;
+    }
+  }
+
+  // 3. PR body
+  const prBody = github.context.payload?.pull_request?.body || '';
+  const walletMatch = prBody.match(/(?:RTC\s*)?Wallet\s*:\s*([A-Za-z0-9]+)/i);
+  if (walletMatch && walletMatch[1]) {
+    core.info(`Wallet resolved from PR body: ${walletMatch[1]}`);
+    return walletMatch[1];
+  }
+
+  return null;
+}
+
+/**
+ * Perform a GET request (no external deps).
+ */
+function httpGet(url) {
+  return new Promise((resolve, reject) => {
+    const mod = url.startsWith('https') ? https : http;
+    mod.get(url, { timeout: 15000 }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        resolve({ statusCode: res.statusCode, body: data });
+      });
+    }).on('error', reject);
+  });
+}
+
+/**
+ * Query RustChain wallet balance (READ-ONLY).
+ * GET {apiBase}/wallet/balance?miner_id={wallet}
+ */
+async function queryBalance(apiBase, walletAddress) {
+  const url = `${apiBase.replace(/\/+$/, '')}/wallet/balance?miner_id=${encodeURIComponent(walletAddress)}`;
+  core.info(`Querying balance at: ${url}`);
+
+  try {
+    const response = await httpGet(url);
+    if (response.statusCode === 200) {
+      const body = JSON.parse(response.body);
+      return {
+        success: true,
+        balance: body.balance ?? body.Balance ?? body.amount ?? JSON.stringify(body),
+        raw: body,
+      };
+    }
+    core.warning(`Balance query returned status ${response.statusCode}: ${response.body}`);
+    return { success: false, balance: 'N/A', raw: response.body };
+  } catch (err) {
+    core.warning(`Balance query failed: ${err.message}`);
+    return { success: false, balance: 'N/A', raw: err.message };
+  }
+}
+
+/**
+ * Post a comment on the PR (unless dry-run).
+ */
+async function postComment(octokit, owner, repo, prNumber, body) {
+  await octokit.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+}
+
+/**
+ * Build the markdown comment body.
+ */
+function buildComment(walletAddress, balanceResult, queryAmount) {
+  const statusIcon = balanceResult.success ? '✅' : '⚠️';
+  const balance = balanceResult.balance;
+  const timestamp = new Date().toISOString();
+
+  let comment = `## ${statusIcon} RTC Balance Query\n\n`;
+  comment += `| Field | Value |\n`;
+  comment += `|---|---|\n`;
+  comment += `| **Wallet** | \`${walletAddress}\` |\n`;
+  comment += `| **Balance** | ${balance} RTC |\n`;
+  comment += `| **Query Amount** | ${queryAmount} RTC (informational) |\n`;
+  comment += `| **Queried at** | ${timestamp} |\n\n`;
+  comment += `> **Note:** This action performs **read-only** queries. No transfers or sends are executed.\n`;
+
+  return comment;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                               */
+/* ------------------------------------------------------------------ */
+async function run() {
+  try {
+    const inputWallet   = core.getInput('wallet-address');
+    const queryAmount   = core.getInput('query-amount') || '20';
+    const apiBase       = core.getInput('api-base-url') || 'https://rustchain.org';
+    const token         = core.getInput('github-token');
+    const dryRun        = core.getInput('dry-run') === 'true';
+
+    // Resolve wallet address
+    const walletAddress = resolveWalletAddress(inputWallet);
+    if (!walletAddress) {
+      core.setFailed(
+        'Could not resolve wallet address. Provide it via `wallet-address` input, `.rtc-wallet` file, or PR body.'
+      );
+      return;
+    }
+
+    core.setOutput('wallet-address', walletAddress);
+
+    // Query balance (read-only)
+    const balanceResult = await queryBalance(apiBase, walletAddress);
+    core.setOutput('balance', balanceResult.balance);
+    core.setOutput('status', balanceResult.success ? 'success' : 'error');
+
+    core.info(`Wallet: ${walletAddress}`);
+    core.info(`Balance: ${balanceResult.balance}`);
+
+    // Post comment unless dry-run
+    const pr = github.context.payload?.pull_request;
+    if (!dryRun && pr && token) {
+      const octokit = github.getOctokit(token);
+      const { owner, repo } = github.context.repo;
+      const prNumber = pr.number;
+
+      const commentBody = buildComment(walletAddress, balanceResult, queryAmount);
+      await postComment(octokit, owner, repo, prNumber, commentBody);
+      core.info(`Comment posted on PR #${prNumber}`);
+    } else if (dryRun) {
+      core.info('Dry-run mode — skipping PR comment.');
+      core.info('Would have posted:\n' + buildComment(walletAddress, balanceResult, queryAmount));
+    } else {
+      core.info('Not in a PR context or no token — skipping comment.');
+    }
+  } catch (error) {
+    core.setFailed(`Action failed: ${error.message}`);
+  }
+}
+
+run();

--- a/rtc-github-action/package.json
+++ b/rtc-github-action/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rtc-github-action",
+  "version": "1.0.0",
+  "description": "GitHub Action to query RustChain (RTC) wallet balance — read-only, no transfers.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests yet\" && exit 0"
+  },
+  "keywords": ["github-action", "rustchain", "rtc", "balance-query", "read-only"],
+  "author": "legendhy",
+  "license": "MIT",
+  "dependencies": {
+    "@actions/core": "^1.10.1",
+    "@actions/github": "^6.0.0"
+  }
+}


### PR DESCRIPTION
## RTC Balance Query GitHub Action

Closes #2864 — Create GitHub Action to auto-query RTC info (20 RTC bounty)

### Features (all read-only)
- **Configurable inputs**: wallet-address, query-amount, api-base-url, github-token, dry-run
- **Wallet resolution**: reads from action input, `.rtc-wallet` file, or PR body
- **Balance query**: GET `https://rustchain.org/wallet/balance?miner_id=WALLET` (read-only)
- **PR comment**: posts formatted balance info as a PR comment
- **Dry-run mode**: log results without posting comments
- **action.yml**: full inputs/outputs definition

### Security
⛔ **Zero transfer/send functionality** — this action only performs GET requests to query balance.

### Files
- `rtc-github-action/action.yml` — action metadata with inputs/outputs
- `rtc-github-action/index.js` — main logic (Node.js 20)
- `rtc-github-action/package.json` — dependencies (@actions/core, @actions/github)
- `rtc-github-action/README.md` — usage docs

### Wallet
`bai-su`

### Testing
Can be tested with `dry-run: true` to verify wallet resolution and API query without posting comments.