### PR TITLE
Claim Bottube code review bounty for three PRs

### DIFF
--- a/claims/code-review-bounty-73-jackane21-bottube-1214-20260522.md
+++ b/claims/code-review-bounty-73-jackane21-bottube-1214-20260522.md
@@ -1,0 +1,52 @@
+# Code Review Bounty Claim: BoTTube PR #1214
+
+## Claimant
+
+- Reviewer: `@JacKane21`
+- Wallet: `RTC7539aeed433526eba7f5a393b1bd455fcd48af176ec4e67d0f7f10cfa477175d`
+- Bounty: Scottcjn/rustchain-bounties#73
+
+## Review Submitted
+
+- Repository: `Scottcjn/bottube`
+- Pull request: https://github.com/Scottcjn/bottube/pull/1214
+- Review: https://github.com/Scottcjn/bottube/pull/1214#pullrequestreview-4349506352
+- Head commit reviewed: `344b10fc8282c8d011c1358af78f1649ca39c295`
+- Review outcome: changes requested
+
+## Finding Summary
+
+The PR fixes several malformed JSON crashes in admin referral and badge
+endpoints, but one malformed-body path remains in the same endpoint family.
+
+`POST /api/admin/badges/assign` validates the top-level JSON body and
+`badge_key`, but still passes unvalidated `agent_name` into
+`_resolve_badge_target_agent()`. That helper performs `.strip()` on
+`agent_name`, so a request with a valid `badge_key` and list-valued
+`agent_name` still raises `AttributeError` before returning a deterministic
+400 response.
+
+Reproduction payload:
+
+```json
+{
+  "agent_name": ["badgeguy"],
+  "badge_key": "early_human_bottube"
+}
+```
+
+I requested validation for `agent_name` before calling
+`_resolve_badge_target_agent()`, or moving that validation into the helper so
+all callers receive the same protection.
+
+## Validation Performed
+
+- `uv run --no-project --with pytest --with flask --with requests --with python-dotenv --with pillow --with qrcode --with pytest-cov python -m pytest -p no:cacheprovider tests/test_malformed_json_admin.py -q` -> 10 passed
+- `uv run --no-project --with flask --with requests --with python-dotenv --with pillow --with qrcode python -m py_compile bottube_server.py tests/test_malformed_json_admin.py` -> passed
+- `git diff --check origin/main...HEAD` -> passed
+
+## Reward Request
+
+Please assess this review under bounty issue #73. Direct issue-comment claims
+are unavailable because GitHub disables comments after 2500 comments, so this
+PR is the fallback claim path.

--- a/claims/code-review-bounty-73-jackane21-bottube-1214-20260522.md
+++ b/claims/code-review-bounty-73-jackane21-bottube-1214-20260522.md
@@ -1,4 +1,4 @@
-# Code Review Bounty Claim: BoTTube PR #1214
+# Code Review Bounty Claim: Three BoTTube PR Reviews
 
 ## Claimant
 
@@ -6,7 +6,9 @@
 - Wallet: `RTC7539aeed433526eba7f5a393b1bd455fcd48af176ec4e67d0f7f10cfa477175d`
 - Bounty: Scottcjn/rustchain-bounties#73
 
-## Review Submitted
+## Reviews Submitted
+
+### 1. Scottcjn/bottube#1214 -- Changes Requested
 
 - Repository: `Scottcjn/bottube`
 - Pull request: https://github.com/Scottcjn/bottube/pull/1214
@@ -14,7 +16,7 @@
 - Head commit reviewed: `344b10fc8282c8d011c1358af78f1649ca39c295`
 - Review outcome: changes requested
 
-## Finding Summary
+Finding summary:
 
 The PR fixes several malformed JSON crashes in admin referral and badge
 endpoints, but one malformed-body path remains in the same endpoint family.
@@ -39,14 +41,73 @@ I requested validation for `agent_name` before calling
 `_resolve_badge_target_agent()`, or moving that validation into the helper so
 all callers receive the same protection.
 
-## Validation Performed
+Validation performed:
 
 - `uv run --no-project --with pytest --with flask --with requests --with python-dotenv --with pillow --with qrcode --with pytest-cov python -m pytest -p no:cacheprovider tests/test_malformed_json_admin.py -q` -> 10 passed
 - `uv run --no-project --with flask --with requests --with python-dotenv --with pillow --with qrcode python -m py_compile bottube_server.py tests/test_malformed_json_admin.py` -> passed
 - `git diff --check origin/main...HEAD` -> passed
 
+### 2. Scottcjn/bottube#1211 -- Approved
+
+- Repository: `Scottcjn/bottube`
+- Pull request: https://github.com/Scottcjn/bottube/pull/1211
+- Review: https://github.com/Scottcjn/bottube/pull/1211#pullrequestreview-4349519447
+- Head commit reviewed: `bc66e2ff5e85522248cd8edd7fc9e83e500431cf`
+- Review outcome: approved
+
+Finding summary:
+
+The review checked the malformed JSON fixes for `/api/beef/arcs` and
+`/api/beef/arcs/<arc_id>/resolve`. The top-level parsed body now stays on the
+validation path for non-object JSON, `relationship_id` now goes through the
+positive-integer parser before DB lookup, `arc_template` is type-checked before
+template membership checks, and `resolution_note` is type-checked before
+SQLite binding.
+
+I also noted one non-blocking follow-up: `resolve_arc()` still performs the
+UPDATE before checking whether an arc exists, so a future cleanup could fetch
+first and return 404 before a no-op update.
+
+Validation performed:
+
+- `uv run --no-project --with pytest --with flask python -m pytest -p no:cacheprovider tests/test_beef_system.py -q` -> 36 passed
+- `uv run --no-project --with flask python -m py_compile agent_relationships.py tests/test_beef_system.py` -> passed
+- `git diff --check origin/main...HEAD` -> passed
+
+### 3. Scottcjn/bottube#1207 -- Changes Requested
+
+- Repository: `Scottcjn/bottube`
+- Pull request: https://github.com/Scottcjn/bottube/pull/1207
+- Review: https://github.com/Scottcjn/bottube/pull/1207#pullrequestreview-4349778405
+- Follow-up review: https://github.com/Scottcjn/bottube/pull/1207#pullrequestreview-4349789426
+- Head commit reviewed: `84823494e7e97067e20187584a5782ecdd1d2dc7`
+- Review outcome: changes requested
+
+Finding summary:
+
+The initial review verified the watch-time telemetry validation path: numeric
+seconds parsing, non-finite and negative rejection, positive-value tracking,
+and regression coverage. A follow-up found that the implementation used
+`request.get_json(silent=True) or {}`, which masks falsy non-object JSON values
+such as `[]`, `false`, `0`, and `""`.
+
+That means an empty-array JSON body becomes `{}` before the `isinstance` check,
+so the endpoint can return a successful no-op instead of the intended `400`
+for a non-object JSON body. I requested the safer shape where only `None`
+defaults to `{}` and other non-dict JSON values return 400, plus a regression
+for an empty array body.
+
+Validation performed:
+
+- `python3 -m py_compile bottube_server.py tests/test_watch_time_input_validation.py` -> passed
+- `git diff --check origin/main...HEAD` -> passed
+- Could not run pytest in the available local Python environments for this
+  review because pytest was not installed; GitHub `test`, `lint`, and
+  `security` checks were green, with only unrelated `auto-label` failing.
+
 ## Reward Request
 
-Please assess this review under bounty issue #73. Direct issue-comment claims
-are unavailable because GitHub disables comments after 2500 comments, so this
-PR is the fallback claim path.
+Please assess these three reviews under bounty issue #73 and the current
+three-reviews-per-24h cap. Direct issue-comment claims are unavailable because
+GitHub disables comments after 2500 comments, so this PR is the fallback claim
+path.


### PR DESCRIPTION
## Bounty Submission

**Bounty**: #73

**RTC Wallet**: `RTC7539aeed433526eba7f5a393b1bd455fcd48af176ec4e67d0f7f10cfa477175d`

## Changes

- Adds a claim document for three substantive JacKane21 reviews under the current #73 three-reviews-per-24h cap.
- Covers Scottcjn/bottube PR #1214, PR #1211, and PR #1207.
- Notes that issue comments are disabled on #73 after 2500+ comments, so this PR is the fallback claim path.

## Evidence

- PR #1214 review: https://github.com/Scottcjn/bottube/pull/1214#pullrequestreview-4349506352
- PR #1211 review: https://github.com/Scottcjn/bottube/pull/1211#pullrequestreview-4349519447
- PR #1207 review: https://github.com/Scottcjn/bottube/pull/1207#pullrequestreview-4349778405
- PR #1207 follow-up: https://github.com/Scottcjn/bottube/pull/1207#pullrequestreview-4349789426

## Validation

- Validation details are recorded in `claims/code-review-bounty-73-jackane21-bottube-1214-20260522.md`.
- Documentation-only claim file; no repository test suite changes.

## Checklist

- [x] Claim references the bounty issue.
- [x] Wallet included.
- [x] No secrets or credentials committed.