### PR TITLE
Claim code review bounty for RustChain PR 6085

### DIFF
--- a/claims/pr6085-review-claim-molhamhamwi.md
+++ b/claims/pr6085-review-claim-molhamhamwi.md
@@ -1,0 +1,15 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6085
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6085#pullrequestreview-4343396527
+- Review result: APPROVED; no blockers found
+- Payout details: to be provided by the account owner if maintainers approve the claim
+
+The review verified that `verify_backup.verify()` now returns a failed `CheckResult` when the selected backup file path is missing, instead of reaching `copy2()` and surfacing an uncaught filesystem exception. The checked behavior preserves the existing live database missing check, fails before copying a missing backup, and reports the failure through the tool's normal result lines.
+
+Validation:
+
+- `uv run --no-project --with pytest --with flask python -m pytest tests/test_verify_backup.py -q` (4 passed)
+- `python3 -m py_compile tools/verify_backup.py tests/test_verify_backup.py`
+- `git diff --check origin/main...HEAD -- tools/verify_backup.py tests/test_verify_backup.py`


### PR DESCRIPTION
Adds a claim record for a Codex-assisted review of Scottcjn/Rustchain#6085 under bounty #73.\n\nReview submitted: https://github.com/Scottcjn/Rustchain/pull/6085#pullrequestreview-4343396527\nValidation recorded in the claim file.\n\nPayout details are intentionally omitted for the account owner to provide separately if maintainers approve the claim.