### PR TITLE
Claim code review bounty for RustChain PR 6082

### DIFF
--- a/claims/pr6082-review-claim-molhamhamwi.md
+++ b/claims/pr6082-review-claim-molhamhamwi.md
@@ -1,0 +1,17 @@
+# Code Review Bounty Claim — Scottcjn/Rustchain#6082
+
+Claimant: `MolhamHamwi`
+
+Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6082
+
+Review submitted: https://github.com/Scottcjn/Rustchain/pull/6082#pullrequestreview-4347553681
+
+## Validation Performed
+
+- `uv run --no-project --with pytest --with flask python -m pytest tests/test_fuzz_corpus_manager.py -q`
+- `python3 -m py_compile tools/fuzz/corpus_manager.py tests/test_fuzz_corpus_manager.py`
+- `git diff --check origin/main...HEAD`
+
+## Outcome
+
+No blocking issues found. The patch makes fuzz corpus imports reject malformed top-level JSON shapes and skip malformed crash entries without breaking valid imports, deduplication, or regression-suite behavior.


### PR DESCRIPTION
## Claim

Claiming the code review bounty for Scottcjn/Rustchain#6082.

## Review

Review submitted: https://github.com/Scottcjn/Rustchain/pull/6082#pullrequestreview-4347553681

## Validation performed

- `uv run --no-project --with pytest --with flask python -m pytest tests/test_fuzz_corpus_manager.py -q`
- `python3 -m py_compile tools/fuzz/corpus_manager.py tests/test_fuzz_corpus_manager.py`
- `git diff --check origin/main...HEAD`

## Outcome

No blocking issues found. The patch makes fuzz corpus imports reject malformed top-level JSON shapes and skip malformed crash entries without breaking valid imports, deduplication, or regression-suite behavior.
