### PR TITLE
Claim code review bounty for RustChain PR 6061

### DIFF
--- a/claims/pr6061-review-claim-molhamhamwi.md
+++ b/claims/pr6061-review-claim-molhamhamwi.md
@@ -1,0 +1,23 @@
+# Code Review Bounty Claim: RustChain PR #6061
+
+## Reviewed PR
+
+- Repository: `Scottcjn/Rustchain`
+- Pull request: https://github.com/Scottcjn/Rustchain/pull/6061
+- Head commit reviewed: `5f1000c88c975420507560c1701f01a8cf616f35`
+
+## Review
+
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6061#pullrequestreview-4345765390
+- Review outcome: approved, no blocking issues found
+
+## Validation Performed
+
+- `uv run --no-project --with pytest python -m pytest node/tests/test_claims_eligibility_helpers.py -q`
+- `python3 -m py_compile node/claims_eligibility.py node/tests/test_claims_eligibility_helpers.py`
+- `git diff --check origin/main...HEAD -- node/claims_eligibility.py node/tests/test_claims_eligibility_helpers.py`
+- Manual ImportError-path smoke check confirming `PER_EPOCH_URTC == 1500000` and `PER_EPOCH_URTC / URTC_PER_RTC == 1.5`.
+
+## Notes
+
+The review focused on the standalone claims eligibility fallback path. The patch keeps the fallback reward amount in uRTC units, preserving the intended 1.5 RTC display instead of inflating the fallback value.


### PR DESCRIPTION
## Claim

Claiming the code review bounty for Scottcjn/Rustchain#6061.

## Review

Review submitted: https://github.com/Scottcjn/Rustchain/pull/6061#pullrequestreview-4345765390

## Validation performed

- `uv run --no-project --with pytest python -m pytest node/tests/test_claims_eligibility_helpers.py -q`
- `python3 -m py_compile node/claims_eligibility.py node/tests/test_claims_eligibility_helpers.py`
- `git diff --check origin/main...HEAD -- node/claims_eligibility.py node/tests/test_claims_eligibility_helpers.py`
- Manual ImportError-path smoke check confirming `PER_EPOCH_URTC == 1500000` and `PER_EPOCH_URTC / URTC_PER_RTC == 1.5`.

## Outcome

No blocking issues found. The patch keeps the standalone claims eligibility fallback reward amount in uRTC units and adds focused regression coverage for that path.
