### PR TITLE
Claim code review bounty for RustChain PR 6065

### DIFF
--- a/claims/pr6065-review-claim-molhamhamwi.md
+++ b/claims/pr6065-review-claim-molhamhamwi.md
@@ -1,0 +1,15 @@
+This claim records a Codex-assisted code review for the ongoing RustChain code review bounty.
+
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/73
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6065
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6065#pullrequestreview-4345332176
+- Review result: APPROVED; no blockers found
+- Payout details: to be provided by the account owner if maintainers approve the claim
+
+The review verified that Beacon envelope storage and signature verification now reject structured or non-string values for required text fields before kind validation, signature encoding, or database writes. Empty and missing fields still use the existing missing-fields path, while valid string fields continue through the prior validation flow.
+
+Validation:
+
+- `PYTHONPATH=node uv run --no-project --with pytest --with pynacl python -m pytest node/tests/test_beacon_anchor_field_validation.py -q` (2 passed)
+- `python3 -m py_compile node/beacon_anchor.py node/tests/test_beacon_anchor_field_validation.py`
+- Manual smoke check for structured `kind`/`sig` rejection and invalid-kind preservation


### PR DESCRIPTION
This PR adds my claim record for a completed Codex-assisted review under the ongoing RustChain code review bounty.

Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6065
Review: https://github.com/Scottcjn/Rustchain/pull/6065#pullrequestreview-4345332176

Validation performed:
- `PYTHONPATH=node uv run --no-project --with pytest --with pynacl python -m pytest node/tests/test_beacon_anchor_field_validation.py -q` (2 passed)
- `python3 -m py_compile node/beacon_anchor.py node/tests/test_beacon_anchor_field_validation.py`
- Manual smoke check for structured `kind`/`sig` rejection and invalid-kind preservation

Payout details are intentionally omitted here; the account owner can provide them separately if maintainers approve the claim.
