### PR TITLE
fix: use miner_id for telegram bot balance lookup

### DIFF
--- a/telegram-bot/README.md
+++ b/telegram-bot/README.md
@@ -41,7 +41,7 @@ python bot.py
 | Endpoint | Purpose |
 |---|---|
 | `GET /health` | Node health |
-| `GET /wallet/balance?wallet_id=<id>` | Wallet balance |
+| `GET /wallet/balance?miner_id=<id>` | Wallet balance |
 | `GET /api/miners` | Active miners list |
 | `GET /epoch` | Epoch info |
 

--- a/telegram-bot/bot.py
+++ b/telegram-bot/bot.py
@@ -45,7 +45,7 @@ async def get_balance(wallet_id: str) -> dict:
         async with httpx.AsyncClient(verify=TLS_CA_BUNDLE, timeout=10) as client:
             r = await client.get(
                 f"{NODE_URL}/wallet/balance",
-                params={"wallet_id": wallet_id},
+                params={"miner_id": wallet_id},
             )
             r.raise_for_status()
             return r.json()


### PR DESCRIPTION
## Summary
- update the Telegram bot balance API docs from `wallet_id` to `miner_id`
- send `miner_id` in the bot balance request so it matches the live RustChain wallet API

## Verification
- `python3 -m py_compile telegram-bot/bot.py`
- `git diff --check -- telegram-bot/README.md telegram-bot/bot.py`
- `rg -n 'wallet/balance\\?wallet_id|params=\\{"wallet_id"' telegram-bot || true`
- `curl -sk -o /tmp/rustchain-wallet-id.json -w "%{http_code}" "https://rustchain.org/wallet/balance?wallet_id=iamdinhthuan"` -> `400`
- `curl -sk -o /tmp/rustchain-miner-id.json -w "%{http_code}" "https://rustchain.org/wallet/balance?miner_id=iamdinhthuan"` -> `200`