### PR TITLE
docs: claim code review bounty for PR 6165

### DIFF
--- a/claims/pr6165-review-claim-molhamhamwi.md
+++ b/claims/pr6165-review-claim-molhamhamwi.md
@@ -1,0 +1,26 @@
+# Code Review Bounty Claim: Scottcjn/Rustchain#6165
+
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6165
+- Submitted review: https://github.com/Scottcjn/Rustchain/pull/6165#pullrequestreview-4351799882
+- Follow-up correction/comment: https://github.com/Scottcjn/Rustchain/pull/6165#issuecomment-4527185494
+- Reviewer: @MolhamHamwi
+- Review outcome: Changes requested
+
+## Review summary
+
+Reviewed the Windows miner installer detection patch. The patch adds Git Bash/MSYS/Cygwin detection and skips service setup on Windows, but the Windows path still uses POSIX virtualenv executable locations (`$VENV_DIR/bin/python` and `$VENV_DIR/bin/pip`) for dependency installation and generated start scripts. Python virtualenvs created on Windows expose executables under `Scripts/`, so the installer can still fail after the new detection branch.
+
+## Validation performed
+
+- Inspected the implementation diff in `install-miner.sh`.
+- Ran shell syntax validation:
+  - `bash -n install-miner.sh`
+  - Result: passed.
+- Ran the dry-run installer path on macOS/arm64:
+  - `./install-miner.sh --dry-run --wallet review-wallet --skip-checksum --skip-service`
+  - Result: passed.
+- Performed static review of the Windows-specific branch and reported the remaining `Scripts/` vs `bin/` virtualenv path issue.
+
+## Notes
+
+The initial review body was mangled by shell interpolation, so I posted a corrected PR comment with the complete blocker details and suggested fix.


### PR DESCRIPTION
Claim code review bounty for Scottcjn/Rustchain#6165.

Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6165
Submitted review: https://github.com/Scottcjn/Rustchain/pull/6165#pullrequestreview-4351799882
Correction/comment with full blocker details: https://github.com/Scottcjn/Rustchain/pull/6165#issuecomment-4527185494

Validation:
- bash -n install-miner.sh -> passed
- ./install-miner.sh --dry-run --wallet review-wallet --skip-checksum --skip-service -> passed on macOS/arm64
- Static Windows branch review found remaining virtualenv `Scripts/` vs `bin/` path blocker

The claim file is in claims/pr6165-review-claim-molhamhamwi.md.
