### PR TITLE
Claim code review bounty for RustChain PR 5784

### DIFF
--- a/claims/code-review-bounty-73-zacharyhu-5784-20260520.md
+++ b/claims/code-review-bounty-73-zacharyhu-5784-20260520.md
@@ -1,0 +1,40 @@
+# Code Review Bounty Claim - RustChain PR #5784
+
+**Bounty:** #73 Code Review Bounty Program
+**Reviewer:** @zacharyhu
+**Payment wallet/miner ID:** removed at contributor request
+
+## Review
+
+Review submitted: https://github.com/Scottcjn/Rustchain/pull/5784#pullrequestreview-4325137792
+
+Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/5784
+
+## Outcome
+
+Requested changes.
+
+## Finding
+
+PR #5784 duplicates the already-open and reviewed PR #5765 for the same `/beacon/submit` non-object JSON fix.
+
+Both PRs modify the same production line in `node/rustchain_v2_integrated_v2.2.1_rip200.py` and add the same regression test file. PR #5765 was already open, clean, CI-passing, and reviewed before #5784 was submitted.
+
+I also noted that #5765 has slightly stronger test coverage because its test monkeypatches `store_envelope()` to prove invalid top-level JSON is rejected before storage side effects. PR #5784 only asserts the final 400 response.
+
+## Maintainer Value
+
+This review helps avoid:
+
+- merging duplicate fixes for the same issue;
+- duplicate bounty/fix claims for issue #5764;
+- accepting the weaker duplicate test when the earlier PR already has better side-effect coverage.
+
+## Verification
+
+Compared the patches for:
+
+- https://github.com/Scottcjn/Rustchain/pull/5784
+- https://github.com/Scottcjn/Rustchain/pull/5765
+
+Confirmed PR #5784 had no prior reviews when reviewed, and the submitted review is now recorded as `CHANGES_REQUESTED`.


### PR DESCRIPTION
## Summary

Adds a Bounty #73 claim artifact for a code review on Scottcjn/RustChain PR #5784.

Review submitted: https://github.com/Scottcjn/Rustchain/pull/5784#pullrequestreview-4325137792

## Review outcome

Requested changes because PR #5784 duplicates the already-open and reviewed PR #5765 for the same `/beacon/submit` non-object JSON fix. I also noted that #5765's regression test has stronger side-effect coverage.

## Payment

Payment information removed at contributor request.

## Notes

Issue #73 is closed to new comments after 2500 comments, so this follows the claim-by-PR pattern used by recent reviewers.
