### PR TITLE
Claim bounty #442: miner test report (ARM64 Linux)

### DIFF
--- a/claims/miner-test-442-thanhdn1984-20260520.md
+++ b/claims/miner-test-442-thanhdn1984-20260520.md
@@ -1,0 +1,32 @@
+# Miner test report for bounty #442 — Thanhdn1984
+
+- OS: Linux 6.8.0-1047-oracle aarch64 (Ubuntu/glibc 2.35)
+- Python: 3.10.12
+- Architecture: aarch64 / ARM64
+- clawrtc version: 1.8.0
+
+Command results:
+
+```text
+$ pip install --user clawrtc
+installed successfully
+
+$ clawrtc mine --dry-run
+usage: clawrtc [-h] [--version]
+               {install,start,mine,stop,status,logs,uninstall,bcos,wallet} ...
+clawrtc: error: unrecognized arguments: --dry-run
+
+$ clawrtc mine --help
+usage: clawrtc mine [-h] [--wallet WALLET] [--service]
+
+options:
+  -h, --help       show this help message and exit
+  --wallet WALLET  Wallet name (will install first if needed)
+  --service        Create background service for auto-restart
+```
+
+Result: the package installs on ARM64 Linux and the CLI is available, but the documented `clawrtc mine --dry-run` command is not supported by the current PyPI CLI (`clawrtc 1.8.0`). I did not start real mining because the bounty asks for a dry run.
+
+Suggestion: either re-add `--dry-run` to the `mine` subcommand or update bounty #442 instructions to use the current supported CLI flow.
+
+AI assistance disclosure: OpenAI Codex / GPT-5 was used to collect and format this report.


### PR DESCRIPTION
Claim for bounty #442. Report added in claims/miner-test-442-thanhdn1984-20260520.md. The current PyPI CLI installs and reports clawrtc 1.8.0, but the documented dry-run command is unsupported; I did not start real mining.