### PR TITLE
docs: fix agent wallet balance parameter

### DIFF
--- a/agent.json
+++ b/agent.json
@@ -25,7 +25,7 @@
     "api_endpoints": {
       "list_bounties": "https://api.github.com/repos/Scottcjn/rustchain-bounties/issues?state=open&labels=bounty",
       "submit_claim": "POST issue comment with wallet + intent",
-      "check_balance": "https://rustchain.org/wallet/balance?miner=<handle>",
+      "check_balance": "https://rustchain.org/wallet/balance?miner_id=<handle>",
       "node_health": "https://rustchain.org/health"
     },
     "notable_autonomous_contributors": [


### PR DESCRIPTION
## Summary
- update `agent.json` check_balance endpoint from `miner=` to `miner_id=`
- align agent metadata with the live RustChain wallet balance API and the other updated docs

## Verification
- `jq . agent.json`
- `git diff --check -- agent.json`
- `curl -sk -o /tmp/rustchain-old-agent-wallet.json -w "%{http_code}" "https://rustchain.org/wallet/balance?miner=iamdinhthuan"` -> `400`
- `curl -sk -o /tmp/rustchain-new-agent-wallet.json -w "%{http_code}" "https://rustchain.org/wallet/balance?miner_id=iamdinhthuan"` -> `200`