### PR TITLE
Claim code review bounty for RustChain PR 6071

### DIFF
--- a/claims/pr6071-review-claim-molhamhamwi.md
+++ b/claims/pr6071-review-claim-molhamhamwi.md
@@ -1,0 +1,23 @@
+# Code Review Bounty Claim: RustChain PR #6071
+
+## Reviewed PR
+
+- Repository: `Scottcjn/Rustchain`
+- Pull request: https://github.com/Scottcjn/Rustchain/pull/6071
+- Head commit reviewed: `fe019da94cb7b6a55ce0baf8d724b6b33436cccb`
+
+## Review
+
+- Review submitted: https://github.com/Scottcjn/Rustchain/pull/6071#pullrequestreview-4346442338
+- Review outcome: approved, no blocking issues found
+
+## Validation Performed
+
+- `uv run --no-project --with pytest --with pyyaml --with flask --with requests python -m pytest tests/test_bounty_verifier.py -q`
+- `python3 -m py_compile tools/bounty_verifier/verifier.py tests/test_bounty_verifier.py`
+- `git diff --check origin/main...HEAD`
+- Manual parser smoke check for RTC-prefixed hex, bare labeled hex, uppercase labeled hex, non-hex labeled text, and short RTC-prefixed text.
+
+## Notes
+
+The review focused on bounty verifier wallet-address parsing. The patch narrows wallet matches to a full 40-character hex suffix while preserving intended normalization of bare hex values after `Wallet:` and `Address:` labels.


### PR DESCRIPTION
## Claim

Claiming the code review bounty for Scottcjn/Rustchain#6071.

## Review

Review submitted: https://github.com/Scottcjn/Rustchain/pull/6071#pullrequestreview-4346442338

## Validation performed

- `uv run --no-project --with pytest --with pyyaml --with flask --with requests python -m pytest tests/test_bounty_verifier.py -q`
- `python3 -m py_compile tools/bounty_verifier/verifier.py tests/test_bounty_verifier.py`
- `git diff --check origin/main...HEAD`
- Manual parser smoke check for RTC-prefixed hex, bare labeled hex, uppercase labeled hex, non-hex labeled text, and short RTC-prefixed text.

## Outcome

No blocking issues found. The patch narrows bounty verifier wallet parsing to full 40-character hex suffixes while preserving intended labeled bare-hex normalization.
