### PR TITLE
docs: fix rustchain-wallet -> clawrtc-rs link in GIG_APPLICANTS.md

### DIFF
--- a/GIG_APPLICANTS.md
+++ b/GIG_APPLICANTS.md
@@ -57,7 +57,7 @@ Expected delivery: <date or "PR linked below">
 ## Wallets & payouts
 
 - You don't need to set up a wallet before claiming. Your GitHub handle works as a wallet identifier by default.
-- If you want a specific RTC address (RTC + 40-char hex), generate one via [rustchain-wallet](https://github.com/Scottcjn/rustchain-wallet) or just tell us the string you want in your first claim.
+- If you want a specific RTC address (RTC + 40-char hex), generate one via [clawrtc-rs](https://github.com/Scottcjn/clawrtc-rs) or just tell us the string you want in your first claim.
 - Payouts land within 24h of a maintainer confirming the deliverable. Same-day in most cases.
 - Track your balance: `curl https://rustchain.org/wallet/balance?miner=<your_wallet>`
 


### PR DESCRIPTION
## Summary

Fixed broken link in `GIG_APPLICANTS.md` line 60:
- **Old (404):** https://github.com/Scottcjn/rustchain-wallet
- **New (200):** https://github.com/Scottcjn/clawrtc-rs

Verification:
```
curl -L --max-time 10 -s -o /dev/null -w "%{http_code}" https://github.com/Scottcjn/rustchain-wallet -> 404
curl -L --max-time 10 -s -o /dev/null -w "%{http_code}" https://github.com/Scottcjn/clawrtc-rs -> 200
```

Bounty: #9018 (May Flowers campaign, 3 RTC)

**Wallet:** `RTC0185366b31bef08729a93115dacb1fd540bb4350`
