### PR TITLE
Claim code review bounty for RustChain PR 6080

### DIFF
--- a/claims/pr6080-review-claim-molhamhamwi.md
+++ b/claims/pr6080-review-claim-molhamhamwi.md
@@ -1,0 +1,15 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6080
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6080#pullrequestreview-4343361058
+- Review result: APPROVED; no blockers found
+- Payout details: to be provided by the account owner if maintainers approve the claim
+
+The review verified that `generate_checklist()` now tolerates malformed Postman collection checklist entries without crashing. The checked behavior skips non-object collection items, defaults malformed `request` payloads before field access, treats malformed response collections as having no examples, and avoids joining non-list URL path values while preserving valid string URLs and normal Postman path flattening.
+
+Validation:
+
+- `python3 -m py_compile docs/postman/validate_postman_collection.py tests/test_postman_collection_validator.py`
+- `uv run --no-project --with pytest --with flask python -m pytest tests/test_postman_collection_validator.py -q` (4 passed)
+- `python3 docs/postman/validate_postman_collection.py` (completed successfully; collection valid, 8 folders, 22 example responses)


### PR DESCRIPTION
Adds a claim record for a Codex-assisted review of Scottcjn/Rustchain#6080 under bounty #73.\n\nReview submitted: https://github.com/Scottcjn/Rustchain/pull/6080#pullrequestreview-4343361058\nValidation recorded in the claim file.\n\nPayout details are intentionally omitted for the account owner to provide separately if maintainers approve the claim.