### PR TITLE
fix(README.fr): repair broken badge/filter links

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -5,16 +5,16 @@
 
 ### Gagnez des RTC en contribuant à l'écosystème RustChain
 
-[![Récompenses Ouvertes](https://img.shields.io/github/issues/Scottcjn/rustchain-bounties/bounty?label=récompenses%20ouvertes&color=brightgreen)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
+[![Récompenses Ouvertes](https://img.shields.io/github/issues/Scottcjn/rustchain-bounties/bounty?label=r%C3%A9compenses%20ouvertes&color=brightgreen)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
 [![Étoiles](https://img.shields.io/github/stars/Scottcjn/rustchain-bounties?style=social)](https://github.com/Scottcjn/rustchain-bounties/stargazers)
 [![Pool RTC](https://img.shields.io/badge/Pool%20RTC-5%2C900%2B%20RTC-or)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
-[![BCOS](https://img.shields.io/badge/BCOS-Certifié%20L1-blue)](https://github.com/Scottcjn/RustChain)
+[![BCOS](https://img.shields.io/badge/BCOS-Certifi%C3%A9%20L1-blue)](https://github.com/Scottcjn/RustChain)
 
 **131 récompenses ouvertes · 5 900+ RTC disponibles · Aucune expérience requise pour de nombreuses missions**
 
-[![Total Versé](https://img.shields.io/badge/Total%20Versé-22%2C756%20RTC-or)](BOUNTY_LEDGER.md)
+[![Total Versé](https://img.shields.io/badge/Total%20Vers%C3%A9-22%2C756%20RTC-or)](BOUNTY_LEDGER.md)
 
-[Consulter Toutes les Récompenses](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty) · [Récompenses Faciles](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3A%22bonne%20première%20mission%22) · [Équipe Rouge](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Ared-team) · [**Comment Soumettre →**](docs/HOW_TO_SUBMIT_A_BOUNTY.md) · [Journal des Paiements](BOUNTY_LEDGER.md) · [Qu'est-ce que RustChain?](https://github.com/Scottcjn/RustChain)
+[Consulter Toutes les Récompenses](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty) · [Récompenses Faciles](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3A%22good%20first%20issue%22) · [Équipe Rouge](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Ared-team) · [**Comment Soumettre →**](docs/HOW_TO_SUBMIT_A_BOUNTY.md) · [Journal des Paiements](BOUNTY_LEDGER.md) · [Qu'est-ce que RustChain?](https://github.com/Scottcjn/RustChain)
 
 </div>
 


### PR DESCRIPTION
## Summary
This PR fixes broken links in `README.fr.md` by URL-encoding accented characters in Shields.io badge URLs and by correcting the “Récompenses Faciles” filter query.

### Changes
- Encode `récompenses` label in badge URL: `r%C3%A9compenses`
- Encode `Certifié` in BCOS badge URL: `Certifi%C3%A9`
- Encode `Versé` in total paid badge URL: `Vers%C3%A9`
- Fix “Récompenses Faciles” issue filter from non-existent French label (`"bonne première mission"`) to existing repo label (`"good first issue"`)

## Verify
I validated all links in `README.fr.md` after changes with `curl -L` and got HTTP < 400 for each URL.

## Limitations
- This PR only touches `README.fr.md` and only addresses link correctness in the header/quick-links section.

Closes #444
