### PR TITLE
Claim code review bounty for RustChain PR 6028

### DIFF
--- a/claims/pr6028-review-claim-molhamhamwi.md
+++ b/claims/pr6028-review-claim-molhamhamwi.md
@@ -2,10 +2,14 @@ This claim records a Codex-assisted code review for the ongoing RustChain code r
 
 - Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
 - Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6028
-- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6028#pullrequestreview-4336007550
-- Review result: CHANGES_REQUESTED
+- Reviews submitted:
+  - Changes requested: https://github.com/Scottcjn/Rustchain/pull/6028#pullrequestreview-4336007550
+  - Follow-up approved after fix: https://github.com/Scottcjn/Rustchain/pull/6028#pullrequestreview-4336157078
+- Review result: CHANGES_REQUESTED, then APPROVED after the author fixed the blocker
 - Payout details: to be provided by the account owner if maintainers approve the claim
 
-The review identified a remaining non-finite total-weight path in `/epoch/enroll`: individually finite `temporal` and `rtc` weights can overflow to `inf` after multiplication, return HTTP 200, consume the one-shot ticket, and store `inf` in `epoch_enroll`.
+The first review identified a remaining non-finite total-weight path in `/epoch/enroll`: individually finite `temporal` and `rtc` weights could overflow to `inf` after multiplication, return HTTP 200, consume the one-shot ticket, and store `inf` in `epoch_enroll`.
+
+The follow-up review verified the fix: the overflow case now returns HTTP 400 with `invalid_weights`, leaves the ticket retryable, and inserts no `epoch_enroll` row.
 
 Validation: `python3 -m py_compile node/sophia_elya_service.py node/tests/test_sophia_elya_service.py`; `uv run --no-project --with pytest --with flask python -m pytest node/tests/test_sophia_elya_service.py -q --tb=short` (6 passed); `uv run --no-project --with ruff python -m ruff check node/sophia_elya_service.py node/tests/test_sophia_elya_service.py`; `python3 tools/bcos_spdx_check.py --base-ref origin/main`; `git diff --check origin/main...HEAD -- node/sophia_elya_service.py node/tests/test_sophia_elya_service.py`; and a direct Flask test-client probe reproducing `weight: inf`.

--- a/claims/pr6028-review-claim-molhamhamwi.md
+++ b/claims/pr6028-review-claim-molhamhamwi.md
@@ -1,0 +1,11 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6028
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6028#pullrequestreview-4336007550
+- Review result: CHANGES_REQUESTED
+- Payout details: to be provided by the account owner if maintainers approve the claim
+
+The review identified a remaining non-finite total-weight path in `/epoch/enroll`: individually finite `temporal` and `rtc` weights can overflow to `inf` after multiplication, return HTTP 200, consume the one-shot ticket, and store `inf` in `epoch_enroll`.
+
+Validation: `python3 -m py_compile node/sophia_elya_service.py node/tests/test_sophia_elya_service.py`; `uv run --no-project --with pytest --with flask python -m pytest node/tests/test_sophia_elya_service.py -q --tb=short` (6 passed); `uv run --no-project --with ruff python -m ruff check node/sophia_elya_service.py node/tests/test_sophia_elya_service.py`; `python3 tools/bcos_spdx_check.py --base-ref origin/main`; `git diff --check origin/main...HEAD -- node/sophia_elya_service.py node/tests/test_sophia_elya_service.py`; and a direct Flask test-client probe reproducing `weight: inf`.


### PR DESCRIPTION
Records a Codex-assisted changes-requested review for RustChain PR 6028 under the ongoing code review bounty #73.

Review: https://github.com/Scottcjn/Rustchain/pull/6028#pullrequestreview-4336007550

Finding: individually finite epoch enrollment weights can overflow to an infinite total weight after multiplication, returning 200, consuming the one-shot ticket, and storing inf in epoch_enroll.

Validation summary: focused pytest 6/6, py_compile, ruff, BCOS SPDX, diff whitespace, and a direct Flask probe reproducing the non-finite total-weight path.

Payout details are intentionally omitted and can be provided by the account owner if maintainers approve the claim.