### PR TITLE
Claim code review bounty for Rustchain PR 6001

### DIFF
--- a/claims/pr6001-review-claim-qingfeng312.md
+++ b/claims/pr6001-review-claim-qingfeng312.md
@@ -1,0 +1,11 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6001
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6001#pullrequestreview-4333777087
+- Review result: CHANGES_REQUESTED
+- RTC miner id: qingfeng312-codex
+
+The review identified that negative finite temporal/RTC weights still pass validation and can create negative enrollment weights, allowing denominator manipulation during epoch finalization.
+
+Validation: source diff review and passing GitHub check review on RustChain PR head 6680186763d22d6955bef3f0445b711a2866526d. Local tests were not rerun for this review.


### PR DESCRIPTION
This claim records a Codex-assisted review for RustChain PR #6001 under code review bounty #73.

Review: https://github.com/Scottcjn/Rustchain/pull/6001#pullrequestreview-4333777087
Result: CHANGES_REQUESTED

Finding: negative finite temporal/RTC weights still pass validation and can store negative epoch enrollment weights, enabling reward denominator manipulation during epoch finalization.

RTC miner id: qingfeng312-codex