### PR TITLE
Claim code review bounty for RustChain PR 6084

### DIFF
--- a/claims/pr6084-review-claim-molhamhamwi.md
+++ b/claims/pr6084-review-claim-molhamhamwi.md
@@ -1,0 +1,15 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6084
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6084#pullrequestreview-4343824827
+- Review result: APPROVED; no blockers found
+- Payout details: to be provided by the account owner if maintainers approve the claim
+
+The review verified that `pending_ops.py list --limit` now rejects zero, negative, and non-integer values through an `argparse` type before `cmd_list()` can construct the `/pending/list` node URL. The checked behavior preserves valid positive integer limits and the existing default, while failing invalid values through the CLI parser path without producing stdout.
+
+Validation:
+
+- `uv run --no-project --with pytest --with flask python -m pytest tests/test_pending_ops.py -q` (7 passed)
+- `python3 -m py_compile tools/pending_ops.py tests/test_pending_ops.py`
+- `git diff --check origin/main...HEAD -- tools/pending_ops.py tests/test_pending_ops.py`


### PR DESCRIPTION
Adds a claim record for a Codex-assisted review of Scottcjn/Rustchain#6084 under bounty #73.\n\nReview submitted: https://github.com/Scottcjn/Rustchain/pull/6084#pullrequestreview-4343824827\nValidation recorded in the claim file.\n\nPayout details are intentionally omitted for the account owner to provide separately if maintainers approve the claim.