### PR TITLE
Add tests for bounty verification claim parsing

### DIFF
--- a/scripts/verify_bounties.py
+++ b/scripts/verify_bounties.py
@@ -14,6 +14,8 @@ Checks:
 Posts a verification comment on the bounty issue with results.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import json
@@ -239,7 +241,11 @@ def update_comment(comment_id: int, body: str) -> bool:
 # Patterns people use to claim bounties
 # We look for GitHub usernames in comments that aren't from bots or the owner
 GITHUB_USERNAME_RE = re.compile(r"@([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})")
-WALLET_RE = re.compile(r"(RTC[a-f0-9]{40}|[a-z0-9_-]{3,40})", re.IGNORECASE)
+RTC_WALLET_RE = re.compile(r"(RTC[a-f0-9]{40})", re.IGNORECASE)
+GENERIC_WALLET_RE = re.compile(
+    r"(?:wallet|address)\s*[:=]?\s*([a-z0-9_-]{3,40})",
+    re.IGNORECASE,
+)
 
 
 def extract_claimants(comments: list[dict], issue_number: int) -> list[dict]:
@@ -273,7 +279,7 @@ def extract_claimants(comments: list[dict], issue_number: int) -> list[dict]:
         seen.add(user.lower())
 
         # Try to extract a wallet address from the comment
-        wallet_match = WALLET_RE.search(body)
+        wallet_match = RTC_WALLET_RE.search(body) or GENERIC_WALLET_RE.search(body)
         wallet = wallet_match.group(1) if wallet_match else ""
 
         claimants.append({

--- a/scripts/verify_bounties.py
+++ b/scripts/verify_bounties.py
@@ -243,7 +243,7 @@ def update_comment(comment_id: int, body: str) -> bool:
 GITHUB_USERNAME_RE = re.compile(r"@([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})")
 RTC_WALLET_RE = re.compile(r"(RTC[a-f0-9]{40})", re.IGNORECASE)
 GENERIC_WALLET_RE = re.compile(
-    r"(?:wallet|address)\s*[:=]?\s*([a-z0-9_-]{3,40})",
+    r"(?:wallet\s+address|wallet|address)\s*[:=]?\s*([a-z0-9_-]{3,80})",
     re.IGNORECASE,
 )
 

--- a/tests/test_verify_bounties.py
+++ b/tests/test_verify_bounties.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+def load_verify_bounties():
+    os.environ.setdefault("GITHUB_TOKEN", "dummy-token-for-tests")
+    requests_stub = types.SimpleNamespace(
+        Session=lambda: types.SimpleNamespace(headers={}, get=None, post=None, patch=None)
+    )
+    sys.modules.setdefault("requests", requests_stub)
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "verify_bounties.py"
+    spec = importlib.util.spec_from_file_location("verify_bounties", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestVerifyBounties(unittest.TestCase):
+    def test_extract_claimants_skips_bot_owner_empty_and_dedupes_users(self):
+        mod = load_verify_bounties()
+        comments = [
+            {
+                "id": 1,
+                "user": {"login": "alice"},
+                "body": "Claiming this one for wallet RTCabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+            },
+            {
+                "id": 2,
+                "user": {"login": "Alice"},
+                "body": "Duplicate claim should not create another claimant",
+            },
+            {
+                "id": 3,
+                "user": {"login": mod.OWNER},
+                "body": "Maintainer note",
+            },
+            {
+                "id": 4,
+                "user": {"login": "verify-bot"},
+                "body": f"{mod.BOT_SIGNATURE}\nExisting report",
+            },
+            {
+                "id": 5,
+                "user": {"login": "empty"},
+                "body": "   ",
+            },
+            {
+                "id": 6,
+                "user": {"login": "bob"},
+                "body": "I can verify this manually.",
+            },
+        ]
+
+        claimants = mod.extract_claimants(comments, issue_number=1589)
+
+        self.assertEqual([c["username"] for c in claimants], ["alice", "bob"])
+        self.assertEqual(claimants[0]["comment_id"], 1)
+        self.assertTrue(claimants[0]["wallet"].startswith("RTCabcdef"))
+        self.assertEqual(claimants[1]["comment_id"], 6)
+        self.assertEqual(claimants[1]["wallet"], "")
+
+    def test_find_existing_bot_comment_returns_first_signature_match(self):
+        mod = load_verify_bounties()
+        comments = [
+            {"id": 10, "body": "Regular comment"},
+            {"id": 11, "body": f"Report\n{mod.BOT_SIGNATURE}"},
+            {"id": 12, "body": f"Newer report\n{mod.BOT_SIGNATURE}"},
+        ]
+
+        self.assertEqual(mod.find_existing_bot_comment(comments), 11)
+        self.assertIsNone(mod.find_existing_bot_comment([{"id": 13, "body": "none"}]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_bounties.py
+++ b/tests/test_verify_bounties.py
@@ -76,6 +76,29 @@ class TestVerifyBounties(unittest.TestCase):
         self.assertEqual(mod.find_existing_bot_comment(comments), 11)
         self.assertIsNone(mod.find_existing_bot_comment([{"id": 13, "body": "none"}]))
 
+    def test_extract_claimants_handles_wallet_address_phrase(self):
+        mod = load_verify_bounties()
+        comments = [
+            {
+                "id": 20,
+                "user": {"login": "alice"},
+                "body": "Wallet address: bai-su",
+            },
+            {
+                "id": 21,
+                "user": {"login": "bob"},
+                "body": "Wallet address: 6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2",
+            },
+        ]
+
+        claimants = mod.extract_claimants(comments, issue_number=1589)
+
+        self.assertEqual(claimants[0]["wallet"], "bai-su")
+        self.assertEqual(
+            claimants[1]["wallet"],
+            "6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add tests for verify_bounties.extract_claimants and find_existing_bot_comment
- prefer RTC wallet matches before generic wallet/address hints so claim text does not capture ordinary words as wallets
- add future annotations so the script imports cleanly on Python 3.9 while keeping its existing type hints

## Bounty
- Targets #1589, 2 RTC per accepted test file

## Tests
- python3 -m unittest discover -s tests -p test_verify_bounties.py
- /tmp/rustchain-bounties-pytest-venv/bin/python -m pytest tests/test_verify_bounties.py -q
- python3 -m py_compile scripts/verify_bounties.py tests/test_verify_bounties.py
- git diff --check

## Payout
- RTC Wallet / miner_id: `zhoueu-star-mac`