### PR TITLE
Claim code review bounty for RustChain PR 6109

### DIFF
--- a/claims/pr6109-review-claim-molhamhamwi.md
+++ b/claims/pr6109-review-claim-molhamhamwi.md
@@ -1,0 +1,23 @@
+# Code Review Bounty Claim: RustChain PR #6109
+
+## Reviewed PR
+
+- Repository: `Scottcjn/Rustchain`
+- Pull request: https://github.com/Scottcjn/Rustchain/pull/6109
+- Head commit reviewed: `9c957f9277e274e4ceeeae02303fea5ca451bfca`
+
+## Review
+
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6109#pullrequestreview-4346032219
+- Review outcome: approved, no blocking issues found
+
+## Validation Performed
+
+- `uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_wallet_transfer_admin_key_unset.py tests/test_api.py tests/test_gov_rotate_api.py -q`
+- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_transfer_admin_key_unset.py tests/test_api.py tests/test_gov_rotate_api.py`
+- `git diff --check origin/main...HEAD`
+- Source-level smoke check confirming the targeted `hmac.compare_digest(..., ADMIN_KEY or "")` empty-fallback patterns are gone.
+
+## Notes
+
+The review focused on fail-closed admin route hardening. The patch removes empty `ADMIN_KEY` fallback comparisons from the remaining admin-report style routes and keeps `/ops/readiness` details hidden unless a configured module key and submitted key are both present.


### PR DESCRIPTION
## Claim

Claiming the code review bounty for Scottcjn/Rustchain#6109.

## Review

Review submitted: https://github.com/Scottcjn/Rustchain/pull/6109#pullrequestreview-4346032219

## Validation performed

- `uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_wallet_transfer_admin_key_unset.py tests/test_api.py tests/test_gov_rotate_api.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_transfer_admin_key_unset.py tests/test_api.py tests/test_gov_rotate_api.py`
- `git diff --check origin/main...HEAD`
- Source-level smoke check confirming the targeted `hmac.compare_digest(..., ADMIN_KEY or "")` empty-fallback patterns are gone.

## Outcome

No blocking issues found. The patch makes the remaining admin report routes fail closed on empty module admin keys and keeps readiness details behind a configured admin key.
