### PR TITLE
Complete vintage hardware museum

### DIFF
--- a/museum/README.md
+++ b/museum/README.md
@@ -1,0 +1,41 @@
+# RustChain Vintage Hardware Museum 3D
+
+Issue: [#65](https://github.com/Scottcjn/rustchain-bounties/issues/65)
+
+This folder contains a static Three.js museum for RustChain proof-of-antiquity hardware.
+
+## Implemented Scope
+
+- Full-screen WebGL exhibit built with Three.js.
+- Procedural 3D exhibits for:
+  - PowerBook G4 collection.
+  - Power Mac G4 MDD + G5 Dual.
+  - IBM POWER8 S824 centerpiece.
+  - Dell C4130 GPU cluster.
+  - 486/386 laptops and SPARCstations.
+- Keyboard movement and pointer look.
+- Mobile touch movement controls.
+- Click/tap exhibit inspection panel.
+- Live read-only miner fetch from `https://explorer.rustchain.org/api/miners`.
+- Green glow and ring state for exhibits with matching active miner data.
+- Responsive HUD with total miners, active miners, and vintage miner count.
+
+## Files
+
+- `index.html` - static entry point and import map.
+- `styles.css` - HUD, detail panel, and mobile controls.
+- `museum.mjs` - Three.js scene, procedural exhibit models, movement, raycast interaction, and live API mapping.
+
+## Local Validation
+
+The Three.js import map loads from a CDN, so serve the folder over HTTP:
+
+```powershell
+python -m http.server 8080
+```
+
+Then open `http://localhost:8080/museum/`.
+
+## Notes
+
+The app is read-only and does not request wallet secrets, private keys, or write credentials. It uses the explorer miners API to map live data onto the closest matching exhibit by architecture, miner name, family, or hardware type.

--- a/museum/index.html
+++ b/museum/index.html
@@ -1,309 +1,63 @@
-<!-- SPDX-License-Identifier: MIT -->
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <title>RustChain Vintage Hardware Museum 3D</title>
-    <style>
-        body { margin: 0; overflow: hidden; background-color: #000; font-family: 'Courier New', Courier, monospace; }
-        canvas { display: block; }
-        #ui {
-            position: absolute;
-            bottom: 20px;
-            left: 20px;
-            color: white;
-            pointer-events: none;
-            text-shadow: 1px 1px 2px black;
-            font-size: 1.2em;
-            z-index: 5;
-        }
-        #info {
-            position: absolute;
-            top: 20px;
-            right: 20px;
-            width: 320px;
-            background: rgba(0, 20, 0, 0.85);
-            color: #0f0;
-            border: 1px solid #0f0;
-            padding: 15px;
-            display: none;
-            font-family: monospace;
-            border-radius: 4px;
-            box-shadow: 0 0 10px #0f0;
-            z-index: 5;
-        }
-        #info h2 { margin-top: 0; font-size: 1.2em; border-bottom: 1px solid #0f0; padding-bottom: 5px; }
-        #crosshair {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            width: 10px;
-            height: 10px;
-            transform: translate(-50%, -50%);
-            color: rgba(255, 255, 255, 0.5);
-            font-size: 24px;
-            pointer-events: none;
-            z-index: 5;
-        }
-        #start-screen {
-            position: absolute;
-            top: 0; left: 0; width: 100%; height: 100%;
-            background: rgba(0,0,0,0.9);
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            color: white;
-            z-index: 10;
-            text-align: center;
-        }
-        #start-screen h1 { color: #0f0; }
-        button {
-            padding: 15px 30px;
-            font-size: 1.2em;
-            background: #0f0;
-            color: #000;
-            border: none;
-            border-radius: 5px;
-            cursor: pointer;
-            margin-top: 20px;
-            font-weight: bold;
-            text-transform: uppercase;
-        }
-        button:hover { background: #5f5; box-shadow: 0 0 15px #0f0; }
-    </style>
-    <!-- Import map for Three.js -->
-    <script type="importmap">
-        {
-            "imports": {
-                "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-                "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/"
-            }
-        }
-    </script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>RustChain Vintage Hardware Museum</title>
+  <link rel="stylesheet" href="./styles.css">
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://unpkg.com/three@0.160.0/build/three.module.js"
+      }
+    }
+  </script>
 </head>
 <body>
-    <div id="start-screen">
-        <h1>Vintage Hardware Museum 3D</h1>
-        <p>Proof-of-Antiquity: Real hardware mining RTC</p>
-        <p>Controls: WASD + Mouse to Move/Look, Mobile Touch to Move, Click to Interact.</p>
-        <button id="start-btn">Enter Exhibit</button>
+  <div id="sceneRoot" class="scene-root" aria-label="RustChain vintage hardware museum"></div>
+
+  <header class="hud">
+    <div>
+      <p class="eyebrow">Proof-of-Antiquity</p>
+      <h1>Vintage Hardware Museum</h1>
     </div>
-    <div id="crosshair">+</div>
-    <div id="ui">WASD: Move | Click: Live Node Data</div>
-    <div id="info">
-        <h2 id="info-title">Machine Info</h2>
-        <div id="info-content">Connecting...</div>
-    </div>
+    <dl class="hud-stats">
+      <div>
+        <dt>Miners</dt>
+        <dd id="minerTotal">0</dd>
+      </div>
+      <div>
+        <dt>Active</dt>
+        <dd id="activeTotal">0</dd>
+      </div>
+      <div>
+        <dt>Vintage</dt>
+        <dd id="vintageTotal">0</dd>
+      </div>
+    </dl>
+  </header>
 
-    <script type="module">
-        import * as THREE from 'three';
-        import { PointerLockControls } from 'three/addons/controls/PointerLockControls.js';
-        import { VRButton } from 'three/addons/webxr/VRButton.js';
+  <aside id="detailPanel" class="detail-panel" aria-live="polite">
+    <button id="closePanel" class="icon-button" type="button" aria-label="Close detail panel">x</button>
+    <p id="detailKicker" class="eyebrow">Select Exhibit</p>
+    <h2 id="detailTitle">Hardware</h2>
+    <p id="detailSummary">Choose an exhibit to inspect live miner status and antiquity data.</p>
+    <dl id="detailStats" class="detail-stats"></dl>
+  </aside>
 
-        // Scene Setup
-        const scene = new THREE.Scene();
-        scene.background = new THREE.Color(0x0a0a0c);
-        scene.fog = new THREE.FogExp2(0x0a0a0c, 0.04);
+  <footer class="dock">
+    <button id="enterBtn" class="primary-action" type="button">Enter Museum</button>
+    <span id="apiStatus" class="status-pill pending">Loading API</span>
+    <span id="selectedLabel" class="selected-label">No exhibit selected</span>
+  </footer>
 
-        const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 100);
-        camera.position.set(0, 1.6, 10);
+  <nav class="mobile-pad" aria-label="Touch movement">
+    <button type="button" data-move="forward">N</button>
+    <button type="button" data-move="left">W</button>
+    <button type="button" data-move="back">S</button>
+    <button type="button" data-move="right">E</button>
+  </nav>
 
-        const renderer = new THREE.WebGLRenderer({ antialias: true });
-        renderer.setSize(window.innerWidth, window.innerHeight);
-        renderer.shadowMap.enabled = true;
-        renderer.xr.enabled = true; // WebXR (VR) Support
-        document.body.appendChild(renderer.domElement);
-        document.body.appendChild(VRButton.createButton(renderer));
-
-        // Controls
-        const controls = new PointerLockControls(camera, document.body);
-        const startScreen = document.getElementById('start-screen');
-        const startBtn = document.getElementById('start-btn');
-        
-        // Audio Context Setup
-        let audioCtx;
-        startBtn.addEventListener('click', () => {
-            if (!audioCtx) {
-                audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-                // Ambient Server Room Hum
-                const osc = audioCtx.createOscillator();
-                osc.type = 'sine';
-                osc.frequency.value = 60;
-                const gain = audioCtx.createGain();
-                gain.gain.value = 0.05;
-                osc.connect(gain);
-                gain.connect(audioCtx.destination);
-                osc.start();
-            }
-            controls.lock();
-        });
-
-        controls.addEventListener('lock', () => startScreen.style.display = 'none');
-        controls.addEventListener('unlock', () => startScreen.style.display = 'flex');
-        scene.add(controls.getObject());
-
-        // Lighting
-        const ambientLight = new THREE.AmbientLight(0xffffff, 0.2);
-        scene.add(ambientLight);
-
-        const spotlights = [
-            [-10, 5, -10], [-5, 5, -10], [0, 6, -5], [5, 5, -10], [10, 5, -10]
-        ];
-        spotlights.forEach(pos => {
-            const spot = new THREE.PointLight(0xaaaaaa, 0.8, 15);
-            spot.position.set(...pos);
-            spot.castShadow = true;
-            scene.add(spot);
-        });
-
-        // Environment geometry
-        const floorGeo = new THREE.PlaneGeometry(60, 60);
-        const floorMat = new THREE.MeshStandardMaterial({ color: 0x111111, roughness: 0.8 });
-        const floor = new THREE.Mesh(floorGeo, floorMat);
-        floor.rotation.x = -Math.PI / 2;
-        floor.receiveShadow = true;
-        scene.add(floor);
-
-        // Exhibits
-        const interactables = [];
-        const exhibitData = [
-            { id: "powerbook_g4", title: "PowerBook G4 Collection", desc: "2.5x Antiquity Multiplier", pos: [-10, 1, -10], color: 0xaaaaaa, scale: [1.2, 0.1, 1.0] },
-            { id: "powermac_g4g5", title: "Power Mac G4 MDD + G5 Dual", desc: "Classic Architecture", pos: [-5, 1, -10], color: 0x8899aa, scale: [0.8, 1.8, 1.5] },
-            { id: "power8_s824", title: "IBM POWER8 S824", desc: "128 Threads, 512GB RAM", pos: [0, 1.5, -5], color: 0x1a1a1a, scale: [2.0, 2.5, 3.0] },
-            { id: "dell_c4130", title: "Dell C4130 GPU Cluster", desc: "High Density Compute", pos: [5, 1, -10], color: 0x333333, scale: [1.5, 0.4, 2.0] },
-            { id: "retro_laptops", title: "486/386 & SPARCstations", desc: "Vintage Silicon", pos: [10, 1, -10], color: 0xcccccc, scale: [1.0, 0.2, 1.0] }
-        ];
-
-        exhibitData.forEach(data => {
-            // Pedestal
-            const pedGeo = new THREE.BoxGeometry(data.scale[0]*1.4, data.pos[1], data.scale[2]*1.4);
-            const pedMat = new THREE.MeshStandardMaterial({ color: 0x222222 });
-            const ped = new THREE.Mesh(pedGeo, pedMat);
-            ped.position.set(data.pos[0], data.pos[1]/2, data.pos[2]);
-            ped.receiveShadow = true;
-            scene.add(ped);
-
-            // Machine Mesh
-            const geo = new THREE.BoxGeometry(...data.scale);
-            const mat = new THREE.MeshStandardMaterial({ color: data.color, roughness: 0.4, metalness: 0.6 });
-            const mesh = new THREE.Mesh(geo, mat);
-            mesh.position.set(data.pos[0], data.pos[1] + data.scale[1]/2, data.pos[2]);
-            mesh.castShadow = true;
-            mesh.userData = { id: data.id, title: data.title, desc: data.desc };
-            scene.add(mesh);
-            interactables.push(mesh);
-
-            // Glow Light (Hidden initially)
-            const glow = new THREE.PointLight(0x00ff00, 0, 4);
-            glow.position.copy(mesh.position);
-            scene.add(glow);
-            mesh.userData.glowLight = glow;
-
-            // Placard Canvas
-            const ctx = document.createElement('canvas').getContext('2d');
-            ctx.canvas.width = 512; ctx.canvas.height = 256;
-            ctx.fillStyle = '#0a0a0a'; ctx.fillRect(0,0,512,256);
-            ctx.strokeStyle = '#0f0'; ctx.lineWidth = 10; ctx.strokeRect(0,0,512,256);
-            ctx.fillStyle = '#0f0'; ctx.font = 'bold 36px monospace'; ctx.textAlign = 'center';
-            ctx.fillText(data.title, 256, 100);
-            ctx.font = '24px monospace'; ctx.fillStyle = '#fff';
-            ctx.fillText(data.desc, 256, 160);
-            
-            const tex = new THREE.CanvasTexture(ctx.canvas);
-            const pMesh = new THREE.Mesh(new THREE.PlaneGeometry(1.2, 0.6), new THREE.MeshBasicMaterial({ map: tex }));
-            pMesh.position.set(data.pos[0], data.pos[1] + 0.5, data.pos[2] + data.scale[2]/2 + 0.71);
-            scene.add(pMesh);
-        });
-
-        // Movement logic
-        const move = { f: false, b: false, l: false, r: false };
-        const velocity = new THREE.Vector3();
-        const direction = new THREE.Vector3();
-
-        document.addEventListener('keydown', e => {
-            if(e.code==='KeyW'||e.code==='ArrowUp') move.f=true;
-            if(e.code==='KeyS'||e.code==='ArrowDown') move.b=true;
-            if(e.code==='KeyA'||e.code==='ArrowLeft') move.l=true;
-            if(e.code==='KeyD'||e.code==='ArrowRight') move.r=true;
-        });
-        document.addEventListener('keyup', e => {
-            if(e.code==='KeyW'||e.code==='ArrowUp') move.f=false;
-            if(e.code==='KeyS'||e.code==='ArrowDown') move.b=false;
-            if(e.code==='KeyA'||e.code==='ArrowLeft') move.l=false;
-            if(e.code==='KeyD'||e.code==='ArrowRight') move.r=false;
-        });
-
-        // Mobile touch logic
-        let touchX, touchY;
-        document.addEventListener('touchstart', e => {
-            if(e.touches.length > 0) {
-                touchX = e.touches[0].clientX;
-                touchY = e.touches[0].clientY;
-                triggerRaycastInteraction(); // Tap to interact fallback for mobile
-            }
-        });
-        document.addEventListener('touchmove', e => {
-            if(e.touches.length > 0) {
-                camera.rotation.order = 'YXZ';
-                const dx = e.touches[0].clientX - touchX;
-                const dy = e.touches[0].clientY - touchY;
-                camera.rotation.y -= dx * 0.005;
-                camera.rotation.x -= dy * 0.005;
-                touchX = e.touches[0].clientX;
-                touchY = e.touches[0].clientY;
-            }
-        });
-
-        // Interaction
-        const raycaster = new THREE.Raycaster();
-        
-        async function triggerRaycastInteraction() {
-            if (!controls.isLocked && !renderer.xr.isPresenting && window.innerWidth > 800) return;
-            raycaster.setFromCamera(new THREE.Vector2(0,0), camera);
-            const intersects = raycaster.intersectObjects(interactables);
-            if (intersects.length > 0) {
-                const obj = intersects[0].object;
-                document.getElementById('info').style.display = 'block';
-                document.getElementById('info-title').innerText = obj.userData.title;
-                const content = document.getElementById('info-content');
-                content.innerHTML = "Querying Live API<br>https://50.28.86.131/api/miners...";
-
-                // Beep Sound Effect
-                if(audioCtx) {
-                    const beep = audioCtx.createOscillator();
-                    beep.type = 'square'; beep.frequency.value = 880;
-                    beep.connect(audioCtx.destination);
-                    beep.start(); beep.stop(audioCtx.currentTime + 0.1);
-                }
-
-                try {
-                    const res = await fetch('https://50.28.86.131/api/miners');
-                    const data = await res.json();
-                    const miner = Array.isArray(data) ? data.find(m => m.id === obj.userData.id) : null;
-                    content.innerHTML = `Network Status: <span style="color:#0f0">ACTIVE</span><br>Multiplier: ${obj.userData.desc}<br>Sync: OK`;
-                    
-                    // Green Glow Effect
-                    obj.userData.glowLight.intensity = 5;
-                    obj.material.emissive.setHex(0x004400);
-                    setTimeout(() => { obj.userData.glowLight.intensity = 0; obj.material.emissive.setHex(0x000000); }, 3000);
-                } catch (e) {
-                    // Display error if CORS/Down but trigger animation anyway for Demo
-                    content.innerHTML = `<span style="color:yellow">Simulated Active Data</span><br>Multiplier: ${obj.userData.desc}<br>(Live API unreachable)`;
-                    obj.userData.glowLight.intensity = 5;
-                    obj.material.emissive.setHex(0x004400);
-                    setTimeout(() => { obj.userData.glowLight.intensity = 0; obj.material.emissive.setHex(0x000000); }, 3000);
-                }
-            }
-        }
-        document.addEventListener('mousedown', triggerRaycastInteraction);
-
-        let prevTime = performance.now();
-        renderer.setAnimationLoop(() => {
-            const time = performance.now();
-            const delta = (time - prevTime) / 1000;
-
-            if (controls.isLocked) {
-                velocity.x -= velocity.x * 10.0 * delta;
-                velocity.z -= velocity.z * 10.0 * delta;
+  <script type="module" src="./museum.mjs"></script>
+</body>
+</html>

--- a/museum/museum.mjs
+++ b/museum/museum.mjs
@@ -1,0 +1,507 @@
+import * as THREE from "three";
+
+const API_URL = "https://explorer.rustchain.org/api/miners";
+const ACTIVE_WINDOW_SECONDS = 300;
+
+const exhibits = [
+  {
+    id: "powerbook-g4",
+    title: "PowerBook G4 Collection",
+    summary: "Portable PowerPC machines representing the highest-antiquity laptop story.",
+    multiplier: "2.5x target",
+    keywords: ["g4", "powerbook", "powerpc"],
+    position: [-10, 0, -8],
+    accent: 0xe2e8f0,
+    build: "laptop",
+  },
+  {
+    id: "powermac-g4-g5",
+    title: "Power Mac G4 MDD + G5 Dual",
+    summary: "Tower-era Apple hardware with a visible repair-and-reuse path.",
+    multiplier: "2.0x target",
+    keywords: ["g5", "g4", "powerpc"],
+    position: [-5, 0, -11],
+    accent: 0xb8c2cc,
+    build: "tower",
+  },
+  {
+    id: "power8-s824",
+    title: "IBM POWER8 S824",
+    summary: "Centerpiece enterprise system: 128 threads, 512GB RAM, active RustChain proof anchor.",
+    multiplier: "2.0x live",
+    keywords: ["power8", "s824", "sophia"],
+    position: [0, 0, -7],
+    accent: 0x2f3d4d,
+    build: "rack",
+  },
+  {
+    id: "dell-c4130",
+    title: "Dell C4130 GPU Cluster",
+    summary: "Dense accelerator hardware for modern compute comparison inside the antiquity museum.",
+    multiplier: "modern cluster",
+    keywords: ["dell", "gpu", "c4130"],
+    position: [5, 0, -11],
+    accent: 0x4b5563,
+    build: "cluster",
+  },
+  {
+    id: "retro-lab",
+    title: "486/386 Laptops + SPARCstations",
+    summary: "Early-era machines grouped as the long-tail proof collection.",
+    multiplier: "deep vintage",
+    keywords: ["486", "386", "sparc", "retro"],
+    position: [10, 0, -8],
+    accent: 0xd6d3d1,
+    build: "shelf",
+  },
+];
+
+const sceneRoot = document.querySelector("#sceneRoot");
+const enterBtn = document.querySelector("#enterBtn");
+const apiStatus = document.querySelector("#apiStatus");
+const selectedLabel = document.querySelector("#selectedLabel");
+const minerTotal = document.querySelector("#minerTotal");
+const activeTotal = document.querySelector("#activeTotal");
+const vintageTotal = document.querySelector("#vintageTotal");
+const detailPanel = document.querySelector("#detailPanel");
+const detailKicker = document.querySelector("#detailKicker");
+const detailTitle = document.querySelector("#detailTitle");
+const detailSummary = document.querySelector("#detailSummary");
+const detailStats = document.querySelector("#detailStats");
+const closePanel = document.querySelector("#closePanel");
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x080b10);
+scene.fog = new THREE.Fog(0x080b10, 16, 54);
+
+const camera = new THREE.PerspectiveCamera(64, window.innerWidth / window.innerHeight, 0.1, 120);
+camera.position.set(0, 2.2, 8);
+camera.rotation.order = "YXZ";
+
+const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: "high-performance" });
+renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+renderer.domElement.tabIndex = 0;
+sceneRoot.appendChild(renderer.domElement);
+
+const clock = new THREE.Clock();
+const raycaster = new THREE.Raycaster();
+const pointer = new THREE.Vector2();
+const keys = new Set();
+const touchMoves = new Set();
+const exhibitGroups = new Map();
+const interactables = [];
+let yaw = 0;
+let pitch = -0.04;
+let dragging = false;
+let lastPointer = { x: 0, y: 0 };
+let pointerTravel = 0;
+let minerData = [];
+let selectedExhibit = null;
+
+setupLighting();
+buildMuseum();
+bindEvents();
+loadMinerData();
+setInterval(loadMinerData, 30000);
+renderer.setAnimationLoop(animate);
+
+function setupLighting() {
+  scene.add(new THREE.HemisphereLight(0xaecfff, 0x1f2933, 0.72));
+
+  const key = new THREE.DirectionalLight(0xffffff, 1.6);
+  key.position.set(-8, 14, 8);
+  key.castShadow = true;
+  key.shadow.mapSize.set(2048, 2048);
+  scene.add(key);
+
+  [
+    [-12, 5, -10, 0xe3b34f],
+    [0, 6, -6, 0x73a7ff],
+    [12, 5, -10, 0x32d17d],
+  ].forEach(([x, y, z, color]) => {
+    const light = new THREE.PointLight(color, 1.2, 18);
+    light.position.set(x, y, z);
+    scene.add(light);
+  });
+}
+
+function buildMuseum() {
+  const floor = new THREE.Mesh(
+    new THREE.PlaneGeometry(34, 30),
+    new THREE.MeshStandardMaterial({ color: 0x111821, roughness: 0.86, metalness: 0.08 })
+  );
+  floor.rotation.x = -Math.PI / 2;
+  floor.receiveShadow = true;
+  scene.add(floor);
+
+  const backWall = new THREE.Mesh(
+    new THREE.BoxGeometry(36, 8, 0.4),
+    new THREE.MeshStandardMaterial({ color: 0x151d27, roughness: 0.72 })
+  );
+  backWall.position.set(0, 4, -15);
+  backWall.receiveShadow = true;
+  scene.add(backWall);
+
+  for (let x = -15; x <= 15; x += 5) {
+    const guide = new THREE.Mesh(
+      new THREE.BoxGeometry(0.035, 0.03, 25),
+      new THREE.MeshBasicMaterial({ color: 0x2b3a48 })
+    );
+    guide.position.set(x, 0.015, -4);
+    scene.add(guide);
+  }
+
+  exhibits.forEach((exhibit) => buildExhibit(exhibit));
+}
+
+function buildExhibit(exhibit) {
+  const group = new THREE.Group();
+  group.position.set(...exhibit.position);
+  group.userData.exhibit = exhibit;
+
+  const pedestal = new THREE.Mesh(
+    new THREE.BoxGeometry(3.2, 0.72, 2.4),
+    new THREE.MeshStandardMaterial({ color: 0x202a34, roughness: 0.62, metalness: 0.2 })
+  );
+  pedestal.position.y = 0.36;
+  pedestal.castShadow = true;
+  pedestal.receiveShadow = true;
+  group.add(pedestal);
+
+  const ring = new THREE.Mesh(
+    new THREE.TorusGeometry(1.78, 0.025, 10, 96),
+    new THREE.MeshBasicMaterial({ color: 0x334155 })
+  );
+  ring.rotation.x = Math.PI / 2;
+  ring.position.y = 0.76;
+  group.add(ring);
+  group.userData.statusRing = ring;
+
+  const glow = new THREE.PointLight(0x32d17d, 0, 5);
+  glow.position.set(0, 2.1, 0);
+  group.add(glow);
+  group.userData.glow = glow;
+
+  const model = buildMachineModel(exhibit);
+  model.position.y = 1.05;
+  group.add(model);
+
+  const label = makeLabel(exhibit.title, exhibit.multiplier);
+  label.position.set(0, 2.75, 0.2);
+  group.add(label);
+
+  group.traverse((node) => {
+    if (node.isMesh) {
+      node.castShadow = true;
+      node.userData.exhibitId = exhibit.id;
+      interactables.push(node);
+    }
+  });
+
+  scene.add(group);
+  exhibitGroups.set(exhibit.id, group);
+}
+
+function buildMachineModel(exhibit) {
+  const group = new THREE.Group();
+  const material = new THREE.MeshStandardMaterial({
+    color: exhibit.accent,
+    roughness: 0.38,
+    metalness: 0.42,
+  });
+  const dark = new THREE.MeshStandardMaterial({ color: 0x0c1118, roughness: 0.5, metalness: 0.28 });
+  const glass = new THREE.MeshStandardMaterial({ color: 0x15263a, roughness: 0.2, metalness: 0.1, emissive: 0x031326 });
+
+  if (exhibit.build === "laptop") {
+    addBox(group, [1.8, 0.12, 1.1], [0, 0.1, 0], material);
+    addBox(group, [1.8, 1.05, 0.1], [0, 0.72, -0.54], material);
+    addBox(group, [1.55, 0.8, 0.04], [0, 0.72, -0.6], glass);
+  } else if (exhibit.build === "tower") {
+    addBox(group, [0.82, 1.85, 1.2], [-0.42, 0.92, 0], material);
+    addBox(group, [0.82, 1.85, 1.2], [0.52, 0.92, 0], material);
+    addVentStack(group, 0.52, 1.1);
+  } else if (exhibit.build === "rack") {
+    addBox(group, [2.35, 2.6, 1.35], [0, 1.3, 0], dark);
+    for (let row = 0; row < 6; row += 1) {
+      addBox(group, [1.88, 0.08, 0.05], [0, 0.38 + row * 0.36, 0.7], glass);
+    }
+  } else if (exhibit.build === "cluster") {
+    addBox(group, [2.35, 0.62, 1.45], [0, 0.54, 0], dark);
+    for (let slot = -3; slot <= 3; slot += 1) {
+      addBox(group, [0.18, 0.38, 1.2], [slot * 0.28, 0.62, 0], material);
+    }
+  } else {
+    addBox(group, [2.45, 1.6, 0.32], [0, 0.8, -0.35], dark);
+    [-0.8, 0, 0.8].forEach((x, index) => {
+      addBox(group, [0.62, 0.18, 0.72], [x, 0.42 + index * 0.35, 0.12], material);
+    });
+  }
+
+  return group;
+}
+
+function addBox(group, size, position, material) {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), material);
+  mesh.position.set(...position);
+  group.add(mesh);
+  return mesh;
+}
+
+function addVentStack(group, x, y) {
+  const ventMaterial = new THREE.MeshBasicMaterial({ color: 0x111827 });
+  for (let i = 0; i < 5; i += 1) {
+    const vent = new THREE.Mesh(new THREE.BoxGeometry(0.48, 0.035, 0.03), ventMaterial);
+    vent.position.set(x, y + i * 0.12, 0.62);
+    group.add(vent);
+  }
+}
+
+function makeLabel(title, subtitle) {
+  const canvas = document.createElement("canvas");
+  canvas.width = 768;
+  canvas.height = 320;
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = "rgba(9, 11, 16, 0.78)";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = "rgba(227, 179, 79, 0.82)";
+  ctx.lineWidth = 8;
+  ctx.strokeRect(8, 8, canvas.width - 16, canvas.height - 16);
+  ctx.fillStyle = "#eef5f8";
+  ctx.font = "700 44px Arial";
+  ctx.textAlign = "center";
+  wrapCanvasText(ctx, title, canvas.width / 2, 112, 640, 48);
+  ctx.fillStyle = "#e3b34f";
+  ctx.font = "700 32px Arial";
+  ctx.fillText(subtitle, canvas.width / 2, 240);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  const sprite = new THREE.Sprite(new THREE.SpriteMaterial({ map: texture, transparent: true }));
+  sprite.scale.set(3.1, 1.28, 1);
+  return sprite;
+}
+
+function wrapCanvasText(ctx, text, x, y, maxWidth, lineHeight) {
+  const words = text.split(" ");
+  let line = "";
+  let currentY = y;
+  words.forEach((word) => {
+    const test = `${line}${word} `;
+    if (ctx.measureText(test).width > maxWidth && line) {
+      ctx.fillText(line.trim(), x, currentY);
+      line = `${word} `;
+      currentY += lineHeight;
+    } else {
+      line = test;
+    }
+  });
+  ctx.fillText(line.trim(), x, currentY);
+}
+
+function bindEvents() {
+  window.addEventListener("resize", onResize);
+  window.addEventListener("keydown", (event) => keys.add(event.code));
+  window.addEventListener("keyup", (event) => keys.delete(event.code));
+
+  enterBtn.addEventListener("click", () => renderer.domElement.focus());
+  closePanel.addEventListener("click", () => {
+    selectedExhibit = null;
+    selectedLabel.textContent = "No exhibit selected";
+    detailPanel.classList.remove("active");
+  });
+
+  renderer.domElement.addEventListener("pointerdown", (event) => {
+    dragging = true;
+    lastPointer = { x: event.clientX, y: event.clientY };
+    pointerTravel = 0;
+    renderer.domElement.setPointerCapture(event.pointerId);
+  });
+  renderer.domElement.addEventListener("pointermove", (event) => {
+    if (!dragging) return;
+    const dx = event.clientX - lastPointer.x;
+    const dy = event.clientY - lastPointer.y;
+    pointerTravel += Math.abs(dx) + Math.abs(dy);
+    yaw -= dx * 0.004;
+    pitch = THREE.MathUtils.clamp(pitch - dy * 0.003, -1.2, 1.1);
+    lastPointer = { x: event.clientX, y: event.clientY };
+  });
+  renderer.domElement.addEventListener("pointerup", (event) => {
+    dragging = false;
+    if (pointerTravel < 7) selectFromPointer(event);
+  });
+
+  document.querySelectorAll("[data-move]").forEach((button) => {
+    const move = button.dataset.move;
+    button.addEventListener("pointerdown", () => touchMoves.add(move));
+    button.addEventListener("pointerup", () => touchMoves.delete(move));
+    button.addEventListener("pointerleave", () => touchMoves.delete(move));
+  });
+}
+
+async function loadMinerData() {
+  apiStatus.className = "status-pill pending";
+  apiStatus.textContent = "Loading API";
+  try {
+    const response = await fetch(API_URL, { cache: "no-store" });
+    if (!response.ok) throw new Error(`API ${response.status}`);
+    const payload = await response.json();
+    minerData = Array.isArray(payload) ? payload : payload.miners || [];
+    apiStatus.className = "status-pill live";
+    apiStatus.textContent = "Live API";
+  } catch (error) {
+    minerData = [];
+    apiStatus.className = "status-pill warn";
+    apiStatus.textContent = error.message;
+  }
+  updateExhibitStatus();
+}
+
+function updateExhibitStatus() {
+  const active = minerData.filter(isActiveMiner);
+  const vintage = minerData.filter((miner) => Number(miner.antiquity_multiplier || 0) > 1.2);
+  minerTotal.textContent = minerData.length;
+  activeTotal.textContent = active.length;
+  vintageTotal.textContent = vintage.length;
+
+  exhibits.forEach((exhibit) => {
+    const group = exhibitGroups.get(exhibit.id);
+    const match = findMinerForExhibit(exhibit);
+    const activeMatch = match && isActiveMiner(match);
+    group.userData.miner = match || null;
+    group.userData.glow.intensity = activeMatch ? 1.8 : 0.18;
+    group.userData.statusRing.material.color.set(activeMatch ? 0x32d17d : 0x52606d);
+  });
+
+  if (selectedExhibit) showDetails(selectedExhibit);
+}
+
+function findMinerForExhibit(exhibit) {
+  const scored = minerData
+    .map((miner) => ({ miner, score: scoreMiner(exhibit, miner) }))
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score || Number(b.miner.last_attest || 0) - Number(a.miner.last_attest || 0));
+  return scored[0]?.miner || null;
+}
+
+function scoreMiner(exhibit, miner) {
+  const text = [
+    miner.miner,
+    miner.device_arch,
+    miner.device_family,
+    miner.hardware_type,
+  ].join(" ").toLowerCase();
+  return exhibit.keywords.reduce((score, keyword) => score + (text.includes(keyword) ? 1 : 0), 0);
+}
+
+function isActiveMiner(miner) {
+  const last = Number(miner.last_attest || 0);
+  if (!last) return false;
+  return Math.max(0, Date.now() / 1000 - last) <= ACTIVE_WINDOW_SECONDS;
+}
+
+function selectFromPointer(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+  const hit = raycaster.intersectObjects(interactables, false)[0];
+  if (!hit) return;
+
+  const exhibit = exhibits.find((item) => item.id === hit.object.userData.exhibitId);
+  if (exhibit) showDetails(exhibit);
+}
+
+function showDetails(exhibit) {
+  selectedExhibit = exhibit;
+  const group = exhibitGroups.get(exhibit.id);
+  const miner = group?.userData.miner;
+  const status = miner ? (isActiveMiner(miner) ? "Active" : "Stale") : "No direct match";
+  selectedLabel.textContent = exhibit.title;
+  detailPanel.classList.add("active");
+  detailKicker.textContent = status;
+  detailTitle.textContent = exhibit.title;
+  detailSummary.textContent = exhibit.summary;
+  detailStats.innerHTML = renderStats([
+    ["Target multiplier", exhibit.multiplier],
+    ["Matched miner", miner?.miner || "No live miner mapped"],
+    ["Hardware", miner?.hardware_type || "Exhibit model"],
+    ["Architecture", miner?.device_arch || "Museum data"],
+    ["Last attest", miner ? relativeTime(miner.last_attest) : "Not available"],
+    ["API status", apiStatus.textContent],
+  ]);
+}
+
+function renderStats(rows) {
+  return rows.map(([label, value]) => `
+    <div>
+      <dt>${escapeHtml(label)}</dt>
+      <dd>${escapeHtml(value)}</dd>
+    </div>
+  `).join("");
+}
+
+function relativeTime(seconds) {
+  const value = Number(seconds || 0);
+  if (!value) return "unknown";
+  const diffSeconds = Math.round((value * 1000 - Date.now()) / 1000);
+  const abs = Math.abs(diffSeconds);
+  const units = [
+    ["day", 86400],
+    ["hour", 3600],
+    ["minute", 60],
+    ["second", 1],
+  ];
+  const [unit, size] = units.find(([, unitSeconds]) => abs >= unitSeconds) || units[3];
+  return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(Math.round(diffSeconds / size), unit);
+}
+
+function onResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+  const delta = Math.min(clock.getDelta(), 0.04);
+  updateCamera(delta);
+  const elapsed = clock.elapsedTime;
+  exhibitGroups.forEach((group) => {
+    const active = group.userData.glow.intensity > 1;
+    group.userData.glow.intensity = active ? 1.5 + Math.sin(elapsed * 3) * 0.55 : 0.18;
+    group.userData.statusRing.rotation.z += delta * 0.35;
+  });
+  renderer.render(scene, camera);
+}
+
+function updateCamera(delta) {
+  const speed = keys.has("ShiftLeft") || keys.has("ShiftRight") ? 8 : 4.2;
+  const forward = new THREE.Vector3(Math.sin(yaw), 0, Math.cos(yaw) * -1);
+  const right = new THREE.Vector3(Math.cos(yaw), 0, Math.sin(yaw));
+  const movement = new THREE.Vector3();
+
+  if (keys.has("KeyW") || keys.has("ArrowUp") || touchMoves.has("forward")) movement.add(forward);
+  if (keys.has("KeyS") || keys.has("ArrowDown") || touchMoves.has("back")) movement.sub(forward);
+  if (keys.has("KeyD") || keys.has("ArrowRight") || touchMoves.has("right")) movement.add(right);
+  if (keys.has("KeyA") || keys.has("ArrowLeft") || touchMoves.has("left")) movement.sub(right);
+
+  if (movement.lengthSq() > 0) {
+    movement.normalize().multiplyScalar(speed * delta);
+    camera.position.add(movement);
+    camera.position.x = THREE.MathUtils.clamp(camera.position.x, -16, 16);
+    camera.position.z = THREE.MathUtils.clamp(camera.position.z, -14, 11);
+  }
+
+  camera.rotation.y = yaw;
+  camera.rotation.x = pitch;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}

--- a/museum/museum.mjs
+++ b/museum/museum.mjs
@@ -9,7 +9,7 @@ const exhibits = [
     title: "PowerBook G4 Collection",
     summary: "Portable PowerPC machines representing the highest-antiquity laptop story.",
     multiplier: "2.5x target",
-    keywords: ["g4", "powerbook", "powerpc"],
+    keywords: ["powerbook", "powerbook g4", "powerbook_g4"],
     position: [-10, 0, -8],
     accent: 0xe2e8f0,
     build: "laptop",
@@ -19,7 +19,7 @@ const exhibits = [
     title: "Power Mac G4 MDD + G5 Dual",
     summary: "Tower-era Apple hardware with a visible repair-and-reuse path.",
     multiplier: "2.0x target",
-    keywords: ["g5", "g4", "powerpc"],
+    keywords: ["power mac", "powermac", "g4 mdd", "g5 dual", "powermac_g4", "powermac_g5"],
     position: [-5, 0, -11],
     accent: 0xb8c2cc,
     build: "tower",
@@ -392,6 +392,12 @@ function scoreMiner(exhibit, miner) {
     miner.device_family,
     miner.hardware_type,
   ].join(" ").toLowerCase();
+
+  if (exhibit.id === "powerbook-g4" || exhibit.id === "powermac-g4-g5") {
+    const isPower8 = text.includes("power8") || text.includes("s824");
+    if (isPower8) return 0;
+  }
+
   return exhibit.keywords.reduce((score, keyword) => score + (text.includes(keyword) ? 1 : 0), 0);
 }
 

--- a/museum/styles.css
+++ b/museum/styles.css
@@ -1,0 +1,303 @@
+:root {
+  color-scheme: dark;
+  --bg: #090b10;
+  --panel: rgba(12, 16, 22, 0.84);
+  --panel-strong: rgba(20, 27, 34, 0.92);
+  --line: rgba(201, 213, 225, 0.18);
+  --text: #eef5f8;
+  --muted: #a6b4c0;
+  --green: #32d17d;
+  --gold: #e3b34f;
+  --blue: #73a7ff;
+  --red: #ff7a6d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button {
+  font: inherit;
+}
+
+.scene-root,
+.scene-root canvas {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.hud {
+  position: fixed;
+  top: 18px;
+  left: 18px;
+  right: 18px;
+  z-index: 5;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  pointer-events: none;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: var(--gold);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: 2.45rem;
+  line-height: 1;
+  letter-spacing: 0;
+  text-shadow: 0 12px 30px rgba(0, 0, 0, 0.55);
+}
+
+.hud-stats,
+.detail-stats {
+  margin: 0;
+}
+
+.hud-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 92px);
+  gap: 8px;
+}
+
+.hud-stats div,
+.detail-stats div,
+.detail-panel,
+.dock {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.32);
+}
+
+.hud-stats div {
+  min-height: 70px;
+  padding: 11px;
+  border-radius: 8px;
+}
+
+dt {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+dd {
+  margin: 5px 0 0;
+  font-size: 1.4rem;
+  font-weight: 900;
+}
+
+.detail-panel {
+  position: fixed;
+  top: 118px;
+  right: 18px;
+  z-index: 6;
+  width: min(390px, calc(100vw - 36px));
+  max-height: calc(100vh - 190px);
+  overflow: auto;
+  padding: 18px;
+  border-radius: 8px;
+}
+
+.detail-panel h2 {
+  margin-bottom: 8px;
+  font-size: 1.35rem;
+  letter-spacing: 0;
+}
+
+.detail-panel p {
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.icon-button {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.detail-stats {
+  display: grid;
+  gap: 8px;
+}
+
+.detail-stats div {
+  padding: 10px;
+  border-radius: 7px;
+}
+
+.detail-stats dd {
+  overflow-wrap: anywhere;
+  font-size: 0.95rem;
+}
+
+.dock {
+  position: fixed;
+  left: 18px;
+  bottom: 18px;
+  z-index: 7;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: calc(100vw - 36px);
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.primary-action,
+.status-pill {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 6px;
+  font-weight: 800;
+}
+
+.primary-action {
+  border: 1px solid rgba(50, 209, 125, 0.72);
+  background: var(--green);
+  color: #08120d;
+  padding: 0 16px;
+  cursor: pointer;
+}
+
+.status-pill {
+  border: 1px solid var(--line);
+  padding: 0 12px;
+  color: var(--muted);
+}
+
+.status-pill.live {
+  border-color: rgba(50, 209, 125, 0.42);
+  color: var(--green);
+}
+
+.status-pill.warn {
+  border-color: rgba(255, 122, 109, 0.42);
+  color: var(--red);
+}
+
+.selected-label {
+  color: var(--muted);
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.mobile-pad {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 8;
+  display: none;
+  grid-template-columns: repeat(3, 44px);
+  grid-template-rows: repeat(2, 44px);
+  gap: 6px;
+}
+
+.mobile-pad button {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-strong);
+  color: var(--text);
+  font-weight: 900;
+}
+
+.mobile-pad [data-move="forward"] {
+  grid-column: 2;
+}
+
+.mobile-pad [data-move="left"] {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.mobile-pad [data-move="back"] {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.mobile-pad [data-move="right"] {
+  grid-column: 3;
+  grid-row: 2;
+}
+
+@media (max-width: 860px) {
+  .hud {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .hud-stats {
+    width: min(100%, 340px);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .detail-panel {
+    top: auto;
+    left: 12px;
+    right: 12px;
+    bottom: 86px;
+    width: auto;
+    max-height: 38vh;
+  }
+
+  .dock {
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    flex-wrap: wrap;
+  }
+
+  .mobile-pad {
+    display: grid;
+  }
+}
+
+@media (max-width: 560px) {
+  .hud-stats {
+    display: none;
+  }
+
+  .selected-label {
+    width: 100%;
+    white-space: normal;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the truncated museum page with a complete static Three.js exhibit
- add procedural 3D exhibits for PowerBook G4, Power Mac G4/G5, IBM POWER8 S824, Dell C4130, and 486/386/SPARC hardware
- add keyboard movement, pointer look, mobile touch controls, click/tap exhibit inspection, live miner API mapping, and active green glow state
- document local serving and API behavior in `museum/README.md`

## Validation
- `node --check museum\museum.mjs`
- `git diff --check -- museum`
- headless Edge render smoke test at 1440x900 created `C:\tmp\rustchain-museum-headless.png`
- screenshot grid sample: 3240 samples, 209 unique colors, 202 bright samples, confirming a nonblank rendered scene

Wallet/miner id: `eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9`

Fixes #65