### PR TITLE
Claim code review bounty for RustChain PR 6101

### DIFF
--- a/claims/pr6101-review-claim-molhamhamwi.md
+++ b/claims/pr6101-review-claim-molhamhamwi.md
@@ -1,0 +1,17 @@
+# Code Review Bounty Claim — Scottcjn/Rustchain#6101
+
+Claimant: `MolhamHamwi`
+
+Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6101
+
+Review submitted: https://github.com/Scottcjn/Rustchain/pull/6101#pullrequestreview-4347998499
+
+## Validation Performed
+
+- `uv run --no-project --with pytest --with requests --with flask python -m pytest tests/test_ppc_miner_hardware_methods.py -q`
+- `python3 -m py_compile miners/ppc/rustchain_powerpc_g4_miner_v2.2.2.py tests/test_ppc_miner_hardware_methods.py`
+- `git diff --check origin/main...HEAD`
+
+## Outcome
+
+No blocking issues found. The patch restores PowerPC G4 miner hardware helper methods as `G4Miner` methods by moving `main()` below the class and adds targeted tests for construction and attestation entropy flow.


### PR DESCRIPTION
## Claim

Claiming the code review bounty for Scottcjn/Rustchain#6101.

## Review

Review submitted: https://github.com/Scottcjn/Rustchain/pull/6101#pullrequestreview-4347998499

## Validation performed

- `uv run --no-project --with pytest --with requests --with flask python -m pytest tests/test_ppc_miner_hardware_methods.py -q`
- `python3 -m py_compile miners/ppc/rustchain_powerpc_g4_miner_v2.2.2.py tests/test_ppc_miner_hardware_methods.py`
- `git diff --check origin/main...HEAD`

## Outcome

No blocking issues found. The patch restores PowerPC G4 miner hardware helper methods as `G4Miner` methods by moving `main()` below the class and adds targeted tests for construction and attestation entropy flow.
