### PR TITLE
test(wallet): cover wallet edge cases

### DIFF
--- a/sdk/python/rustchain_sdk/tests/test_wallet.py
+++ b/sdk/python/rustchain_sdk/tests/test_wallet.py
@@ -166,3 +166,35 @@ class TestRustChainWalletExportImport:
         """Invalid word count raises ValueError."""
         with pytest.raises(ValueError, match="Seed phrase must be 12 or 24"):
             RustChainWallet.from_seed_phrase(["abandon"] * 10)
+
+class TestRustChainWalletEdgeCases:
+    """Additional wallet edge-case tests for import and signing helpers."""
+
+    def test_from_seed_phrase_unknown_word_still_derives_wallet(self):
+        """from_seed_phrase derives from arbitrary words without wordlist lookup."""
+        words = ["not-a-bip39-word"] * 12
+        wallet = RustChainWallet.from_seed_phrase(words)
+        assert wallet.seed_phrase == words
+        assert wallet.address.startswith("RTC")
+        assert len(wallet.private_key_hex) == 64
+
+    def test_import_missing_seed_phrase_raises_key_error(self):
+        """Import requires the exported seed_phrase field."""
+        with pytest.raises(KeyError):
+            RustChainWallet.import_({"version": 1})
+
+    def test_sign_transfer_default_fee_is_zero(self):
+        """Transfers omit fee argument default to zero."""
+        wallet = RustChainWallet.create(strength=128)
+        transfer = wallet.sign_transfer("RTCrecipient123", 42)
+        assert transfer["fee"] == 0
+        assert transfer["amount"] == 42
+        assert len(transfer["signature"]) == 128
+
+    def test_repr_contains_address_without_private_key_or_seed(self):
+        """repr is safe: address only, no private key or seed words."""
+        wallet = RustChainWallet.create(strength=128)
+        rendered = repr(wallet)
+        assert wallet.address in rendered
+        assert wallet.private_key_hex not in rendered
+        assert " ".join(wallet.seed_phrase) not in rendered

--- a/sdk/python/rustchain_sdk/wallet.py
+++ b/sdk/python/rustchain_sdk/wallet.py
@@ -154,12 +154,20 @@ _BIP39_WORDLIST: List[str] = [
 ]
 
 
-def _to_words(data: bytes, wordlist: List[str]) -> List[str]:
+def _to_words(data: bytes, wordlist: List[str], count: Optional[int] = None) -> List[str]:
     """Convert raw bytes to BIP39-style words."""
+    if count is None:
+        count = (len(data) + 1) // 2
+
     words: List[str] = []
-    for i in range(0, len(data), 2):
-        word_index = int.from_bytes(data[i : i + 2], byteorder="big") % len(wordlist)
-        words.append(wordlist[word_index])
+    stream = data
+    while len(words) < count:
+        for i in range(0, len(stream), 2):
+            if len(words) >= count:
+                break
+            word_index = int.from_bytes(stream[i : i + 2], byteorder="big") % len(wordlist)
+            words.append(wordlist[word_index])
+        stream = hashlib.sha256(stream).digest()
     return words
 
 
@@ -266,8 +274,8 @@ class RustChainWallet:
         checksum = hashlib.sha256(raw_bytes).digest()[:1]
         extended = raw_bytes + checksum
 
-        # Convert to words
-        words = _to_words(extended, _BIP39_WORDLIST)
+        # Convert to the expected mnemonic length.
+        words = _to_words(extended, _BIP39_WORDLIST, 12 if strength == 128 else 24)
 
         # Derive seed from words
         seed = _hmac_sha512(b"mnemonic", " ".join(words).encode("utf-8"))


### PR DESCRIPTION
Closes #1589

## Summary
- Added pytest coverage for wallet import/signing/repr edge cases.
- Fixed generated mnemonic length so 128-bit wallets produce 12 words and 256-bit wallets produce 24 words.

## Verification
- `pytest -q sdk/python/rustchain_sdk/tests/test_wallet.py` -> 24 passed

## Payout
- GitHub: Thanhdn1984
- Wallet: not provided yet; can provide on request.