### PR TITLE
docs: claim code review bounty for PR 6116

### DIFF
--- a/claims/pr6116-review-claim-molhamhamwi.md
+++ b/claims/pr6116-review-claim-molhamhamwi.md
@@ -1,0 +1,17 @@
+# Code Review Bounty Claim - Scottcjn/Rustchain#6116
+
+Claimant: `MolhamHamwi`
+
+Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6116
+
+Review submitted: https://github.com/Scottcjn/Rustchain/pull/6116#pullrequestreview-4349023820
+
+## Validation Performed
+
+- `uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_wallet_transfer_admin_key_unset.py -q`
+- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_transfer_admin_key_unset.py`
+- `git diff --check origin/main...HEAD`
+
+## Outcome
+
+No blocking issues found. The patch centralizes touched admin-route checks so unset admin-key configuration fails closed with `ADMIN_KEY_UNSET` instead of falling through to empty-key authorization behavior.


### PR DESCRIPTION
## Summary

- Adds a code review bounty claim for Scottcjn/Rustchain#6116.
- Links the submitted approving review and the validation commands that were run.

## Validation

- `uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_wallet_transfer_admin_key_unset.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_transfer_admin_key_unset.py`
- `git diff --check origin/main...HEAD`
