### PR TITLE
docs: add quick reference table to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,3 +189,16 @@ By contributing, you agree that your contributions will be licensed under the sa
 ---
 
 **Happy contributing! Every PR brings Rustchain closer to its vision.** 🦀⛓️
+
+---
+
+## Quick Reference
+
+| Task | Command |
+|------|--------|
+| Fork repo | Click Fork on GitHub |
+| Create branch | git checkout -b my-fix |
+| Push changes | git push origin my-fix |
+| Open PR | Use GitHub PR UI against main |
+| Check balance | curl -k https://50.28.86.131/balance/WALLET_ID |
+| Explorer | https://explorer.rustchain.org/ |


### PR DESCRIPTION
Closes #2178

Small documentation improvement: added a Quick Reference table to CONTRIBUTING.md with common commands for contributors.

| Task | Command |
|------|--------|
| Fork repo | Click Fork on GitHub |
| Create branch | `git checkout -b my-fix` |
| Push changes | `git push origin my-fix` |
| Open PR | Use GitHub PR UI against `main` |
| Check balance | `curl -k https://50.28.86.131/balance/WALLET_ID` |
| Explorer | https://explorer.rustchain.org/ |

1 file changed, 14 insertions.

GitHub: @zp6
Wallet: zp6