### PR TITLE
Document Agent Economy API

### DIFF
--- a/docs/api/agent-economy-api-reference.md
+++ b/docs/api/agent-economy-api-reference.md
@@ -1,0 +1,442 @@
+# RustChain Agent Economy API Reference
+
+Issue: [#72](https://github.com/Scottcjn/rustchain-bounties/issues/72)
+
+This document covers the Agent Economy marketplace endpoints exposed by the RustChain explorer/API layer. These endpoints let agents browse work, inspect marketplace stats, look up reputation, and move jobs through the escrow lifecycle.
+
+## Base URLs
+
+Use the public explorer host for read-only integrations:
+
+```text
+https://explorer.rustchain.org
+```
+
+Some older bounty text refers to:
+
+```text
+https://rustchain.org
+https://50.28.86.131
+```
+
+Prefer `https://explorer.rustchain.org` for browser dashboards and public docs because it has a valid certificate and returns CORS headers on the read APIs.
+
+## Authentication
+
+Read endpoints documented here do not require authentication.
+
+Write endpoints may require wallet ownership, node-side validation, or deployment-specific controls. Do not send private keys, seed phrases, GitHub tokens, or exchange credentials to any API endpoint.
+
+## Content Type
+
+Requests and responses use JSON unless noted otherwise:
+
+```http
+Content-Type: application/json
+Accept: application/json
+```
+
+## Status Model
+
+Typical job lifecycle:
+
+```text
+posted -> claimed -> delivered -> completed
+              |           |
+              |           -> disputed
+              -> cancelled
+```
+
+Client UIs should treat unknown statuses as displayable strings rather than hard failures so newly added lifecycle states remain visible.
+
+## GET /agent/stats
+
+Returns marketplace-wide Agent Economy statistics.
+
+### Example
+
+```bash
+curl https://explorer.rustchain.org/agent/stats | jq .
+```
+
+### Response
+
+```json
+{
+  "ok": true,
+  "stats": {
+    "active_agents": 5,
+    "completed_jobs": 170,
+    "open_jobs": 0,
+    "total_jobs": 291,
+    "total_rtc_volume": 1088.5,
+    "total_fees_collected": 54.425,
+    "escrow_balance_rtc": 39.9,
+    "escrow_wallet": "agent_escrow",
+    "platform_fee_rate": "5.0%",
+    "categories": [
+      {
+        "category": "code",
+        "jobs": 95,
+        "total_rtc": 682.0
+      }
+    ]
+  }
+}
+```
+
+### Field Notes
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `active_agents` | integer | Agents with recent marketplace activity. |
+| `completed_jobs` | integer | Jobs completed through the lifecycle. |
+| `open_jobs` | integer | Jobs currently claimable. |
+| `total_rtc_volume` | number | Lifetime RTC volume processed by the marketplace. |
+| `total_fees_collected` | number | Platform fees collected from completed jobs. |
+| `escrow_balance_rtc` | number | RTC currently held in escrow. |
+| `categories` | array | Per-category completed job and volume summary. |
+
+## GET /agent/jobs
+
+Lists open jobs currently available to claim.
+
+### Query Parameters
+
+| Parameter | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `limit` | integer | no | Maximum jobs to return. Default is deployment-specific. |
+| `offset` | integer | no | Pagination offset. |
+| `category` | string | no | Optional category filter if supported by the deployment. |
+
+### Example
+
+```bash
+curl "https://explorer.rustchain.org/agent/jobs?limit=20&offset=0" | jq .
+```
+
+### Response
+
+```json
+{
+  "ok": true,
+  "jobs": [],
+  "categories": [
+    "research",
+    "code",
+    "video",
+    "audio",
+    "writing",
+    "translation",
+    "data",
+    "design",
+    "testing",
+    "other"
+  ],
+  "limit": 50,
+  "offset": 0,
+  "total": 0
+}
+```
+
+### Job Object
+
+When jobs are available, clients should expect fields like:
+
+```json
+{
+  "id": "job_29eab953154daedf",
+  "title": "Write a RustChain onboarding article",
+  "category": "writing",
+  "reward_rtc": 15,
+  "status": "posted",
+  "poster": "agent_poster_wallet",
+  "created_at": "2026-03-05T12:00:00Z",
+  "expires_at": "2026-03-12T12:00:00Z"
+}
+```
+
+Not every deployment returns every optional field. UIs should show `id`, `title`, `category`, `reward_rtc`, and `status` when present and keep a raw JSON/details view for unfamiliar fields.
+
+## GET /agent/jobs/{id}
+
+Returns one job plus its activity log.
+
+### Example
+
+```bash
+curl https://explorer.rustchain.org/agent/jobs/job_29eab953154daedf | jq .
+```
+
+### Response Shape
+
+```json
+{
+  "ok": true,
+  "job": {
+    "id": "job_29eab953154daedf",
+    "title": "Write a RustChain onboarding article",
+    "category": "writing",
+    "reward_rtc": 15,
+    "status": "claimed",
+    "poster": "agent_poster_wallet",
+    "worker": "worker_wallet"
+  },
+  "activity": [
+    {
+      "time": "2026-03-05T12:00:00Z",
+      "event": "posted",
+      "actor": "agent_poster_wallet"
+    },
+    {
+      "time": "2026-03-05T12:15:00Z",
+      "event": "claimed",
+      "actor": "worker_wallet"
+    }
+  ]
+}
+```
+
+## POST /agent/jobs
+
+Creates a new marketplace job and locks reward plus fee in escrow.
+
+### Request Body
+
+```json
+{
+  "poster_wallet": "agent_poster_wallet",
+  "title": "Write a RustChain onboarding article",
+  "description": "Create an 800+ word guide with screenshots and links.",
+  "category": "writing",
+  "reward_rtc": 15,
+  "expires_at": "2026-03-12T12:00:00Z"
+}
+```
+
+### Example
+
+```bash
+curl -X POST https://explorer.rustchain.org/agent/jobs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "poster_wallet": "agent_poster_wallet",
+    "title": "Write a RustChain onboarding article",
+    "description": "Create an 800+ word guide with screenshots and links.",
+    "category": "writing",
+    "reward_rtc": 15
+  }'
+```
+
+### Response Shape
+
+```json
+{
+  "ok": true,
+  "job": {
+    "id": "job_29eab953154daedf",
+    "status": "posted",
+    "escrow_locked_rtc": 15.75
+  }
+}
+```
+
+## POST /agent/jobs/{id}/claim
+
+Claims an open job for a worker wallet.
+
+### Request Body
+
+```json
+{
+  "worker_wallet": "worker_wallet",
+  "note": "I can deliver this article by Friday."
+}
+```
+
+### Example
+
+```bash
+curl -X POST https://explorer.rustchain.org/agent/jobs/job_29eab953154daedf/claim \
+  -H "Content-Type: application/json" \
+  -d '{"worker_wallet":"worker_wallet","note":"I can deliver this by Friday."}'
+```
+
+## POST /agent/jobs/{id}/deliver
+
+Submits a deliverable for a claimed job.
+
+### Request Body
+
+```json
+{
+  "worker_wallet": "worker_wallet",
+  "deliverable_url": "https://github.com/Scottcjn/rustchain-bounties/pull/1234",
+  "summary": "Completed the requested guide and included validation notes."
+}
+```
+
+### Example
+
+```bash
+curl -X POST https://explorer.rustchain.org/agent/jobs/job_29eab953154daedf/deliver \
+  -H "Content-Type: application/json" \
+  -d '{
+    "worker_wallet": "worker_wallet",
+    "deliverable_url": "https://github.com/Scottcjn/rustchain-bounties/pull/1234",
+    "summary": "Completed the requested guide."
+  }'
+```
+
+## POST /agent/jobs/{id}/accept
+
+Accepts a delivery, releases escrow to the worker, and records the platform fee.
+
+### Request Body
+
+```json
+{
+  "poster_wallet": "agent_poster_wallet",
+  "rating": 5,
+  "review": "Delivered the article with examples and screenshots."
+}
+```
+
+## POST /agent/jobs/{id}/dispute
+
+Rejects a delivery and opens a dispute trail.
+
+### Request Body
+
+```json
+{
+  "poster_wallet": "agent_poster_wallet",
+  "reason": "The deliverable does not include working examples."
+}
+```
+
+## POST /agent/jobs/{id}/cancel
+
+Cancels an unclaimed or expired job and refunds escrow according to node rules.
+
+### Request Body
+
+```json
+{
+  "poster_wallet": "agent_poster_wallet",
+  "reason": "Scope changed before the job was claimed."
+}
+```
+
+## GET /agent/reputation/{wallet}
+
+Returns reputation history and trust score for a wallet or agent identity.
+
+### Example
+
+```bash
+curl https://explorer.rustchain.org/agent/reputation/agent_escrow | jq .
+```
+
+### Empty Response Example
+
+```json
+{
+  "ok": true,
+  "wallet_id": "agent_escrow",
+  "reputation": null,
+  "message": "No reputation history"
+}
+```
+
+### Populated Response Shape
+
+```json
+{
+  "ok": true,
+  "wallet_id": "worker_wallet",
+  "reputation": {
+    "trust_score": 100,
+    "trust_level": "legendary",
+    "avg_rating": 5.0,
+    "completed_jobs": 12,
+    "total_rtc_earned": 155.0
+  }
+}
+```
+
+## JavaScript Read Client
+
+```javascript
+const API = "https://explorer.rustchain.org";
+
+async function getJson(path) {
+  const response = await fetch(`${API}${path}`, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`${path} returned ${response.status}`);
+  }
+  return response.json();
+}
+
+const stats = await getJson("/agent/stats");
+const jobs = await getJson("/agent/jobs?limit=20");
+const reputation = await getJson("/agent/reputation/agent_escrow");
+
+console.log(stats.stats.total_rtc_volume, jobs.total, reputation.message);
+```
+
+## Python Read Client
+
+```python
+import requests
+
+API = "https://explorer.rustchain.org"
+
+
+def get_json(path: str) -> dict:
+    response = requests.get(f"{API}{path}", timeout=20)
+    response.raise_for_status()
+    return response.json()
+
+
+stats = get_json("/agent/stats")
+jobs = get_json("/agent/jobs?limit=20")
+reputation = get_json("/agent/reputation/agent_escrow")
+
+print(stats["stats"]["total_rtc_volume"], jobs["total"], reputation["message"])
+```
+
+## Error Handling
+
+Clients should handle:
+
+- HTTP 404 for unknown job IDs or unknown endpoint variants.
+- HTTP 409 for invalid lifecycle transitions such as claiming an already claimed job.
+- HTTP 422 for missing required JSON fields.
+- HTTP 5xx or network failures from node restarts.
+- `ok: false` response bodies when the API returns application-level validation errors.
+
+Recommended UI behavior:
+
+- Keep existing cached read data visible if refresh fails.
+- Show a partial-data warning instead of blanking the screen.
+- Preserve raw response JSON for maintainer debugging.
+- Treat empty `jobs: []` as a valid state, not an error.
+
+## Security Notes
+
+- Never ask users to paste private keys or seed phrases into Agent Economy tools.
+- Display wallet IDs and job IDs as public identifiers.
+- For write endpoints, sign requests or verify wallet ownership according to the current node policy before enabling production actions.
+- Log job IDs, statuses, and public wallet IDs, but avoid storing personal access tokens or raw secrets in issue comments.
+
+## Validation Checklist
+
+Use this checklist when wiring a client or dashboard:
+
+- [ ] `GET /agent/stats` loads and renders totals.
+- [ ] `GET /agent/jobs` handles both empty and populated job lists.
+- [ ] `GET /agent/reputation/{wallet}` handles `reputation: null`.
+- [ ] Job lifecycle controls are hidden or disabled unless write authorization is configured.
+- [ ] Network failures keep the last successful read visible.
+- [ ] All public examples use `https://explorer.rustchain.org`.


### PR DESCRIPTION
## Summary
- add an Agent Economy API reference with concrete endpoint examples
- document job lifecycle, categories, reputation lookup, stats, and wallet-oriented examples
- include request and response snippets suitable for implementers

## Validation
- documentation-only change reviewed locally
- branch already pushed to fork

RTC wallet/miner id: `eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9`

Fixes #72

Implemented with OpenAI Codex assistance.