### PR TITLE
docs: claim code review bounty for PR 6117

### DIFF
--- a/claims/pr6117-review-claim-molhamhamwi.md
+++ b/claims/pr6117-review-claim-molhamhamwi.md
@@ -1,0 +1,17 @@
+# Code Review Bounty Claim - Scottcjn/Rustchain#6117
+
+Claimant: `MolhamHamwi`
+
+Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6117
+
+Review submitted: https://github.com/Scottcjn/Rustchain/pull/6117#pullrequestreview-4349031460
+
+## Validation Performed
+
+- `uv run --no-project --with pytest --with flask python -m pytest tests/test_utxo_malformed_pubkey.py -q`
+- `python3 -m py_compile node/utxo_endpoints.py tests/test_utxo_malformed_pubkey.py`
+- `git diff --check origin/main...HEAD`
+
+## Outcome
+
+No blocking issues found. The patch turns malformed `public_key` hex values in `/utxo/transfer` into a 400 `Invalid public_key` response instead of allowing the address converter exception to surface as a server error.


### PR DESCRIPTION
## Summary

- Adds a code review bounty claim for Scottcjn/Rustchain#6117.
- Links the submitted approving review and the validation commands that were run.

## Validation

- `uv run --no-project --with pytest --with flask python -m pytest tests/test_utxo_malformed_pubkey.py -q`
- `python3 -m py_compile node/utxo_endpoints.py tests/test_utxo_malformed_pubkey.py`
- `git diff --check origin/main...HEAD`
