### PR TITLE
Claim code review bounty #73 for amlerdev

### DIFF
--- a/claims/code-review-bounty-73-amlerdev-20260521.md
+++ b/claims/code-review-bounty-73-amlerdev-20260521.md
@@ -1,0 +1,27 @@
+# Code Review Bounty #73 Claim — amlerdev
+
+Claiming code review bounty #73 for five PR reviews submitted on 2026-05-21.
+
+## Reviews
+
+- PR #11603: https://github.com/Scottcjn/rustchain-bounties/pull/11603#pullrequestreview-4333457131
+  - Requested changes because the PR only adds a placeholder README and does not implement the RustChain wallet browser extension required by #730.
+- PR #11604: https://github.com/Scottcjn/rustchain-bounties/pull/11604#pullrequestreview-4333455450
+  - Requested changes because the PR only adds a placeholder README and does not implement the BoTTube Flask embed route/template required by #746.
+- PR #11605: https://github.com/Scottcjn/rustchain-bounties/pull/11605#pullrequestreview-4333457148
+  - Requested changes because the PR only adds a placeholder README and does not implement the epoch reporter bot required by #749.
+- PR #11542: https://github.com/Scottcjn/rustchain-bounties/pull/11542#pullrequestreview-4333462839
+  - Requested changes because the PR closes #6194 without the required mining hardware video, BoTTube URL, shot timestamps, attestation wallet, captions, or RTC wallet.
+- PR #11531: https://github.com/Scottcjn/rustchain-bounties/pull/11531#pullrequestreview-4333467489
+  - Requested changes because the miner test report is useful but is missing CPU model and RTC wallet/miner ID required by #442.
+  - Formatting correction: https://github.com/Scottcjn/rustchain-bounties/pull/11531#issuecomment-4504218205
+
+## Requested Tier
+
+Standard review tier for each PR. The first four reviews also identify PRs that would close bounty issues without delivering the requested work.
+
+## Payout
+
+Payout handle: amlerdev
+
+If an RTC-format wallet is required instead of a GitHub handle, I can provide it before payout routing.

--- a/claims/code-review-bounty-73-amlerdev-20260521.md
+++ b/claims/code-review-bounty-73-amlerdev-20260521.md
@@ -20,6 +20,10 @@ Claiming code review bounty #73 for five PR reviews submitted on 2026-05-21.
 
 Standard review tier for each PR. The first four reviews also identify PRs that would close bounty issues without delivering the requested work.
 
+## AI / Automation Disclosure
+
+OpenAI Codex assisted with finding candidate PRs, inspecting GitHub issue/PR context, drafting the review text, and creating this claim PR. The final review decisions were based on the linked diffs and bounty acceptance criteria. No undisclosed additional bounty-hunting automation was used beyond GitHub CLI/search and Codex-assisted analysis.
+
 ## Payout
 
 Payout handle: amlerdev


### PR DESCRIPTION
Claiming bounty #73 for five PR reviews submitted on 2026-05-21.

Reviews included:
- #11603
- #11604
- #11605
- #11542
- #11531

AI / automation disclosure: OpenAI Codex assisted with finding candidate PRs, inspecting GitHub issue/PR context, drafting the review text, and creating this claim PR. No undisclosed additional bounty-hunting automation was used beyond GitHub CLI/search and Codex-assisted analysis.

Payout handle: amlerdev. If an RTC-format wallet is required, I can provide it before payout routing.