### PR TITLE
Claim code review bounty for RustChain PR 6106

### DIFF
--- a/claims/pr6106-review-claim-molhamhamwi.md
+++ b/claims/pr6106-review-claim-molhamhamwi.md
@@ -1,0 +1,15 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6106
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6106#pullrequestreview-4344046282
+- Review result: APPROVED; no blockers found
+- Payout details: to be provided by the account owner if maintainers approve the claim
+
+The review verified that passport PDF repair-history rendering now formats malformed, missing, and overflow-style `repair_date` values through `_format_repair_date()` instead of allowing `datetime.fromtimestamp()` to abort PDF export. It also checked that missing repair type and description fields no longer crash the table row rendering, while valid timestamps still render as dates.
+
+Validation:
+
+- `PYTHONPATH=node uv run --no-project --with pytest --with flask --with reportlab python -m pytest node/tests/test_machine_passport.py -q` (36 passed, 4 subtests passed)
+- `python3 -m py_compile node/machine_passport.py node/tests/test_machine_passport.py`
+- Manual `generate_passport_pdf()` smoke test with a malformed repair date produced a non-empty PDF successfully


### PR DESCRIPTION
This PR adds my claim record for a completed Codex-assisted review under the ongoing RustChain code review bounty.

Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6106
Review: https://github.com/Scottcjn/Rustchain/pull/6106#pullrequestreview-4344046282

Validation performed:
- `PYTHONPATH=node uv run --no-project --with pytest --with flask --with reportlab python -m pytest node/tests/test_machine_passport.py -q` (36 passed, 4 subtests passed)
- `python3 -m py_compile node/machine_passport.py node/tests/test_machine_passport.py`
- Manual `generate_passport_pdf()` smoke test with a malformed repair date produced a non-empty PDF successfully

Payout details are intentionally omitted here; the account owner can provide them separately if maintainers approve the claim.
