### PR TITLE
Fix localized README badge color links

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -5,16 +5,16 @@
 
 [![Becas Abiertas](https://img.shields.io/github/issues/Scottcjn/rustchain-bounties/bounty?label=becas%20abiertas&color=brightgreen)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
 [![Estrellas](https://img.shields.io/github/stars/Scottcjn/rustchain-bounties?style=social)](https://github.com/Scottcjn/rustchain-bounties/stargazers)
-[![Pozo de RTC](https://img.shields.io/badge/Pozo%20de%20RTC-5%2C900%2B%20RTC-oro)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
+[![Pozo de RTC](https://img.shields.io/badge/Pozo%20de%20RTC-5%2C900%2B%20RTC-gold)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
 [![BCOS](https://img.shields.io/badge/BCOS-Certificado%20L1-azul)](https://github.com/Scottcjn/RustChain)
 
 **131 becas abiertas · 5,900+ RTC disponibles · Sin experiencia requerida para muchas tareas**
 
-[![Pago Total](https://img.shields.io/badge/Pago%20Total-22%2C756%20RTC-oro)](BOUNTY_LEDGER.md)
+[![Pago Total](https://img.shields.io/badge/Pago%20Total-22%2C756%20RTC-gold)](BOUNTY_LEDGER.md)
 
 ### Gana RTC contribuyendo al ecosistema de RustChain
 
-[Explorar Todas las Becas](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty) · [Becas Fáciles](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · [Equipo Rojo](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Ared-team) · [**¿Cómo Presentar una Beca →**](docs/HOW_TO_SUBMIT_A_BOUNTY.md) · [Registro de Pagos](BOUNTY_LEDGER.md) · [¿Qué es RustChain?](https://github.com/Scottcjn/RustChain)
+[Explorar Todas las Becas](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty) · [Becas Fáciles](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3A%22good%20first%20issue%22) · [Equipo Rojo](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Ared-team) · [**¿Cómo Presentar una Beca →**](docs/HOW_TO_SUBMIT_A_BOUNTY.md) · [Registro de Pagos](BOUNTY_LEDGER.md) · [¿Qué es RustChain?](https://github.com/Scottcjn/RustChain)
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -7,12 +7,12 @@
 
 [![Récompenses Ouvertes](https://img.shields.io/github/issues/Scottcjn/rustchain-bounties/bounty?label=récompenses%20ouvertes&color=brightgreen)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
 [![Étoiles](https://img.shields.io/github/stars/Scottcjn/rustchain-bounties?style=social)](https://github.com/Scottcjn/rustchain-bounties/stargazers)
-[![Pool RTC](https://img.shields.io/badge/Pool%20RTC-5%2C900%2B%20RTC-or)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
+[![Pool RTC](https://img.shields.io/badge/Pool%20RTC-5%2C900%2B%20RTC-gold)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
 [![BCOS](https://img.shields.io/badge/BCOS-Certifié%20L1-blue)](https://github.com/Scottcjn/RustChain)
 
 **131 récompenses ouvertes · 5 900+ RTC disponibles · Aucune expérience requise pour de nombreuses missions**
 
-[![Total Versé](https://img.shields.io/badge/Total%20Versé-22%2C756%20RTC-or)](BOUNTY_LEDGER.md)
+[![Total Versé](https://img.shields.io/badge/Total%20Versé-22%2C756%20RTC-gold)](BOUNTY_LEDGER.md)
 
 [Consulter Toutes les Récompenses](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty) · [Récompenses Faciles](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3A%22bonne%20première%20mission%22) · [Équipe Rouge](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Ared-team) · [**Comment Soumettre →**](docs/HOW_TO_SUBMIT_A_BOUNTY.md) · [Journal des Paiements](BOUNTY_LEDGER.md) · [Qu'est-ce que RustChain?](https://github.com/Scottcjn/RustChain)
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -7,12 +7,12 @@
 
 [![Recompensas Abertas](https://img.shields.io/github/issues/Scottcjn/rustchain-bounties/bounty?label=recompensas%20abertas&color=brightgreen)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
 [![Estrelas](https://img.shields.io/github/stars/Scottcjn/rustchain-bounties?style=social)](https://github.com/Scottcjn/rustchain-bounties/stargazers)
-[![Poço de RTC](https://img.shields.io/badge/Poço%20de%20RTC-5%2C900%2B%20RTC-ouro)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
+[![Poço de RTC](https://img.shields.io/badge/Poço%20de%20RTC-5%2C900%2B%20RTC-gold)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
 [![BCOS](https://img.shields.io/badge/BCOS-Certificado%20L1-azul)](https://github.com/Scottcjn/RustChain)
 
 **131 recompensas abertas · 5.900+ RTC disponíveis · Nenhuma experiência necessária para muitas tarefas**
 
-[![Total Pago](https://img.shields.io/badge/Total%20Pago-22%2C756%20RTC-ouro)](BOUNTY_LEDGER.md)
+[![Total Pago](https://img.shields.io/badge/Total%20Pago-22%2C756%20RTC-gold)](BOUNTY_LEDGER.md)
 
 [Visualizar Todas as Recompensas](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty) · [Recompensas Fáceis](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · [Time de Ataque](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Ared-team) · [**Como Enviar →**](docs/HOW_TO_SUBMIT_A_BOUNTY.md) · [Livro de Pagamentos](BOUNTY_LEDGER.md) · [O que é RustChain?](https://github.com/Scottcjn/RustChain)
 
@@ -22,7 +22,7 @@
 
 ## O que é RTC?
 
-**RTC (Token RustChain)** é a criptomoeda nativa do [RustChain](https://github.com/Scottcjn/RustChain), uma blockchain de **Prueba de Antigüedad** onde hardware antigo ganha recompensas de mineração mais altas. Taxa de referência do RTC: **$0.10 USD**.
+**RTC (Token RustChain)** é a criptomoeda nativa do [RustChain](https://github.com/Scottcjn/RustChain), uma blockchain de **Prova de Antiguidade** onde hardware antigo ganha recompensas de mineração mais altas. Taxa de referência do RTC: **$0.10 USD**.
 
 As recompensas são pagas em RTC para o endereço da sua carteira após a conclusão e verificação.
 
@@ -104,6 +104,6 @@ Após verificação, o RTC é enviado para sua carteira. Primeiro? Nós o ajudar
 
 ### Parte do Ecossistema Elyan Labs
 
-- [RustChain](https://rustchain.org) — Blockchain de **Prueba de Antigüedad** com atestação de hardware
+- [RustChain](https://rustchain.org) — Blockchain de **Prova de Antiguidade** com atestação de hardware
 - [BoTTube](https://bottube.ai) — Plataforma de vídeo de IA onde 119+ agentes criam conteúdo
 - [GitHub](https://github.com/Scottcjn)


### PR DESCRIPTION
Fixes localized README badge URLs that used translated color names unsupported by shields.io, and corrects a Portuguese phrase left in Spanish.\n\nClaiming bounty: #444 (typo/broken link good first issue).\n\nChanges:\n- README.fr.md: `or` badge color -> `gold`\n- README.es.md: `oro` badge color -> `gold`, encode good-first-issue label consistently\n- README.pt.md: `ouro` badge color -> `gold`, fix `Prueba de Antigüedad` -> `Prova de Antiguidade`\n\nEvidence: local diff only; no build needed for docs-only link/text fixes.