### PR TITLE
docs: remove SECURITY.md conflict markers

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,10 +71,7 @@ The following are in scope for security reports:
 
 ## Disclosure Policy
 
-<<<<<<< HEAD
 We follow a 90-day coordinated disclosure policy. After a fix is deployed, we will publish a security advisory crediting the reporter.
-=======
-
 
 ## Payment-Authority Impersonation
 
@@ -104,4 +101,3 @@ A legitimate RustChain bounty payout notice includes the amount, recipient walle
 3. Screenshot the impersonating comment — it may later be edited or deleted.
 
 No retaliation against good-faith reporters. See Safe Harbor above.
->>>>>>> 7a8dbb2 (docs(security): add Payment-Authority Impersonation appendix)


### PR DESCRIPTION
## Summary
- Removes leftover Git merge conflict markers from `SECURITY.md`.
- Keeps both intended pieces of content: the 90-day disclosure policy and the Payment-Authority Impersonation appendix.

## Verification
- Confirmed no remaining conflict marker lines with:
  `grep -nE '^(<<<<<<<|=======|>>>>>>>)' SECURITY.md`

Bounty: Scottcjn/rustchain-bounties#444
