### PR TITLE
Add factual Stage 2 funnel origin story pack

### DIFF
--- a/submissions/human-funnel-stage2-kekehanshujun/README.md
+++ b/submissions/human-funnel-stage2-kekehanshujun/README.md
@@ -1,0 +1,279 @@
+# Human Funnel Stage 2 Origin Story Pack
+
+Bounty: [#316](https://github.com/Scottcjn/rustchain-bounties/issues/316)  
+Contributor: `@kekehanshujun`  
+RTC wallet: `RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7`
+
+This pack is written as founder-facing campaign copy for RustChain's human onboarding funnel. It avoids fabricated user counts, fake earnings, nonexistent GUI flows, and guaranteed-return language. The copy centers on the actual RustChain angle: real hardware, Proof-of-Antiquity, modest RTC rewards, and the command-line `clawrtc` setup path.
+
+## Deliverable 1: Origin Story Thread
+
+### Post 1/15
+
+I kept an old Mac long after it stopped feeling modern. It was not fast. It was not pretty. It had the kind of fan noise that makes you wonder whether the machine is thinking or just complaining.
+
+But it still booted.
+
+That was the part I could not ignore.
+
+### Post 2/15
+
+Most software treats a computer like it expires the day it stops running the latest stack. A working machine becomes "obsolete" because it is slow, unsupported, or inconvenient.
+
+That always felt wrong to me. If a computer still computes, why is the default answer to throw it away?
+
+### Post 3/15
+
+At the same time, I kept seeing crypto mining move in the opposite direction: newer chips, larger farms, more specialized hardware, more pressure to buy something bigger.
+
+It was supposed to be decentralized, but normal people with old machines were pushed to the edge.
+
+### Post 4/15
+
+So I started asking a simple question:
+
+What would a network look like if it respected machines that survived?
+
+Not the fastest machines. Not the newest machines. Real machines with history, quirks, scars, and a reason to stay plugged in.
+
+### Post 5/15
+
+That became RustChain's core idea: Proof-of-Antiquity.
+
+Instead of rewarding only raw speed, RustChain recognizes hardware identity and age. A vintage PowerPC G4 can receive a higher multiplier than a new machine because the point is not an arms race.
+
+The point is proof that the machine is real.
+
+### Post 6/15
+
+This is not a get-rich story.
+
+RustChain rewards are intentionally modest. The reference rate discussed in the project is about $0.10 per RTC, and an epoch reward is small. The point is not to pretend an old laptop replaces a salary.
+
+The point is that unused hardware can still participate.
+
+### Post 7/15
+
+The first emotional proof is not the balance.
+
+It is the moment a machine that everyone else wrote off shows a wallet, a public identity, and a live status instead of a recycling label.
+
+That changes how people look at the computer in the closet.
+
+### Post 8/15
+
+The setup path is deliberately plain:
+
+Install the miner with `pip install clawrtc`.
+
+Create or view a wallet with `clawrtc wallet`.
+
+Start mining with `clawrtc start`.
+
+Check status and balance with `clawrtc status` and `clawrtc wallet show`.
+
+No special GPU. No deposit. No promise of easy riches.
+
+### Post 9/15
+
+The smallness matters.
+
+RustChain is still early. The community is not pretending there are millions of miners or giant payouts. That honesty is part of the appeal.
+
+It is easier to trust a project that says "try this on a real machine and see what happens" than one that tells you a fantasy.
+
+### Post 10/15
+
+There is also a sustainability argument here, but I do not want to overstate it.
+
+One old computer mining RTC will not solve e-waste. But a network that makes people hesitate before discarding working hardware is a different cultural signal.
+
+It says: useful does not have to mean new.
+
+### Post 11/15
+
+That is why the hardware fingerprinting matters.
+
+RustChain tries to distinguish real machines from disposable cloud identities and VM farms. The miner checks for physical signals, hardware details, and consistency. A virtual machine can run code, but it should not receive the same trust as a real device.
+
+### Post 12/15
+
+The rebellion is quiet.
+
+It is not "destroy the old system." It is:
+
+Keep the machine.
+
+Run the command.
+
+Let the old hardware prove it is still here.
+
+That is enough for a first step.
+
+### Post 13/15
+
+I like that RustChain makes people talk about computers as objects with memory again.
+
+The old Mac from school.
+
+The ThinkPad from a first job.
+
+The desktop a parent built and never recycled.
+
+Those machines are not just specs. They are part of a person's history.
+
+### Post 14/15
+
+RustChain is an invitation to test that history on a public network.
+
+If it still boots, it might still contribute. If it still computes, it can attempt the same proof as everyone else. If the hardware is older, the network may value that age instead of ignoring it.
+
+### Post 15/15
+
+Before you recycle the old computer in your closet, give it one more job.
+
+Visit `https://rustchain.org`, install `clawrtc`, create a wallet, and try a safe first run.
+
+You may not get rich. You may get something better: proof that a machine you almost gave up on still has work to do.
+
+## Deliverable 2: Long-Form Article Draft
+
+# I Refused to Throw Away My Old Macs - So I Built a Blockchain That Pays Them Instead
+
+There is a small moment that happens before we throw away a computer.
+
+You open the lid, press the power button, and wait. Maybe the fan starts loudly. Maybe the boot takes too long. Maybe the screen flickers before it remembers what it is supposed to be. A newer machine would feel smoother. A cleaner person would recycle it. A more practical person would stop being sentimental.
+
+But then the login screen appears.
+
+It still works.
+
+That was the feeling RustChain grew out of. Not a whitepaper first. Not a token chart first. A working old machine sitting on a desk, being treated by the rest of the industry as if it had already died.
+
+The strange thing about computers is how quickly we declare them worthless. A machine can survive years of travel, school, jobs, late-night work, family photos, music libraries, and half-finished projects. Then one operating system update passes it by, and suddenly the story becomes: this is obsolete.
+
+The hardware did not stop being real. It just stopped fitting into the upgrade cycle.
+
+At the same time, crypto mining kept moving toward newer and more specialized hardware. The message was clear: if you want to participate, buy the right machine, run the right rig, join the arms race. Decentralization sounded open in theory, but in practice a normal person with an old laptop had almost no reason to try.
+
+That contradiction bothered me.
+
+What if a network did not treat old hardware as a disadvantage? What if survival itself mattered? What if an old PowerPC Mac, an aging ThinkPad, or a spare desktop could become part of a system that values proof of real hardware instead of only raw speed?
+
+That question became Proof-of-Antiquity.
+
+RustChain is built around a simple inversion: older real hardware can matter more, not less. The network does not ask every machine to pretend it is the fastest. It asks the machine to prove that it is real, consistent, and physically grounded. Vintage hardware can receive an antiquity multiplier because the goal is not to create another race for the newest GPU. The goal is to make participation possible for machines that other systems ignore.
+
+This is also why RustChain cares about hardware fingerprinting. If the network rewarded any claimed identity at face value, it would invite VM farms and fake vintage claims. So the miner collects hardware signals, checks for virtualization patterns, and penalizes synthetic environments. The point is not to punish experimentation. The point is to keep the reward model honest: one real machine should not become a thousand fake ones.
+
+The economics are deliberately modest. RustChain is not a promise that an old laptop will replace a job. The public reference rate discussed by the project is about $0.10 per RTC, and the rewards per epoch are small. That honesty matters. A project about old hardware should not sell people a fantasy about instant wealth.
+
+The better promise is quieter:
+
+your old computer can still do something useful.
+
+The first time someone installs the miner, the setup should feel like a first step, not a ritual. The core flow is command-line simple: install `clawrtc`, create or view a wallet, start the miner, and check status. The project still needs better onboarding, better error messages, and clearer Windows paths. But even now, the idea is visible in the flow. You are not buying into a scheme. You are asking an actual machine to prove that it exists.
+
+There is something emotionally different about that.
+
+A balance number is useful. A public miner ID is useful. But the deeper hook is the moment when a computer that was headed for a drawer or a recycling bin becomes legible again. It has a wallet. It has a status. It has a role. It may not be fast, but it is no longer invisible.
+
+That is the part of RustChain I keep coming back to.
+
+Most technology stories are told from the perspective of the new: new hardware, new platforms, new funding rounds, new roadmaps, new promises. RustChain starts from the opposite direction. It asks what is already here. It asks what still boots. It asks whether the machine you almost discarded can be part of a network precisely because it has a past.
+
+No venture-capital framing is needed for that. No hype cycle is needed. The idea is easy enough to explain to someone who does not care about crypto:
+
+"That old computer in your closet might be useful again."
+
+That sentence is the funnel.
+
+It is also the mission.
+
+If you want to try it, start with a machine you already own. Do not buy hardware for the fantasy of returns. Do not believe anyone promising guaranteed income. Pick a working computer, visit `https://rustchain.org`, install the miner, create a wallet, and run a safe first test. If it works, let it run. If it fails, the error output can still help improve the onboarding path for the next person.
+
+RustChain is early, small, and imperfect. That is part of why I like it. It is still close enough to the hardware to remember what the hardware means.
+
+Every old machine has a story. RustChain gives that story one more possible chapter:
+
+not obsolete,
+
+not discarded,
+
+still working.
+
+## Deliverable 3: Emotional 60-Second Video Script
+
+Title: `Still Boots`
+
+Tone: quiet, honest, human-first. No hype, no guaranteed earning claims.
+
+### 0:00-0:05
+
+Visual: Close-up of an old laptop lid opening. Dust on the keyboard. The power button is pressed.
+
+Voiceover: "They told me to recycle it."
+
+On-screen text: `Too old?`
+
+### 0:05-0:12
+
+Visual: The machine slowly reaches a login screen. The fan is audible but not dramatic.
+
+Voiceover: "Too slow. Too loud. Too far behind."
+
+On-screen text: `Still boots.`
+
+### 0:12-0:20
+
+Visual: Cut between an old Mac, an old desktop, and a worn keyboard. Warm desk lighting.
+
+Voiceover: "But a working computer is not trash just because the upgrade cycle moved on."
+
+On-screen text: `If it still computes, it still matters.`
+
+### 0:20-0:30
+
+Visual: Terminal opens. The commands appear slowly:
+
+```bash
+pip install clawrtc
+clawrtc wallet show
+clawrtc start
+```
+
+Voiceover: "So RustChain asks a different question: what if real old hardware could prove itself on a network?"
+
+### 0:30-0:42
+
+Visual: Simple animation of old machines connecting as nodes. No fake balances. No exaggerated numbers.
+
+Voiceover: "Proof-of-Antiquity rewards real machines, and older hardware can receive a higher multiplier."
+
+On-screen text: `One real machine. One public proof.`
+
+### 0:42-0:52
+
+Visual: The old laptop remains on the desk, screen glowing. A wallet address or public miner ID is shown in blurred/short form, never a private key.
+
+Voiceover: "It will not make you rich overnight. That is not the point."
+
+On-screen text: `Modest rewards. Real hardware.`
+
+### 0:52-1:00
+
+Visual: Fade to the machine still running, then a clean RustChain URL screen.
+
+Voiceover: "Before you throw it away, give it one more job. Start at rustchain.org."
+
+On-screen text: `RustChain - old hardware, new purpose`
+
+## Acceptance Checklist
+
+- 15-post origin story thread included.
+- Long-form article draft included with the requested title.
+- 60-second video script included with timed beats.
+- Uses real `clawrtc` command-line flow.
+- Avoids fabricated earnings, fake miner counts, fake testimonials, and nonexistent GUI setup.
+- Human-facing language: problem, rejection, build, proof, invite.
+- Clear CTA: `https://rustchain.org`.

--- a/submissions/human-funnel-stage2-kekehanshujun/README.md
+++ b/submissions/human-funnel-stage2-kekehanshujun/README.md
@@ -1,7 +1,7 @@
 # Human Funnel Stage 2 Origin Story Pack
 
-Bounty: [#316](https://github.com/Scottcjn/rustchain-bounties/issues/316)  
-Contributor: `@kekehanshujun`  
+Bounty: [#316](https://github.com/Scottcjn/rustchain-bounties/issues/316)
+Contributor: `@kekehanshujun`
 RTC wallet: `RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7`
 
 This pack is written as founder-facing campaign copy for RustChain's human onboarding funnel. It avoids fabricated user counts, fake earnings, nonexistent GUI flows, and guaranteed-return language. The copy centers on the actual RustChain angle: real hardware, Proof-of-Antiquity, modest RTC rewards, and the command-line `clawrtc` setup path.


### PR DESCRIPTION
## Summary
- Adds a focused Stage 2 origin story pack for bounty #316.
- Includes a 15-post origin story thread, the requested long-form article draft, and a timed 60-second video script.
- Keeps the copy RustChain-specific and avoids fabricated user counts, fake earnings, nonexistent GUI setup, or guaranteed-return claims.

## Validation
- git diff --check -- submissions/human-funnel-stage2-kekehanshujun/README.md`n- clawrtc --help`n- clawrtc wallet --help`n- clawrtc start --help`n
Bounty: #316
RTC wallet: RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7