### PR TITLE
Claim code review bounty for RustChain PR 6073

### DIFF
--- a/claims/pr6073-review-claim-molhamhamwi.md
+++ b/claims/pr6073-review-claim-molhamhamwi.md
@@ -1,0 +1,14 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6073
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6073#pullrequestreview-4344969739
+- Review result: APPROVED; no blockers found
+- Payout details: to be provided by the account owner if maintainers approve the claim
+
+The review verified that the GitHub bounty verifier now preserves 204 No Content response status in the returned header map so `check_following()` can correctly detect a successful follow relationship. The tested path covers the user-exists request followed by the 204 follow-status check without changing normal JSON-response handling.
+
+Validation:
+
+- `uv run --no-project --with pytest --with flask --with pyyaml --with requests python -m pytest tests/test_bounty_verifier.py -q` (42 passed)
+- `python3 -m py_compile tools/bounty_verifier/github_client.py tests/test_bounty_verifier.py`


### PR DESCRIPTION
This PR adds my claim record for a completed Codex-assisted review under the ongoing RustChain code review bounty.

Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6073
Review: https://github.com/Scottcjn/Rustchain/pull/6073#pullrequestreview-4344969739

Validation performed:
- `uv run --no-project --with pytest --with flask --with pyyaml --with requests python -m pytest tests/test_bounty_verifier.py -q` (42 passed)
- `python3 -m py_compile tools/bounty_verifier/github_client.py tests/test_bounty_verifier.py`

Payout details are intentionally omitted here; the account owner can provide them separately if maintainers approve the claim.
