### PR TITLE
Fix markdown emphasis around funnel links

### DIFF
--- a/STAR_FUNNEL_EXPLAINER.md
+++ b/STAR_FUNNEL_EXPLAINER.md
@@ -162,6 +162,6 @@ Every star is a person who walked through the door. What they do after that is u
 
 *Elyan Labs — Every CPU Has a Voice*
 
-*Explorer: https://50.28.86.131/explorer*
-*Bounties: https://github.com/Scottcjn/rustchain-bounties*
+*Explorer:* https://50.28.86.131/explorer
+*Bounties:* https://github.com/Scottcjn/rustchain-bounties
 *Stats generated: March 6, 2026*


### PR DESCRIPTION
Fixes malformed emphasis around two footer links in STAR_FUNNEL_EXPLAINER.md.\n\nThe previous text put the closing emphasis marker after the URL, which can make markdown parsers include the trailing asterisk as part of the autolink. This keeps the label emphasized and leaves the URL clean.\n\nRelated: #444