### PR TITLE
Claim code review bounty for RustChain PR 6069

### DIFF
--- a/claims/pr6069-review-claim-molhamhamwi.md
+++ b/claims/pr6069-review-claim-molhamhamwi.md
@@ -1,0 +1,17 @@
+# Code Review Bounty Claim — Scottcjn/Rustchain#6069
+
+Claimant: `MolhamHamwi`
+
+Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6069
+
+Review submitted: https://github.com/Scottcjn/Rustchain/pull/6069#pullrequestreview-4347331317
+
+## Validation Performed
+
+- `uv run --no-project --with pytest --with flask python -m pytest tests/test_fleet_scores_limit_validation.py -q`
+- `python3 -m py_compile rips/python/rustchain/fleet_immune_system.py tests/test_fleet_scores_limit_validation.py`
+- `git diff --check origin/main...HEAD`
+
+## Outcome
+
+No blocking issues found. The patch restores the `miner` column in the filtered fleet scores query so the response mapper keeps miner, epoch, and signal fields correctly aligned.


### PR DESCRIPTION
## Claim

Claiming the code review bounty for Scottcjn/Rustchain#6069.

## Review

Review submitted: https://github.com/Scottcjn/Rustchain/pull/6069#pullrequestreview-4347331317

## Validation performed

- `uv run --no-project --with pytest --with flask python -m pytest tests/test_fleet_scores_limit_validation.py -q`
- `python3 -m py_compile rips/python/rustchain/fleet_immune_system.py tests/test_fleet_scores_limit_validation.py`
- `git diff --check origin/main...HEAD`

## Outcome

No blocking issues found. The patch restores the `miner` column in the filtered fleet scores query so the response mapper keeps miner, epoch, and signal fields correctly aligned.
