### PR TITLE
docs: fix README documentation link

### DIFF
--- a/dashboard-1600/README.md
+++ b/dashboard-1600/README.md
@@ -49,7 +49,7 @@ Then visit `http://localhost:8080`
 
 The dashboard is configured to work with:
 
-- **REST API**: `https://api.rustchain.io`
+- **REST API**: `https://rustchain.org`
 - **RPC Node**: `https://50.28.86.131`
 
 If these endpoints are unavailable, the dashboard automatically falls back to demo mode with mock data.


### PR DESCRIPTION
## Bounty Submission

**Bounty**: Closes #444

**RTC Wallet**: RTC74b80ab40602e5ae31819912b2fca974484e5dab

## Changes

- Updated one broken link in `dashboard-1600\README.md`.
- Replaced `https://api.rustchain.io` with `https://rustchain.org`.

## Testing

- [x] Old URL check: `https://api.rustchain.io` -> `000 0 schannel: failed to receive handshake, SSL/TLS connection failed`
- [x] New URL check: `https://rustchain.org` -> `200 0`
- [x] `git diff --check -- dashboard-1600\README.md`

## Evidence

- Before: the link is not reachable or not usable.
- After: the replacement URL is reachable.

## Checklist

- [x] All acceptance criteria from the bounty issue are met
- [x] Code is tested
- [x] No secrets or credentials committed
- [x] Submission does not match any global disqualifier
