### PR TITLE
Claim code review bounty for RustChain PR 6066

### DIFF
--- a/claims/pr6066-review-claim-molhamhamwi.md
+++ b/claims/pr6066-review-claim-molhamhamwi.md
@@ -1,0 +1,15 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6066
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6066#pullrequestreview-4345153494
+- Review result: APPROVED; no blockers found
+- Payout details: to be provided by the account owner if maintainers approve the claim
+
+The review verified that `get_tls_verify()` now follows the same explicit CA bundle and local opt-out precedence as `get_ssl_context()`. `RUSTCHAIN_TLS_VERIFY=false` returns `False`, otherwise `RUSTCHAIN_CA_BUNDLE` is honored before the pinned cert fallback, while the default path still uses verified TLS.
+
+Validation:
+
+- `PYTHONPATH=. uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_tls_config.py -q` (6 passed)
+- `python3 -m py_compile node/tls_config.py tests/test_tls_config.py`
+- Manual smoke check for explicit CA bundle and local opt-out precedence


### PR DESCRIPTION
This PR adds my claim record for a completed Codex-assisted review under the ongoing RustChain code review bounty.

Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6066
Review: https://github.com/Scottcjn/Rustchain/pull/6066#pullrequestreview-4345153494

Validation performed:
- `PYTHONPATH=. uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_tls_config.py -q` (6 passed)
- `python3 -m py_compile node/tls_config.py tests/test_tls_config.py`
- Manual smoke check for explicit CA bundle and local opt-out precedence

Payout details are intentionally omitted here; the account owner can provide them separately if maintainers approve the claim.
