### PR TITLE
docs: fix wallet balance miner parameter

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -59,7 +59,7 @@ RustChain is a working blockchain where vintage and exotic hardware (Amiga, Powe
 
 - Node health: `https://rustchain.org/health` — returns `{"ok": true}` + version + uptime.
 - Explorer: `https://explorer.rustchain.org`.
-- Wallet balance: `GET https://rustchain.org/wallet/balance?miner=<handle>`.
+- Wallet balance: `GET https://rustchain.org/wallet/balance?miner_id=<handle>`.
 - Miners API: `GET https://rustchain.org/api/miners`.
 - Current epoch: `GET https://rustchain.org/epoch`.
 


### PR DESCRIPTION
## Summary
- Update `llms.txt` wallet balance endpoint example from `miner=` to `miner_id=`.

## Evidence
- `https://rustchain.org/wallet/balance?miner=iamdinhthuan` -> HTTP 400, `miner_id or address required`
- `https://rustchain.org/wallet/balance?miner_id=iamdinhthuan` -> HTTP 200

## Bounty
- Bounty #2178 docs fix
- Wallet/miner ID: iamdinhthuan