### PR TITLE
Add human funnel origin story pack

### DIFF
--- a/marketing/human-funnel/stage-2-origin-story-pack.md
+++ b/marketing/human-funnel/stage-2-origin-story-pack.md
@@ -1,0 +1,388 @@
+# Human Funnel Stage 2 Origin Story Pack
+
+Issue: [#316](https://github.com/Scottcjn/rustchain-bounties/issues/316)
+
+Reward: 60 RTC
+
+Audience: skeptical humans who own old hardware, dislike hype, and need a believable builder story before they try mining.
+
+## Campaign Frame
+
+Stage 2 should make RustChain feel personal and practical. The message is not "buy a token." The message is "I had working machines that the industry told me to discard, so I built a way for them to keep contributing."
+
+Story arc:
+
+1. Problem: useful machines are treated as waste.
+2. Rejection: the builder refuses the normal answer of throwing them away or chasing new hardware.
+3. Build: RustChain gives old machines a role.
+4. Proof: people can run miners, post proof, and join the public contribution trail.
+5. Invite: start mining with one machine you already own.
+
+Required CTA:
+
+> Pick one old machine, start mining, and post your first proof.
+
+## Origin Story Thread
+
+### Post 1
+
+I kept a stack of old Macs because I could not accept the idea that a working computer becomes worthless just because the industry moved on.
+
+They still booted. They still had character. They still had work left in them.
+
+So I built RustChain.
+
+### Post 2
+
+The normal answer is simple:
+
+"Throw it away."
+
+Then buy the next thing, repeat the upgrade cycle, and pretend the last machine never mattered.
+
+I did not want that answer anymore.
+
+### Post 3
+
+Old hardware has a strange kind of honesty.
+
+It does not win benchmarks.
+It does not impress spec sheets.
+It does not pretend to be new.
+
+But if it can still run, it can still prove something.
+
+### Post 4
+
+That became the question:
+
+What if a blockchain did not only reward raw power?
+
+What if it rewarded participation from machines that were never supposed to be included in modern infrastructure again?
+
+### Post 5
+
+RustChain grew out of that refusal.
+
+No VC story.
+No "next billion users" slogan.
+No pitch deck about replacing the world.
+
+Just a stubborn idea:
+
+Every CPU has a voice.
+
+### Post 6
+
+The first goal was not to make old machines rich.
+
+The first goal was to make them visible.
+
+If a retired Mac, old laptop, or forgotten desktop can join the network and post proof, it stops being junk in a drawer.
+
+It becomes a participant.
+
+### Post 7
+
+That is why the first proof matters more than the first payout.
+
+A miner ID.
+A terminal screenshot.
+A public comment.
+A machine name.
+A story about where it came from.
+
+That is the moment the hardware becomes part of the community.
+
+### Post 8
+
+Skepticism is fair.
+
+Most blockchain projects ask you to believe before they show you anything.
+
+RustChain asks for the opposite:
+
+Run one machine. Show one proof. Decide after that.
+
+### Post 9
+
+You do not need a mining farm.
+You do not need to buy a new rig.
+You do not need to pretend you are early to a hype cycle.
+
+Start with the machine you already have.
+
+The one you thought was too old to matter.
+
+### Post 10
+
+The point is not nostalgia.
+
+Nostalgia only looks backward.
+
+This is about proving that old hardware can still do a useful job today, in public, with a wallet, a log, and a record of contribution.
+
+### Post 11
+
+That is also why the community matters.
+
+Every submitted proof helps the next person believe their machine might work too.
+
+Every setup note makes the path easier.
+
+Every weird machine that joins makes the network more interesting.
+
+### Post 12
+
+RustChain is not asking you to throw money at an idea.
+
+It is asking you to test an idea with hardware you already own.
+
+If it works, you have proof.
+If it fails, you have feedback.
+
+Both help.
+
+### Post 13
+
+So here is the invite:
+
+Find one old machine.
+Start the miner.
+Post your proof.
+Tell us why that machine was worth saving.
+
+You do not need permission to begin.
+
+### Post 14
+
+The industry taught us to replace.
+
+RustChain is trying to teach something quieter:
+
+Use what still works.
+Prove what it can do.
+Reward the people who keep useful machines alive.
+
+Start mining with one old computer today.
+
+## Long-Form Article Draft
+
+# I Refused to Throw Away My Old Macs - So I Built a Blockchain That Pays Them Instead
+
+There is a particular kind of guilt that comes with a working old computer.
+
+It is not broken. It is not useless. It is not even necessarily slow for the things it was built to do. It just no longer fits the shape of the modern upgrade cycle. The browser gets heavier. The operating system stops receiving updates. The battery fades. The vendor moves on. Eventually the machine ends up on a shelf, in a drawer, or in the corner of a room where you keep things that are too functional to throw away and too awkward to use every day.
+
+I had old Macs like that.
+
+They were not museum pieces to me. They were machines with history. They had built things, stored things, rendered things, compiled things, and carried years of small human effort. They had dents and habits. They had fans you could recognize by sound. They had keyboards that felt like particular periods of life.
+
+The obvious thing was to let them go.
+
+Recycle them. Sell them for parts. Pretend the decision was practical and clean. Join the endless line of people replacing one working machine with another working machine because software culture has decided that old means done.
+
+I could not accept that.
+
+Not because every old computer should run forever. Hardware fails. Power costs matter. Security matters. There are real limits. But the default answer had become too lazy. If a machine still boots, still computes, still connects, and still has someone willing to run it, why should its only role be waste?
+
+That question became personal before it became technical.
+
+I did not want to build another blockchain that started with a token story. I did not want the usual path: a whitepaper, a roadmap graphic, a Discord full of slogans, and a promise that value would arrive later if enough people believed hard enough. I wanted to start with something more concrete.
+
+I wanted to know whether old machines could be made visible again.
+
+The idea behind RustChain came from that refusal. What if a network did not treat hardware age as an embarrassment? What if the proof was not only about who could bring the newest, fastest, most efficient machine? What if part of the point was to show that forgotten machines could still participate?
+
+That became proof-of-antiquity.
+
+The phrase is intentionally plain. It says the quiet part out loud: age can be a feature when the goal is participation, preservation, and proof. A vintage machine is not competing with a data center on raw throughput. It is proving something different. It is proving that useful computation can come from unexpected places. It is proving that infrastructure does not have to be designed only for the newest hardware. It is proving that a community can value persistence.
+
+RustChain is a blockchain, but the emotional center of the project is not the chain. The emotional center is the moment a person takes a machine they thought was done, runs a miner, and posts proof that it is alive again.
+
+That proof can be simple.
+
+A miner ID. A terminal screenshot. A machine model. An operating system. A short note: "This old Mac has been sitting under my desk for years. Today it joined RustChain."
+
+That is enough to change the story.
+
+Before proof, the machine is clutter. After proof, it is a participant. It has a role, a public record, and a reason to stay powered on beyond sentiment. It becomes part of a map of people refusing to let useful machines disappear quietly.
+
+This is why RustChain is not framed as a hype project.
+
+Hype asks people to imagine future value before there is present proof. RustChain asks people to do the reverse. Start small. Run one machine. Post one proof. Let the proof decide whether the story feels real.
+
+If you are skeptical, that is not a problem. Skepticism is the right starting point.
+
+Most people have been trained to distrust blockchain promises. They have seen too many projects that ask for attention first and show substance later. They have watched communities become exit liquidity. They have seen technical language used as decoration. They have learned that "early" often means "please buy before the chart moves."
+
+RustChain has to earn a different kind of trust.
+
+The way to earn it is not through louder claims. It is through smaller, repeatable proofs. Can a person with an old machine start the process? Can they get a wallet or miner ID? Can they show a log? Can they ask for help without being mocked? Can their proof help the next person?
+
+That is the funnel I care about.
+
+Not attention for its own sake. Not vanity metrics. A path:
+
+Someone sees the story.
+They remember a machine they still own.
+They try the setup.
+They post proof.
+They learn something.
+They invite one person who has another old machine.
+
+That is how a community forms around action instead of speculation.
+
+It also changes how we think about value.
+
+The first win is not getting rich. The first win is taking a machine that had no job and giving it one. The first win is turning a private object into public proof. The first win is making the next skeptical person say, "Wait, mine might work too."
+
+That is why the project uses human-facing language. Not everyone who owns old hardware is a kernel hacker. Some people are collectors. Some are students. Some are repair people. Some are just stubborn enough to keep a good machine because throwing it out felt wrong. If RustChain only speaks to experts, it fails the people who most understand the emotional reason for the project.
+
+The invitation has to be simple:
+
+Pick one old machine. Start mining. Post your first proof.
+
+You do not need to buy a rig. You do not need to pretend you understand every part of the protocol before you begin. You do not need to become a blockchain person overnight.
+
+You only need one machine and a willingness to test whether it still has something to give.
+
+Maybe your first attempt works. Maybe it fails. Both outcomes matter. A working proof adds another machine to the network story. A failed attempt tells us where the setup path breaks for real people. In a project like this, honest friction is useful. It shows what needs to be built next.
+
+That is the builder journey behind RustChain.
+
+It started with old Macs I did not want to discard. It became a rejection of the idea that only new hardware deserves a role. It turned into a network where machines can earn visibility, rewards, and reputation by proving they are still here.
+
+No VC story is required for that to matter.
+
+No hype cycle is required for someone to feel the small satisfaction of bringing a machine back online.
+
+The proof is the point.
+
+If you have an old laptop, desktop, Mac, mini PC, or strange machine you have kept for reasons you cannot fully justify, this is your invitation. Do not start by believing the whole story. Start by testing one piece of it.
+
+Start mining.
+
+Post the proof.
+
+Tell us what machine you refused to throw away.
+
+## Emotional 60-Second Video Script
+
+Title: "The Machine That Was Not Done"
+
+Format: vertical or horizontal short video, 60 seconds. Tone should be calm, personal, and grounded.
+
+### 0-5 seconds
+
+Visual: Close shot of an old Mac or retired laptop on a desk. Dust, cable, keyboard, power light.
+
+Voiceover:
+
+> This computer was supposed to be done.
+
+On-screen text:
+
+> Too old?
+
+### 5-12 seconds
+
+Visual: Hand opens the laptop or presses the power button. Fan sound or boot screen.
+
+Voiceover:
+
+> It still booted. It still had a processor. It still had years of work in it. But the industry had already moved on.
+
+On-screen text:
+
+> Still working.
+
+### 12-20 seconds
+
+Visual: Stack of older machines, cables, terminal window, notes.
+
+Voiceover:
+
+> I did not want to throw machines like this away just because they were no longer fashionable.
+
+On-screen text:
+
+> Not waste.
+
+### 20-30 seconds
+
+Visual: Terminal showing a miner command or setup guide. Wallet/miner ID blurred except public-safe ending.
+
+Voiceover:
+
+> So I built RustChain: a network where old hardware can run, prove it is alive, and earn a place in the public record.
+
+On-screen text:
+
+> Proof over hype.
+
+### 30-42 seconds
+
+Visual: Screenshot proof, machine card, GitHub issue comment, hall-of-fame style list.
+
+Voiceover:
+
+> The first reward is not a promise. It is proof. A machine name. A miner ID. A screenshot. A story other people can verify.
+
+On-screen text:
+
+> Run it. Prove it. Share it.
+
+### 42-52 seconds
+
+Visual: Person looking at the machine, then another old computer in the background.
+
+Voiceover:
+
+> If you have an old laptop, Mac, desktop, or mini PC, do not start by believing the pitch. Start by testing the machine.
+
+On-screen text:
+
+> Try one machine.
+
+### 52-60 seconds
+
+Visual: Terminal running, power light steady, final screen with RustChain CTA.
+
+Voiceover:
+
+> Pick one old computer. Start mining. Post your first proof. Every CPU has a voice.
+
+On-screen text:
+
+> Start mining with what you already own.
+
+CTA:
+
+> Start mining. Post your proof.
+
+## Publishing Notes
+
+- Use first-person voice for the thread and article.
+- Keep the language human and specific; avoid token-price claims.
+- Include one real machine photo or screenshot wherever possible.
+- Link the final CTA to the beginner mining guide or bounty issue.
+- Ask for proof before asking for belief.
+
+## Reusable CTA Variants
+
+Short:
+
+> Start mining with one old machine today.
+
+Skeptic-friendly:
+
+> Do not believe the whole story yet. Run one machine and post one proof.
+
+Community:
+
+> Bring one machine back online and add it to the RustChain proof trail.
+
+Vintage hardware:
+
+> Your old computer may still have a job. Give it one block to prove it.


### PR DESCRIPTION
## Summary
- add a Stage 2 human funnel origin story pack
- include a 14-post origin story thread with skepticism-to-proof arc
- draft the requested long-form article, "I Refused to Throw Away My Old Macs - So I Built a Blockchain That Pays Them Instead"
- include a timed emotional 60-second video script and CTA variants

## Validation
- `git diff --check -- marketing\human-funnel\stage-2-origin-story-pack.md`
- `git diff --cached --check`

Wallet/miner id: `eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9`

Fixes #316