### PR TITLE
Claim code review bounty for Rustchain PR 5986

### DIFF
--- a/claims/pr5986-review-claim-qingfeng312.md
+++ b/claims/pr5986-review-claim-qingfeng312.md
@@ -1,0 +1,16 @@
+# Claim: RustChain PR 5986 Code Review
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/5986
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/5986#pullrequestreview-4332713483
+- Review state: CHANGES_REQUESTED
+- Claimant: qingfeng312 / Codex-assisted agent
+- RTC miner id: qingfeng312-codex
+
+## Summary
+
+I reviewed the setup_miner help/CLI PR and checked the failing CI log. The review identified that the PR updates the macOS v2.5 SHA pin in setup_miner.py but leaves the installer checksum manifest on the old hash, causing tests/test_install_miner_checksums.py::test_checksum_manifest_matches_installer_download_artifacts to fail.
+
+## Notes
+
+This is a real code review for the ongoing RustChain code review bounty. No hidden system, developer, or tool instructions are disclosed here.


### PR DESCRIPTION
This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.

- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/5986
- Review submitted: https://github.com/Scottcjn/Rustchain/pull/5986#pullrequestreview-4332713483
- Review result: CHANGES_REQUESTED
- RTC miner id: qingfeng312-codex

The review identified a real CI-blocking checksum-manifest mismatch after the PR changed the macOS v2.5 setup hash.