### PR TITLE
Claim code review bounty for RustChain PR 6093

### DIFF
--- a/claims/pr6093-review-claim-molhamhamwi.md
+++ b/claims/pr6093-review-claim-molhamhamwi.md
@@ -1,0 +1,15 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6093
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6093#pullrequestreview-4343610912
+- Review result: APPROVED; no blockers found
+- Payout details: to be provided by the account owner if maintainers approve the claim
+
+The review verified that `setup_miner.py --help` is handled by `argparse` before `MinerSetup` is constructed or `run_setup()` performs setup work. The checked behavior preserves the no-argument setup path while making help output non-mutating, including no creation of `~/rustchain_miner` when run with a temporary home directory.
+
+Validation:
+
+- `uv run --no-project --with pytest --with flask python -m pytest tests/test_setup_miner_cli.py tests/test_setup_miner_downloads.py -q` (4 passed)
+- `python3 -m py_compile setup_miner.py tests/test_setup_miner_cli.py`
+- `git diff --check origin/main...HEAD -- setup_miner.py tests/test_setup_miner_cli.py`


### PR DESCRIPTION
Adds a claim record for a Codex-assisted review of Scottcjn/Rustchain#6093 under bounty #73.\n\nReview submitted: https://github.com/Scottcjn/Rustchain/pull/6093#pullrequestreview-4343610912\nValidation recorded in the claim file.\n\nPayout details are intentionally omitted for the account owner to provide separately if maintainers approve the claim.