### PR TITLE
docs: fix wRTC token logo URI

### DIFF
--- a/docs/wrtc-pack/jupiter-token-list.json
+++ b/docs/wrtc-pack/jupiter-token-list.json
@@ -6,7 +6,7 @@
     "symbol": "wRTC",
     "decimals": 6,
     "mintAddress": "12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X",
-    "logoURI": "https://github.com/Scottcjn/rustchain-bounties/raw/main/assets/wrtc-logo.png",
+    "logoURI": "https://bottube.ai/static/img/wrtc-logo.png",
     "tags": ["utility", "bridge", "rustchain", "ai-mining"]
   },
   "extensions": {


### PR DESCRIPTION
## Summary\n- update the wRTC Jupiter token-list logoURI from a missing repository asset to the live BoTTube wRTC logo PNG\n\n## Validation\n- old URL https://github.com/Scottcjn/rustchain-bounties/raw/main/assets/wrtc-logo.png -> 404\n- new URL https://bottube.ai/static/img/wrtc-logo.png -> 200 image/png\n- python3 -m json.tool docs/wrtc-pack/jupiter-token-list.json >/dev/null\n- git diff --check -- docs/wrtc-pack/jupiter-token-list.json\n\n## Duplicate and safety checks\n- searched rustchain-bounties issues, PRs, and #444 comments for wrtc-logo/jupiter-token-list/logoURI before opening this PR; no matching prior report or fix found\n- no private tokens, secrets, wallet operations, withdrawals, or production calls used