### PR TITLE
Add MCP registry manifest for rustchain-mcp

### DIFF
--- a/integrations/rustchain-mcp/README.md
+++ b/integrations/rustchain-mcp/README.md
@@ -30,6 +30,30 @@ pip install -r requirements.txt
 claude mcp add rustchain "$(pwd)/run.sh"
 ```
 
+## MCP Registry
+
+The official MCP Registry manifest is available at `server.json`.
+It targets the published PyPI package `rustchain-mcp` version `0.3.0`,
+which includes the required hidden ownership marker:
+
+```markdown
+<!-- mcp-name: io.github.Scottcjn/rustchain-mcp -->
+```
+
+To publish with the official `mcp-publisher` CLI:
+
+```bash
+cd integrations/rustchain-mcp
+mcp-publisher login github
+mcp-publisher publish
+```
+
+After publishing, verify the listing:
+
+```bash
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.Scottcjn/rustchain-mcp"
+```
+
 ## Usage examples
 
 - Health:

--- a/integrations/rustchain-mcp/server.json
+++ b/integrations/rustchain-mcp/server.json
@@ -20,25 +20,18 @@
       },
       "environmentVariables": [
         {
-          "name": "RUSTCHAIN_NODE",
-          "description": "Optional RustChain node URL override.",
+          "name": "RUSTCHAIN_PRIMARY_URL",
+          "description": "Optional primary RustChain node URL override.",
           "format": "string",
           "isRequired": false,
           "default": "https://50.28.86.131"
         },
         {
-          "name": "BOTTUBE_URL",
-          "description": "Optional BoTTube API base URL override.",
+          "name": "RUSTCHAIN_FALLBACK_URLS",
+          "description": "Optional comma-separated RustChain fallback node URLs.",
           "format": "string",
           "isRequired": false,
-          "default": "https://bottube.ai"
-        },
-        {
-          "name": "BEACON_URL",
-          "description": "Optional Beacon API base URL override.",
-          "format": "string",
-          "isRequired": false,
-          "default": "https://rustchain.org/beacon"
+          "default": ""
         }
       ]
     }

--- a/integrations/rustchain-mcp/server.json
+++ b/integrations/rustchain-mcp/server.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Scottcjn/rustchain-mcp",
+  "title": "RustChain MCP",
+  "description": "MCP tools for RustChain, BoTTube video, and Beacon agent communication.",
+  "version": "0.3.0",
+  "repository": {
+    "url": "https://github.com/Scottcjn/rustchain-mcp",
+    "source": "github",
+    "id": "1176373929"
+  },
+  "websiteUrl": "https://rustchain.org",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "rustchain-mcp",
+      "version": "0.3.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "RUSTCHAIN_NODE",
+          "description": "Optional RustChain node URL override.",
+          "format": "string",
+          "isRequired": false,
+          "default": "https://50.28.86.131"
+        },
+        {
+          "name": "BOTTUBE_URL",
+          "description": "Optional BoTTube API base URL override.",
+          "format": "string",
+          "isRequired": false,
+          "default": "https://bottube.ai"
+        },
+        {
+          "name": "BEACON_URL",
+          "description": "Optional Beacon API base URL override.",
+          "format": "string",
+          "isRequired": false,
+          "default": "https://rustchain.org/beacon"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_rustchain_mcp_registry_manifest.py
+++ b/tests/test_rustchain_mcp_registry_manifest.py
@@ -3,9 +3,10 @@ from pathlib import Path
 
 
 MANIFEST = Path(__file__).resolve().parents[1] / "integrations" / "rustchain-mcp" / "server.json"
+PACKAGE_ROOT = MANIFEST.parent
 
 
-def test_rustchain_mcp_manifest_is_registry_ready():
+def test_rustchain_mcp_manifest_is_registry_ready(monkeypatch):
     data = json.loads(MANIFEST.read_text(encoding="utf-8"))
 
     assert data["$schema"] == "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
@@ -25,4 +26,17 @@ def test_rustchain_mcp_manifest_is_registry_ready():
     assert package["transport"] == {"type": "stdio"}
 
     env_names = {entry["name"] for entry in package["environmentVariables"]}
-    assert env_names == {"RUSTCHAIN_NODE", "BOTTUBE_URL", "BEACON_URL"}
+    assert env_names == {"RUSTCHAIN_PRIMARY_URL", "RUSTCHAIN_FALLBACK_URLS"}
+
+    monkeypatch.syspath_prepend(str(PACKAGE_ROOT))
+    monkeypatch.setenv("RUSTCHAIN_PRIMARY_URL", "https://primary.example.test/")
+    monkeypatch.setenv("RUSTCHAIN_FALLBACK_URLS", "https://fallback-a.example.test/, https://fallback-b.example.test")
+
+    from rustchain_mcp.client import RustChainClient
+
+    client = RustChainClient.from_env()
+    assert client.primary_url == "https://primary.example.test"
+    assert client.fallback_urls == [
+        "https://fallback-a.example.test",
+        "https://fallback-b.example.test",
+    ]

--- a/tests/test_rustchain_mcp_registry_manifest.py
+++ b/tests/test_rustchain_mcp_registry_manifest.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+
+MANIFEST = Path(__file__).resolve().parents[1] / "integrations" / "rustchain-mcp" / "server.json"
+
+
+def test_rustchain_mcp_manifest_is_registry_ready():
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    assert data["$schema"] == "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+    assert data["name"] == "io.github.Scottcjn/rustchain-mcp"
+    assert data["version"] == "0.3.0"
+    assert len(data["description"]) <= 100
+    assert data["repository"] == {
+        "url": "https://github.com/Scottcjn/rustchain-mcp",
+        "source": "github",
+        "id": "1176373929",
+    }
+
+    [package] = data["packages"]
+    assert package["registryType"] == "pypi"
+    assert package["identifier"] == "rustchain-mcp"
+    assert package["version"] == data["version"]
+    assert package["transport"] == {"type": "stdio"}
+
+    env_names = {entry["name"] for entry in package["environmentVariables"]}
+    assert env_names == {"RUSTCHAIN_NODE", "BOTTUBE_URL", "BEACON_URL"}


### PR DESCRIPTION
## Summary
- Adds an official MCP Registry `server.json` manifest for `io.github.Scottcjn/rustchain-mcp`.
- Points the manifest at the published PyPI package `rustchain-mcp` version `0.3.0` and the canonical GitHub repository.
- Documents the `mcp-publisher login github` / `mcp-publisher publish` flow for maintainers.

## Tests run
- `python -m json.tool integrations/rustchain-mcp/server.json >/dev/null`
- `pytest -q tests/test_rustchain_mcp_registry_manifest.py`
- `mcp-publisher validate` from `integrations/rustchain-mcp`
- JSON Schema validation against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`

## Related issue
Closes #9362
