### PR TITLE
docs: fix RIP-306 canonical link

### DIFF
--- a/scripts/sophia_db.py
+++ b/scripts/sophia_db.py
@@ -5,7 +5,7 @@
 SQLite storage for Sophia Elya inspection verdicts, historical fingerprints,
 and admin override audit trail.
 
-RIP-306: https://github.com/ArokyaMatthew/rustchain-bounties/docs/protocol/RIP-0306-sophia-attestation-inspector.md
+RIP-306: https://github.com/Scottcjn/rustchain-bounties/blob/main/docs/protocol/RIP-0306-sophia-attestation-inspector.md
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary\n- replace the stale ArokyaMatthew fork URL in scripts/sophia_db.py with the canonical Scottcjn/rustchain-bounties RIP-306 document URL\n\n## Validation\n- old URL https://github.com/ArokyaMatthew/rustchain-bounties/docs/protocol/RIP-0306-sophia-attestation-inspector.md -> 404\n- new URL https://github.com/Scottcjn/rustchain-bounties/blob/main/docs/protocol/RIP-0306-sophia-attestation-inspector.md -> 200\n- python3 -B -m py_compile scripts/sophia_db.py\n- git diff --check -- scripts/sophia_db.py\n\n## Duplicate and safety checks\n- searched rustchain-bounties issues, PRs, and #444 comments for ArokyaMatthew/RIP-0306/sophia_db before opening this PR; no matching prior report or fix found\n- no private tokens, secrets, wallet operations, withdrawals, or production calls used