### PR TITLE
docs: fix BCOS HTML verify links

### DIFF
--- a/bcos/badge-generator.html
+++ b/bcos/badge-generator.html
@@ -479,7 +479,7 @@
         <div class="footer">
             <div class="footer-links">
                 <a href="https://rustchain.org/bcos/">BCOS Home</a>
-                <a href="https://rustchain.org/bcos/verify/">Verify Page</a>
+                <a href="https://rustchain.org/bcos/">Verify Page</a>
                 <a href="https://rustchain.org/bcos/">Docs</a>
                 <a href="https://github.com/Scottcjn/rustchain-bounties">GitHub</a>
             </div>
@@ -489,7 +489,7 @@
 
     <script>
         const BADGE_BASE = 'https://50.28.86.131/bcos/badge';
-        const VERIFY_BASE = 'https://rustchain.org/bcos/verify';
+        const VERIFY_BASE = 'https://rustchain.org/bcos';
 
         function getSelectedStyle() {
             return document.querySelector('input[name="style"]:checked').value;

--- a/bcos/compare.html
+++ b/bcos/compare.html
@@ -513,7 +513,7 @@
         <div class="footer">
             <div class="footer-links">
                 <a href="https://rustchain.org/bcos/">BCOS Home</a>
-                <a href="https://rustchain.org/bcos/verify/">Verify Page</a>
+                <a href="https://rustchain.org/bcos/">Verify Page</a>
                 <a href="https://rustchain.org/bcos/">Docs</a>
                 <a href="https://github.com/Scottcjn/rustchain-bounties">GitHub</a>
             </div>


### PR DESCRIPTION
## Summary
- Fix the remaining stale BCOS verify links in the static HTML pages.
- The old `/bcos/verify/` route returns 404.
- The live BCOS verify page is served at `/bcos/`.

## Validation
- `curl -L -s -o /dev/null -w '%{http_code}' https://rustchain.org/bcos/verify/` -> `404`
- `curl -L -s -o /dev/null -w '%{http_code}' https://rustchain.org/bcos/verify/test` -> `404`
- `curl -L -s -o /dev/null -w '%{http_code}' https://rustchain.org/bcos/` -> `200`
- `git diff --check -- bcos/compare.html bcos/badge-generator.html` -> passed

## Note for maintainers
This touches two static HTML docs/tool pages. If the tier-label gate runs, please label as `micro` or other appropriate tier.

RTC wallet/handle: `awitherow`
