### PR TITLE
docs: fix GIG_APPLICANTS wallet balance parameter

### DIFF
--- a/GIG_APPLICANTS.md
+++ b/GIG_APPLICANTS.md
@@ -59,7 +59,7 @@ Expected delivery: <date or "PR linked below">
 - You don't need to set up a wallet before claiming. Your GitHub handle works as a wallet identifier by default.
 - If you want a specific RTC address (RTC + 40-char hex), generate one via [rustchain-wallet](https://github.com/Scottcjn/rustchain-wallet) or just tell us the string you want in your first claim.
 - Payouts land within 24h of a maintainer confirming the deliverable. Same-day in most cases.
-- Track your balance: `curl https://rustchain.org/wallet/balance?miner=<your_wallet>`
+- Track your balance: `curl https://rustchain.org/wallet/balance?miner_id=<your_wallet>`
 
 ## Questions
 


### PR DESCRIPTION
## Summary
- Update `GIG_APPLICANTS.md` wallet balance command from `miner=` to `miner_id=`.

## Verification
- `https://rustchain.org/wallet/balance?miner=iamdinhthuan` -> 400, `{"error":"miner_id or address required","ok":false}`
- `https://rustchain.org/wallet/balance?miner_id=iamdinhthuan` -> 200, response includes `"miner_id":"iamdinhthuan"`
- `git diff --check -- GIG_APPLICANTS.md` -> passed

## Bounty
- Bounty #2178 docs fix
- Wallet/miner ID: iamdinhthuan