### PR TITLE
Claim code review bounty for RustChain PR 6079

### DIFF
--- a/claims/pr6079-review-claim-molhamhamwi.md
+++ b/claims/pr6079-review-claim-molhamhamwi.md
@@ -1,0 +1,15 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6079
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6079#pullrequestreview-4344636736
+- Review result: APPROVED; no blockers found
+- Payout details: to be provided by the account owner if maintainers approve the claim
+
+The review verified that `validate_security()` now skips malformed path-item entries before method lookup and only inspects dictionary-shaped operations. Malformed OpenAPI `paths` content no longer aborts security-scheme validation, while valid operations still report undefined security schemes.
+
+Validation:
+
+- `uv run --no-project --with pytest --with pyyaml --with flask python -m pytest tests/test_openapi_validator.py -q` (6 passed)
+- `python3 -m py_compile docs/api/validate_openapi.py tests/test_openapi_validator.py`
+- `uv run --no-project --with pyyaml python docs/api/validate_openapi.py docs/api/openapi.yaml` was attempted, but the checked-in OpenAPI spec currently stops on an existing YAML parse error, so the focused unit coverage was treated as the relevant validation for this patch


### PR DESCRIPTION
This PR adds my claim record for a completed Codex-assisted review under the ongoing RustChain code review bounty.

Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6079
Review: https://github.com/Scottcjn/Rustchain/pull/6079#pullrequestreview-4344636736

Validation performed:
- `uv run --no-project --with pytest --with pyyaml --with flask python -m pytest tests/test_openapi_validator.py -q` (6 passed)
- `python3 -m py_compile docs/api/validate_openapi.py tests/test_openapi_validator.py`
- `uv run --no-project --with pyyaml python docs/api/validate_openapi.py docs/api/openapi.yaml` was attempted, but the checked-in OpenAPI spec currently stops on an existing YAML parse error, so the focused unit coverage was treated as the relevant validation for this patch

Payout details are intentionally omitted here; the account owner can provide them separately if maintainers approve the claim.
