### PR TITLE
docs: claim code review bounty for PR 6141

### DIFF
--- a/claims/pr6141-review-claim-molhamhamwi.md
+++ b/claims/pr6141-review-claim-molhamhamwi.md
@@ -1,0 +1,35 @@
+# Code review bounty claim: RustChain PR #6141
+
+## Summary
+
+Claiming a code-review bounty for reviewing Scottcjn/Rustchain#6141 (`Reject malformed governance public keys`).
+
+## Review evidence
+
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6141
+- Submitted review: https://github.com/Scottcjn/Rustchain/pull/6141#pullrequestreview-4351346202
+- Reviewed commit: `688be1c11460e64c32a726993326ea782888170b`
+- Scope reviewed: `node/rustchain_v2_integrated_v2.2.1_rip200.py`, `setup_miner.py`, `tests/test_governance_api.py`, and `tests/test_setup_miner_help.py`
+- Local validation run:
+  - `python3 -m pytest tests/test_governance_api.py tests/test_setup_miner_help.py -q`
+  - `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py setup_miner.py tests/test_governance_api.py tests/test_setup_miner_help.py`
+  - `git diff --check origin/main...HEAD`
+- Result: targeted tests passed (`7 passed`); py_compile and diff whitespace checks passed.
+
+## Findings
+
+### Critical
+
+None found.
+
+### Warnings
+
+None found.
+
+### Verdict
+
+Approve. The PR rejects non-string and malformed governance `public_key` payloads with a controlled `invalid_public_key` 400 response before wallet derivation, preventing a malformed request from taking the endpoint down a server-error path. The added regression coverage exercises the bad-key behavior, and the setup-miner argparse change makes `--help` safe/non-mutating while preserving normal setup execution.
+
+## Payout note
+
+No wallet or payout details are included here; the account owner can provide any required payout information separately if approved.


### PR DESCRIPTION
## Summary
- adds a code review bounty claim for Scottcjn/Rustchain#6141
- links the submitted approval review and reviewed commit
- records local validation: targeted pytest, py_compile, and git diff --check

## Validation
- python3 -m pytest tests/test_governance_api.py tests/test_setup_miner_help.py -q → 7 passed
- python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py setup_miner.py tests/test_governance_api.py tests/test_setup_miner_help.py
- git diff --check origin/main...HEAD