### PR TITLE
Add block explorer dashboard

### DIFF
--- a/block-explorer-dashboard/README.md
+++ b/block-explorer-dashboard/README.md
@@ -1,0 +1,42 @@
+# RustChain Block Explorer Dashboard
+
+Issue: [#686](https://github.com/Scottcjn/rustchain-bounties/issues/686)
+
+This is a dependency-free static dashboard for the live RustChain explorer APIs.
+
+## Implemented Scope
+
+Tier 1 miner dashboard:
+
+- Fetches `https://explorer.rustchain.org/api/miners`.
+- Shows active miners, online count, vintage node count, and top antiquity multiplier.
+- Renders architecture badges, hardware type, multiplier bars, attestation age, and online/stale status.
+- Includes search, family filter, status filter, sorting, manual refresh, and 30-second refresh cadence.
+
+Tier 2 Agent Economy view:
+
+- Fetches `https://explorer.rustchain.org/agent/stats`.
+- Fetches `https://explorer.rustchain.org/agent/jobs`.
+- Looks up wallet reputation with `https://explorer.rustchain.org/agent/reputation/{wallet}`.
+- Shows active agents, open jobs, escrow balance, fee rate, total RTC volume, category distribution, and job lifecycle states.
+- Includes category filtering and an empty state when no open jobs are returned by the API.
+
+## Files
+
+- `index.html` - dashboard layout.
+- `styles.css` - responsive dashboard styling.
+- `app.js` - API loading, normalization, filters, sorting, and rendering.
+
+## Local Validation
+
+Open `index.html` in a browser, or serve the folder with any static file server.
+
+```powershell
+python -m http.server 8080
+```
+
+Then open `http://localhost:8080/block-explorer-dashboard/`.
+
+## API Notes
+
+The dashboard is read-only. It does not require a wallet, token, server secret, or write access. If an API call fails, the page keeps the rest of the successful data visible and shows a partial-data warning.

--- a/block-explorer-dashboard/app.js
+++ b/block-explorer-dashboard/app.js
@@ -1,0 +1,426 @@
+const API_BASE = "https://explorer.rustchain.org";
+const REFRESH_INTERVAL_MS = 30000;
+const ONLINE_WINDOW_SECONDS = 180;
+
+const state = {
+  miners: [],
+  jobs: [],
+  stats: null,
+  errors: [],
+  lastLoadedAt: null,
+  timer: null,
+};
+
+const els = {
+  healthBadge: document.querySelector("#healthBadge"),
+  updatedAt: document.querySelector("#updatedAt"),
+  refreshBtn: document.querySelector("#refreshBtn"),
+  errorPanel: document.querySelector("#errorPanel"),
+  minerCount: document.querySelector("#minerCount"),
+  onlineCount: document.querySelector("#onlineCount"),
+  vintageCount: document.querySelector("#vintageCount"),
+  topMultiplier: document.querySelector("#topMultiplier"),
+  topMiner: document.querySelector("#topMiner"),
+  agentVolume: document.querySelector("#agentVolume"),
+  agentJobs: document.querySelector("#agentJobs"),
+  minerRows: document.querySelector("#minerRows"),
+  minerCaption: document.querySelector("#minerCaption"),
+  minerSearch: document.querySelector("#minerSearch"),
+  familyFilter: document.querySelector("#familyFilter"),
+  statusFilter: document.querySelector("#statusFilter"),
+  sortSelect: document.querySelector("#sortSelect"),
+  archBars: document.querySelector("#archBars"),
+  activeAgents: document.querySelector("#activeAgents"),
+  openJobs: document.querySelector("#openJobs"),
+  escrowBalance: document.querySelector("#escrowBalance"),
+  feeRate: document.querySelector("#feeRate"),
+  categoryBars: document.querySelector("#categoryBars"),
+  reputationWallet: document.querySelector("#reputationWallet"),
+  reputationBtn: document.querySelector("#reputationBtn"),
+  reputationResult: document.querySelector("#reputationResult"),
+  jobList: document.querySelector("#jobList"),
+  jobCaption: document.querySelector("#jobCaption"),
+  jobCategoryFilter: document.querySelector("#jobCategoryFilter"),
+};
+
+function formatNumber(value, digits = 0) {
+  const number = Number(value || 0);
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  }).format(number);
+}
+
+function formatRtc(value) {
+  return `${formatNumber(value, 1)} RTC`;
+}
+
+function unixToDate(seconds) {
+  const value = Number(seconds || 0);
+  if (!value) return null;
+  return new Date(value * 1000);
+}
+
+function relativeTime(seconds) {
+  const date = unixToDate(seconds);
+  if (!date) return "unknown";
+
+  const diffSeconds = Math.round((date.getTime() - Date.now()) / 1000);
+  const abs = Math.abs(diffSeconds);
+  const units = [
+    ["day", 86400],
+    ["hour", 3600],
+    ["minute", 60],
+    ["second", 1],
+  ];
+
+  const [unit, size] = units.find(([, unitSeconds]) => abs >= unitSeconds) || units[3];
+  const value = Math.round(diffSeconds / size);
+  return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(value, unit);
+}
+
+function onlineStatus(miner) {
+  const last = Number(miner.last_attest || 0);
+  if (!last) return "stale";
+  const age = Math.max(0, Date.now() / 1000 - last);
+  return age <= ONLINE_WINDOW_SECONDS ? "online" : "stale";
+}
+
+function shortMiner(id) {
+  const value = String(id || "unknown");
+  if (value.length <= 28) return value;
+  return `${value.slice(0, 14)}...${value.slice(-8)}`;
+}
+
+function familyClass(family) {
+  const value = String(family || "").toLowerCase();
+  if (value.includes("power")) return "power";
+  if (value.includes("apple") || value.includes("x86") || value.includes("windows")) return "modern";
+  return "";
+}
+
+async function fetchJson(path) {
+  const response = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`${path} returned ${response.status}`);
+  }
+  return response.json();
+}
+
+async function loadDashboard() {
+  els.refreshBtn.disabled = true;
+  els.refreshBtn.textContent = "Refreshing";
+  state.errors = [];
+
+  const [minersResult, jobsResult, statsResult, healthResult] = await Promise.allSettled([
+    fetchJson("/api/miners"),
+    fetchJson("/agent/jobs"),
+    fetchJson("/agent/stats"),
+    fetchJson("/health"),
+  ]);
+
+  if (minersResult.status === "fulfilled") {
+    state.miners = Array.isArray(minersResult.value.miners) ? minersResult.value.miners : [];
+  } else {
+    state.errors.push(minersResult.reason.message);
+  }
+
+  if (jobsResult.status === "fulfilled") {
+    state.jobs = Array.isArray(jobsResult.value.jobs) ? jobsResult.value.jobs : [];
+  } else {
+    state.errors.push(jobsResult.reason.message);
+  }
+
+  if (statsResult.status === "fulfilled") {
+    state.stats = statsResult.value.stats || null;
+  } else {
+    state.errors.push(statsResult.reason.message);
+  }
+
+  if (healthResult.status === "rejected") {
+    state.errors.push(healthResult.reason.message);
+  }
+
+  state.lastLoadedAt = new Date();
+  render();
+  els.refreshBtn.disabled = false;
+  els.refreshBtn.textContent = "Refresh";
+  resetRefreshTimer();
+}
+
+function resetRefreshTimer() {
+  if (state.timer) window.clearTimeout(state.timer);
+  state.timer = window.setTimeout(loadDashboard, REFRESH_INTERVAL_MS);
+}
+
+function render() {
+  renderHealth();
+  renderMetrics();
+  renderFamilyOptions();
+  renderMiners();
+  renderArchitectureBars();
+  renderAgentEconomy();
+  renderJobCategoryOptions();
+  renderJobs();
+}
+
+function renderHealth() {
+  const hasData = state.miners.length > 0 || state.stats;
+  els.healthBadge.className = `health-badge ${state.errors.length ? "warn" : "ok"}`;
+  els.healthBadge.textContent = state.errors.length ? "Partial data" : hasData ? "Live" : "No data";
+  els.updatedAt.textContent = state.lastLoadedAt
+    ? `Updated ${state.lastLoadedAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}`
+    : "Not loaded";
+
+  if (state.errors.length) {
+    els.errorPanel.hidden = false;
+    els.errorPanel.textContent = state.errors.join(" | ");
+  } else {
+    els.errorPanel.hidden = true;
+    els.errorPanel.textContent = "";
+  }
+}
+
+function renderMetrics() {
+  const miners = state.miners;
+  const online = miners.filter((miner) => onlineStatus(miner) === "online");
+  const vintage = miners.filter((miner) => Number(miner.antiquity_multiplier || 0) > 1.2);
+  const top = miners.reduce((best, miner) => {
+    return Number(miner.antiquity_multiplier || 0) > Number(best?.antiquity_multiplier || 0) ? miner : best;
+  }, null);
+
+  els.minerCount.textContent = miners.length;
+  els.onlineCount.textContent = `${online.length} online`;
+  els.vintageCount.textContent = vintage.length;
+  els.topMultiplier.textContent = `${formatNumber(top?.antiquity_multiplier || 0, 2)}x`;
+  els.topMiner.textContent = top ? shortMiner(top.miner) : "No miner";
+
+  const stats = state.stats || {};
+  els.agentVolume.textContent = formatRtc(stats.total_rtc_volume);
+  els.agentJobs.textContent = `${formatNumber(stats.completed_jobs)} completed`;
+}
+
+function renderFamilyOptions() {
+  const current = els.familyFilter.value;
+  const families = [...new Set(state.miners.map((miner) => miner.device_family || "Unknown"))].sort();
+  els.familyFilter.innerHTML = [
+    `<option value="all">All</option>`,
+    ...families.map((family) => `<option value="${escapeHtml(family)}">${escapeHtml(family)}</option>`),
+  ].join("");
+
+  if (families.includes(current)) {
+    els.familyFilter.value = current;
+  }
+}
+
+function getFilteredMiners() {
+  const search = els.minerSearch.value.trim().toLowerCase();
+  const family = els.familyFilter.value;
+  const status = els.statusFilter.value;
+  const sort = els.sortSelect.value;
+
+  return [...state.miners]
+    .filter((miner) => {
+      const text = [
+        miner.miner,
+        miner.device_arch,
+        miner.device_family,
+        miner.hardware_type,
+      ].join(" ").toLowerCase();
+      const familyOk = family === "all" || miner.device_family === family;
+      const statusOk = status === "all" || onlineStatus(miner) === status;
+      return (!search || text.includes(search)) && familyOk && statusOk;
+    })
+    .sort((a, b) => {
+      if (sort === "miner" || sort === "device_family") {
+        return String(a[sort] || "").localeCompare(String(b[sort] || ""));
+      }
+      return Number(b[sort] || 0) - Number(a[sort] || 0);
+    });
+}
+
+function renderMiners() {
+  const miners = getFilteredMiners();
+  els.minerCaption.textContent = `${miners.length} of ${state.miners.length} miners shown`;
+
+  if (!miners.length) {
+    els.minerRows.innerHTML = `<tr><td colspan="6" class="empty-cell">No miners match the current view.</td></tr>`;
+    return;
+  }
+
+  const maxMultiplier = Math.max(...state.miners.map((miner) => Number(miner.antiquity_multiplier || 0)), 1);
+  els.minerRows.innerHTML = miners.map((miner) => {
+    const multiplier = Number(miner.antiquity_multiplier || 0);
+    const fill = Math.max(4, Math.min(100, (multiplier / maxMultiplier) * 100));
+    const status = onlineStatus(miner);
+    const first = relativeTime(miner.first_attest);
+    const last = relativeTime(miner.last_attest);
+    const family = miner.device_family || "Unknown";
+
+    return `
+      <tr>
+        <td>
+          <span class="miner-id" title="${escapeHtml(miner.miner || "")}">${escapeHtml(shortMiner(miner.miner))}</span>
+          <span class="subtle">First seen ${escapeHtml(first)}</span>
+        </td>
+        <td><span class="badge ${familyClass(family)}">${escapeHtml(family)}</span></td>
+        <td>
+          ${escapeHtml(miner.hardware_type || "Unknown")}
+          <span class="subtle">${escapeHtml(miner.device_arch || "unknown arch")}</span>
+        </td>
+        <td>
+          <span class="multiplier">
+            <strong>${formatNumber(multiplier, 2)}x</strong>
+            <span class="multiplier-track"><span class="multiplier-fill" style="--fill:${fill}%"></span></span>
+          </span>
+        </td>
+        <td>${escapeHtml(last)}</td>
+        <td><span class="status-dot ${status}">${status}</span></td>
+      </tr>
+    `;
+  }).join("");
+}
+
+function renderArchitectureBars() {
+  const counts = countBy(state.miners, (miner) => miner.device_family || "Unknown");
+  const total = Math.max(1, state.miners.length);
+  els.archBars.innerHTML = renderBars(counts, total);
+}
+
+function renderAgentEconomy() {
+  const stats = state.stats || {};
+  els.activeAgents.textContent = formatNumber(stats.active_agents);
+  els.openJobs.textContent = formatNumber(stats.open_jobs);
+  els.escrowBalance.textContent = formatRtc(stats.escrow_balance_rtc);
+  els.feeRate.textContent = stats.platform_fee_rate || "0%";
+
+  const categories = {};
+  (stats.categories || []).forEach((category) => {
+    categories[category.category || "other"] = Number(category.jobs || 0);
+  });
+  const total = Object.values(categories).reduce((sum, value) => sum + value, 0) || 1;
+  els.categoryBars.innerHTML = renderBars(categories, total);
+}
+
+function renderJobCategoryOptions() {
+  const current = els.jobCategoryFilter.value;
+  const statsCategories = ((state.stats || {}).categories || []).map((category) => category.category);
+  const jobCategories = state.jobs.map((job) => job.category).filter(Boolean);
+  const categories = [...new Set([...statsCategories, ...jobCategories])].filter(Boolean).sort();
+  els.jobCategoryFilter.innerHTML = [
+    `<option value="all">All</option>`,
+    ...categories.map((category) => `<option value="${escapeHtml(category)}">${escapeHtml(category)}</option>`),
+  ].join("");
+
+  if (categories.includes(current)) {
+    els.jobCategoryFilter.value = current;
+  }
+}
+
+function renderJobs() {
+  const category = els.jobCategoryFilter.value;
+  const jobs = state.jobs.filter((job) => category === "all" || job.category === category);
+  els.jobCaption.textContent = `${jobs.length} of ${state.jobs.length} open jobs`;
+
+  if (!jobs.length) {
+    els.jobList.innerHTML = `<p class="empty-state">No open jobs are currently returned by the API.</p>`;
+    return;
+  }
+
+  els.jobList.innerHTML = jobs.map((job) => {
+    const title = job.title || job.name || `Job ${job.id || ""}`.trim();
+    const reward = job.reward_rtc || job.reward || job.amount || "RTC";
+    const category = job.category || "uncategorized";
+    const status = job.status || "posted";
+    return `
+      <article class="job-row">
+        <div>
+          <strong>${escapeHtml(title)}</strong>
+          <small>${escapeHtml(category)} | ${escapeHtml(status)}</small>
+        </div>
+        <span class="badge">${escapeHtml(String(reward))}</span>
+        <code>${escapeHtml(job.id || job.job_id || "open")}</code>
+      </article>
+    `;
+  }).join("");
+}
+
+async function lookupReputation() {
+  const wallet = els.reputationWallet.value.trim();
+  if (!wallet) {
+    els.reputationResult.textContent = "Enter a wallet or agent id.";
+    return;
+  }
+
+  els.reputationBtn.disabled = true;
+  els.reputationBtn.textContent = "Checking";
+  els.reputationResult.textContent = "Loading reputation...";
+
+  try {
+    const data = await fetchJson(`/agent/reputation/${encodeURIComponent(wallet)}`);
+    if (!data.reputation) {
+      els.reputationResult.textContent = `${data.wallet_id || wallet}: no reputation history returned.`;
+    } else {
+      els.reputationResult.textContent = `${data.wallet_id || wallet}: ${JSON.stringify(data.reputation)}`;
+    }
+  } catch (error) {
+    els.reputationResult.textContent = error.message;
+  } finally {
+    els.reputationBtn.disabled = false;
+    els.reputationBtn.textContent = "Lookup";
+  }
+}
+
+function countBy(items, selector) {
+  return items.reduce((counts, item) => {
+    const key = selector(item);
+    counts[key] = (counts[key] || 0) + 1;
+    return counts;
+  }, {});
+}
+
+function renderBars(counts, total) {
+  const entries = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+  if (!entries.length) {
+    return `<p class="empty-state">No data available.</p>`;
+  }
+
+  return entries.map(([name, count]) => {
+    const fill = Math.max(4, Math.round((count / total) * 100));
+    return `
+      <div class="bar-row">
+        <span class="bar-name"><span>${escapeHtml(name)}</span><strong>${formatNumber(count)}</strong></span>
+        <span></span>
+        <span class="bar-rail"><span class="bar-fill" style="--fill:${fill}%"></span></span>
+      </div>
+    `;
+  }).join("");
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+[
+  els.minerSearch,
+  els.familyFilter,
+  els.statusFilter,
+  els.sortSelect,
+].forEach((control) => control.addEventListener("input", renderMiners));
+
+els.jobCategoryFilter.addEventListener("change", renderJobs);
+els.reputationBtn.addEventListener("click", lookupReputation);
+els.reputationWallet.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") lookupReputation();
+});
+els.refreshBtn.addEventListener("click", loadDashboard);
+window.addEventListener("visibilitychange", () => {
+  if (!document.hidden) loadDashboard();
+});
+
+loadDashboard();

--- a/block-explorer-dashboard/index.html
+++ b/block-explorer-dashboard/index.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RustChain Explorer Dashboard</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <main class="shell">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">RustChain Explorer</p>
+        <h1>Miner Dashboard</h1>
+      </div>
+      <div class="status-cluster">
+        <span id="healthBadge" class="health-badge pending">Checking</span>
+        <span id="updatedAt" class="muted">Not loaded</span>
+        <button id="refreshBtn" class="primary-action" type="button">Refresh</button>
+      </div>
+    </header>
+
+    <section class="metrics-grid" aria-label="Explorer summary">
+      <article class="metric-tile">
+        <span class="metric-label">Active Miners</span>
+        <strong id="minerCount">0</strong>
+        <small id="onlineCount">0 online</small>
+      </article>
+      <article class="metric-tile">
+        <span class="metric-label">Vintage Nodes</span>
+        <strong id="vintageCount">0</strong>
+        <small>Multiplier above modern baseline</small>
+      </article>
+      <article class="metric-tile">
+        <span class="metric-label">Top Multiplier</span>
+        <strong id="topMultiplier">0x</strong>
+        <small id="topMiner">No miner</small>
+      </article>
+      <article class="metric-tile">
+        <span class="metric-label">Agent Volume</span>
+        <strong id="agentVolume">0 RTC</strong>
+        <small id="agentJobs">0 jobs completed</small>
+      </article>
+    </section>
+
+    <section id="errorPanel" class="error-panel" hidden></section>
+
+    <section class="workspace">
+      <div class="panel miners-panel">
+        <div class="panel-header">
+          <div>
+            <h2>Miners</h2>
+            <p id="minerCaption">Live attestations from the explorer API</p>
+          </div>
+          <div class="controls">
+            <label>
+              <span>Search</span>
+              <input id="minerSearch" type="search" placeholder="miner or hardware">
+            </label>
+            <label>
+              <span>Family</span>
+              <select id="familyFilter">
+                <option value="all">All</option>
+              </select>
+            </label>
+            <label>
+              <span>Status</span>
+              <select id="statusFilter">
+                <option value="all">All</option>
+                <option value="online">Online</option>
+                <option value="stale">Stale</option>
+              </select>
+            </label>
+            <label>
+              <span>Sort</span>
+              <select id="sortSelect">
+                <option value="last_attest">Latest attest</option>
+                <option value="antiquity_multiplier">Multiplier</option>
+                <option value="device_family">Family</option>
+                <option value="miner">Miner</option>
+              </select>
+            </label>
+          </div>
+        </div>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Miner</th>
+                <th>Family</th>
+                <th>Hardware</th>
+                <th>Multiplier</th>
+                <th>Last Attest</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody id="minerRows">
+              <tr>
+                <td colspan="6" class="empty-cell">Loading miners...</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <aside class="side-stack">
+        <section class="panel">
+          <div class="panel-header compact">
+            <h2>Architecture Mix</h2>
+          </div>
+          <div id="archBars" class="bar-list"></div>
+        </section>
+
+        <section class="panel">
+          <div class="panel-header compact">
+            <h2>Agent Economy</h2>
+          </div>
+          <dl class="stats-list">
+            <div>
+              <dt>Active agents</dt>
+              <dd id="activeAgents">0</dd>
+            </div>
+            <div>
+              <dt>Open jobs</dt>
+              <dd id="openJobs">0</dd>
+            </div>
+            <div>
+              <dt>Escrow</dt>
+              <dd id="escrowBalance">0 RTC</dd>
+            </div>
+            <div>
+              <dt>Fee rate</dt>
+              <dd id="feeRate">0%</dd>
+            </div>
+          </dl>
+          <div id="categoryBars" class="bar-list compact-bars"></div>
+          <div class="lookup-box">
+            <label>
+              <span>Reputation Lookup</span>
+              <input id="reputationWallet" type="search" placeholder="wallet or agent id">
+            </label>
+            <button id="reputationBtn" type="button">Lookup</button>
+            <p id="reputationResult" class="lookup-result">No wallet selected.</p>
+          </div>
+        </section>
+      </aside>
+    </section>
+
+    <section class="panel jobs-panel">
+      <div class="panel-header">
+        <div>
+          <h2>Marketplace Jobs</h2>
+          <p id="jobCaption">Current claimable Agent Economy jobs</p>
+        </div>
+        <div class="jobs-actions">
+          <label>
+            <span>Category</span>
+            <select id="jobCategoryFilter">
+              <option value="all">All</option>
+            </select>
+          </label>
+          <code class="curl-chip">curl https://explorer.rustchain.org/agent/jobs</code>
+        </div>
+      </div>
+      <div class="lifecycle" aria-label="Job lifecycle">
+        <span>Posted</span>
+        <span>Claimed</span>
+        <span>Delivered</span>
+        <span>Completed</span>
+      </div>
+      <div id="jobList" class="job-list">
+        <p class="empty-state">Loading jobs...</p>
+      </div>
+    </section>
+  </main>
+  <script src="./app.js" defer></script>
+</body>
+</html>

--- a/block-explorer-dashboard/styles.css
+++ b/block-explorer-dashboard/styles.css
@@ -1,0 +1,595 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f7fb;
+  --panel: #ffffff;
+  --panel-strong: #eef3f6;
+  --text: #1f2933;
+  --muted: #657282;
+  --line: #d8e0e7;
+  --accent: #0f766e;
+  --accent-2: #365f91;
+  --warn: #b45309;
+  --danger: #b42318;
+  --success: #147a4b;
+  --gold: #a16207;
+  --shadow: 0 12px 32px rgba(31, 41, 51, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.shell {
+  width: min(1480px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
+
+.topbar {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 16px 0 20px;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: 2.65rem;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 6px;
+  font-size: 1.05rem;
+  letter-spacing: 0;
+}
+
+.muted,
+.panel-header p,
+.metric-tile small {
+  color: var(--muted);
+}
+
+.status-cluster,
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.health-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.health-badge.ok {
+  border-color: rgba(20, 122, 75, 0.28);
+  background: rgba(20, 122, 75, 0.08);
+  color: var(--success);
+}
+
+.health-badge.warn {
+  border-color: rgba(180, 83, 9, 0.28);
+  background: rgba(180, 83, 9, 0.08);
+  color: var(--warn);
+}
+
+.primary-action {
+  min-height: 38px;
+  padding: 0 16px;
+  border: 1px solid #0b615a;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.primary-action:disabled {
+  cursor: progress;
+  opacity: 0.75;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.metric-tile,
+.panel,
+.error-panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.metric-tile {
+  min-height: 118px;
+  padding: 18px;
+  display: grid;
+  align-content: space-between;
+  gap: 8px;
+}
+
+.metric-label {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.metric-tile strong {
+  overflow-wrap: anywhere;
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.error-panel {
+  margin-bottom: 16px;
+  padding: 12px 14px;
+  border-color: rgba(180, 35, 24, 0.3);
+  background: #fff7f5;
+  color: var(--danger);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 16px;
+  align-items: start;
+}
+
+.panel {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(180deg, #fff, var(--panel-strong));
+}
+
+.panel-header.compact {
+  align-items: center;
+  padding-bottom: 12px;
+}
+
+.panel-header p {
+  margin-bottom: 0;
+  font-size: 0.9rem;
+}
+
+.controls label {
+  display: grid;
+  gap: 4px;
+  min-width: 136px;
+}
+
+.controls span,
+.jobs-actions span,
+.lookup-box span {
+  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.controls input,
+.controls select,
+.jobs-actions select,
+.lookup-box input {
+  width: 100%;
+  min-height: 36px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--text);
+  padding: 0 10px;
+}
+
+.table-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  min-width: 860px;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+th {
+  color: var(--muted);
+  font-size: 0.76rem;
+  text-transform: uppercase;
+}
+
+td {
+  font-size: 0.92rem;
+}
+
+tbody tr:hover {
+  background: #f8fbfd;
+}
+
+.miner-id {
+  display: block;
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.subtle {
+  display: block;
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 0 9px;
+  border-radius: 999px;
+  background: #e7f3f1;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.badge.power {
+  background: #fff6df;
+  color: var(--gold);
+}
+
+.badge.modern {
+  background: #e9f0fb;
+  color: var(--accent-2);
+}
+
+.multiplier {
+  display: grid;
+  gap: 6px;
+  min-width: 130px;
+}
+
+.multiplier-track {
+  height: 8px;
+  border-radius: 999px;
+  background: #e8eef3;
+  overflow: hidden;
+}
+
+.multiplier-fill {
+  display: block;
+  height: 100%;
+  width: var(--fill, 0%);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent), var(--gold));
+}
+
+.status-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 800;
+}
+
+.status-dot::before {
+  content: "";
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--warn);
+}
+
+.status-dot.online::before {
+  background: var(--success);
+  box-shadow: 0 0 0 4px rgba(20, 122, 75, 0.12);
+}
+
+.empty-cell,
+.empty-state {
+  color: var(--muted);
+  text-align: center;
+}
+
+.side-stack {
+  display: grid;
+  gap: 16px;
+}
+
+.bar-list {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 1fr) 64px;
+  gap: 10px;
+  align-items: center;
+}
+
+.bar-name {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--text);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.bar-rail {
+  grid-column: 1 / -1;
+  height: 9px;
+  border-radius: 999px;
+  background: #e8eef3;
+  overflow: hidden;
+}
+
+.bar-fill {
+  display: block;
+  height: 100%;
+  width: var(--fill, 0%);
+  border-radius: inherit;
+  background: var(--accent-2);
+}
+
+.compact-bars .bar-fill {
+  background: var(--accent);
+}
+
+.lookup-box {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 0 16px 16px;
+}
+
+.lookup-box label {
+  display: grid;
+  gap: 4px;
+}
+
+.lookup-box button {
+  align-self: end;
+  min-height: 36px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--accent-2);
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.lookup-result {
+  grid-column: 1 / -1;
+  min-height: 42px;
+  margin: 0;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fbfdfe;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.stats-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  background: var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.stats-list div {
+  min-height: 72px;
+  padding: 12px;
+  background: #fff;
+}
+
+.stats-list dt {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.stats-list dd {
+  margin: 6px 0 0;
+  font-size: 1.24rem;
+  font-weight: 900;
+}
+
+.jobs-panel {
+  margin-top: 16px;
+}
+
+.curl-chip {
+  align-self: center;
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #f9fbfc;
+  color: var(--accent-2);
+  font-size: 0.8rem;
+}
+
+.jobs-actions {
+  display: flex;
+  align-items: end;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.jobs-actions label {
+  display: grid;
+  gap: 4px;
+  min-width: 160px;
+}
+
+.lifecycle {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  border-bottom: 1px solid var(--line);
+  background: var(--line);
+}
+
+.lifecycle span {
+  min-height: 44px;
+  display: grid;
+  place-items: center;
+  background: #fff;
+  color: var(--muted);
+  font-size: 0.84rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.job-list {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+}
+
+.job-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfdfe;
+}
+
+.job-row strong {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.job-row small {
+  color: var(--muted);
+}
+
+@media (max-width: 1120px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .side-stack {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .shell {
+    width: min(100vw - 20px, 760px);
+  }
+
+  .topbar,
+  .panel-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .metrics-grid,
+  .side-stack {
+    grid-template-columns: 1fr;
+  }
+
+  .controls {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .status-cluster {
+    align-items: stretch;
+  }
+
+  .primary-action,
+  .health-badge {
+    justify-content: center;
+  }
+
+  .jobs-actions {
+    justify-content: stretch;
+  }
+}
+
+@media (max-width: 540px) {
+  .controls,
+  .lifecycle,
+  .job-row,
+  .lookup-box {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dependency-free static block explorer dashboard
- implement miner metrics, architecture badges, multiplier bars, attestation status, filters, sorting, and 30-second refresh cadence
- add Agent Economy stats, category bars, job lifecycle view, job category filtering, and wallet reputation lookup
- document local serving, API endpoints, and read-only behavior

## Validation
- `node --check block-explorer-dashboard\app.js`
- `git diff --check -- block-explorer-dashboard`
- verified live explorer API shapes for `/api/miners`, `/agent/jobs`, `/agent/stats`, and `/agent/reputation/{wallet}`
- verified `/api/miners` returns `Access-Control-Allow-Origin: *` for static dashboard fetches

Wallet/miner id: `eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9`

Fixes #686