### PR TITLE
Fix RTC reward action node URL docs

### DIFF
--- a/.github/actions/rtc-reward-action/README.md
+++ b/.github/actions/rtc-reward-action/README.md
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: Scottcjn/rtc-reward-action@v1
         with:
-          node-url: https://50.28.86.131
+          node-url: https://rustchain.org
           amount: 5
           wallet-from: your-project-fund
           admin-key: ${{ secrets.RTC_ADMIN_KEY }}
@@ -34,7 +34,7 @@ jobs:
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `node-url` | No | `https://50.28.86.131` | RustChain node URL |
+| `node-url` | No | `https://rustchain.org` | RustChain node URL |
 | `amount` | No | `5` | RTC per merged PR |
 | `wallet-from` | **Yes** | — | Source wallet name |
 | `admin-key` | **Yes** | — | Admin key (store in GitHub Secret) |


### PR DESCRIPTION
Fixes a stale/broken default node URL in the RTC reward action documentation.\n\nChanges:\n- Replaces the raw IP URL with https://rustchain.org in the workflow example\n- Updates the documented default `node-url` value to match\n\nBounty context: https://github.com/Scottcjn/rustchain-bounties/issues/444\n\nWallet: 0xad18c8c29b0439a93cc8d744f6978f4a3a1c5543