### PR TITLE
Claim code review bounty for RustChain PR 6105

### DIFF
--- a/claims/pr6105-review-claim-molhamhamwi.md
+++ b/claims/pr6105-review-claim-molhamhamwi.md
@@ -1,0 +1,15 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6105
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6105#pullrequestreview-4344450465
+- Review result: APPROVED; no blockers found
+- Payout details: to be provided by the account owner if maintainers approve the claim
+
+The review verified that the explorer `/api/miners` and `/api/miner/<id>` paths now handle malformed `last_seen` data without returning a 500 response while calculating miner status. Invalid or missing values become `status: "unknown"`, and valid numeric timestamps still produce the expected online/idle/offline status calculation and formatted timestamp.
+
+Validation:
+
+- `PYTHONPATH=. uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_explorer_last_seen_validation.py -q` (2 passed)
+- `python3 -m py_compile explorer/app.py tests/test_explorer_last_seen_validation.py`
+- Manual Flask client smoke checks for valid and missing `last_seen` values


### PR DESCRIPTION
This PR adds my claim record for a completed Codex-assisted review under the ongoing RustChain code review bounty.

Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6105
Review: https://github.com/Scottcjn/Rustchain/pull/6105#pullrequestreview-4344450465

Validation performed:
- `PYTHONPATH=. uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_explorer_last_seen_validation.py -q` (2 passed)
- `python3 -m py_compile explorer/app.py tests/test_explorer_last_seen_validation.py`
- Manual Flask client smoke checks for valid and missing `last_seen` values

Payout details are intentionally omitted here; the account owner can provide them separately if maintainers approve the claim.
