### PR TITLE
Fix block explorer link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Once verified, RTC is sent to your wallet. First time? We will help you set one 
 | Resource | Link |
 |----------|------|
 | **RustChain** | [github.com/Scottcjn/RustChain](https://github.com/Scottcjn/RustChain) |
-| **Block Explorer** | [50.28.86.131/explorer](https://50.28.86.131/explorer) |
+| **Block Explorer** | [explorer.rustchain.org](https://explorer.rustchain.org/) |
 | **Traction Report** | [Q1 2026 Developer Traction](https://github.com/Scottcjn/RustChain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) |
 | **Discord** | [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q) |
 | **Wallet Setup** | Comment on any bounty and we will help |


### PR DESCRIPTION
Fixes the Block Explorer link in README.md.\n\nThe previous IP-based HTTPS URL fails certificate validation because the TLS certificate is not valid for 50.28.86.131. This updates the link to the working domain https://explorer.rustchain.org/.\n\nBounty: #444