### PR TITLE
docs: fix broken BCOS verify link

### DIFF
--- a/bcos/README.md
+++ b/bcos/README.md
@@ -31,7 +31,7 @@ Two static HTML pages implementing BCOS v2 tooling for rustchain.org.
 **Deploy:** `rustchain.org/bcos/badge-generator.html`
 
 **Badge endpoint:** `GET https://50.28.86.131/bcos/badge/{cert_id}-{style}.svg`  
-**Verify page:** `https://rustchain.org/bcos/verify/{cert_id}`
+**Verify page:** `https://rustchain.org/bcos/`
 
 ## Bounty Payment
 


### PR DESCRIPTION
## Summary
- Fix the BCOS README `Verify page` link.
- The old URL (`https://rustchain.org/bcos/verify/{cert_id}`) currently resolves to a missing `/bcos/verify/...` route.
- The replacement (`https://rustchain.org/bcos/`) is the live BCOS page.

## Validation
- `curl -L -s -o /dev/null -w '%{http_code}' https://rustchain.org/bcos/verify/test` -> `404`
- `curl -L -s -o /dev/null -w '%{http_code}' https://rustchain.org/bcos/` -> `200`
- `git diff --check -- bcos/README.md` -> passed

## Bounty note
This is a single-file docs/link fix. RTC wallet/handle: `awitherow`