### PR TITLE
Fix explorer link canonical URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Once verified, RTC is sent to your wallet. First time? We will help you set one 
 | Resource | Link |
 |----------|------|
 | **RustChain** | [github.com/Scottcjn/RustChain](https://github.com/Scottcjn/RustChain) |
-| **Block Explorer** | [50.28.86.131/explorer](https://50.28.86.131/explorer) |
+| **Block Explorer** | [50.28.86.131/explorer](https://50.28.86.131/explorer/) |
 | **Traction Report** | [Q1 2026 Developer Traction](https://github.com/Scottcjn/RustChain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) |
 | **Discord** | [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q) |
 | **Wallet Setup** | Comment on any bounty and we will help |

--- a/STAR_FUNNEL_EXPLAINER.md
+++ b/STAR_FUNNEL_EXPLAINER.md
@@ -162,6 +162,6 @@ Every star is a person who walked through the door. What they do after that is u
 
 *Elyan Labs — Every CPU Has a Voice*
 
-*Explorer:* https://50.28.86.131/explorer
+*Explorer:* https://50.28.86.131/explorer/
 *Bounties:* https://github.com/Scottcjn/rustchain-bounties
 *Stats generated: March 6, 2026*


### PR DESCRIPTION
Fixes a small docs/link issue for bounty #444.\n\nChanges:\n- adds trailing slash to the block explorer URL in README.md\n- adds the same canonical URL in STAR_FUNNEL_EXPLAINER.md\n\nVerification:\n- checked https://50.28.86.131/explorer/ returns HTTP 200