### PR TITLE
docs: claim code review bounty for PR 6168

### DIFF
--- a/claims/pr6168-review-claim-molhamhamwi.md
+++ b/claims/pr6168-review-claim-molhamhamwi.md
@@ -1,0 +1,40 @@
+# Code Review Bounty Claim: Scottcjn/Rustchain#6168
+
+- Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6168
+- Submitted review: https://github.com/Scottcjn/Rustchain/pull/6168#pullrequestreview-4351840213
+- Reviewer: @MolhamHamwi
+- Review outcome: Approved / no blockers
+
+## Review summary
+
+Reviewed the server proxy allowlist hardening for the public G4/miner API. The PR restricts forwarded `/api/*` traffic to the advertised routes only (`POST /api/register`, `POST /api/mine`, `GET /api/stats`), rejects wrong methods/unlisted paths before upstream calls, and adds JSON-object validation for POST payloads.
+
+## Validation performed
+
+- Inspected the current diff in `node/server_proxy.py` and `tests/test_server_proxy_path.py`.
+- Confirmed the allowlist is narrow and preserves the existing dot-segment/path-escape rejection before proxying.
+- Confirmed unlisted paths, wrong methods, non-object POST JSON, allowed GET/POST forwarding, and upstream error-sanitization paths are covered by tests.
+- Ran the focused proxy regression tests:
+
+  ```text
+  python -m pytest tests/test_server_proxy_path.py -q
+  12 passed
+  ```
+
+- Ran syntax validation:
+
+  ```text
+  python -m py_compile node/server_proxy.py tests/test_server_proxy_path.py
+  passed
+  ```
+
+- Ran whitespace/diff validation:
+
+  ```text
+  git diff --check origin/main...HEAD
+  passed
+  ```
+
+## Notes
+
+No blockers found. The change is fail-closed for public proxy routing and keeps the public endpoint surface aligned with the service's documented G4/miner API.


### PR DESCRIPTION
Adds my code review bounty claim for Scottcjn/Rustchain#6168.\n\nReviewed and approved: https://github.com/Scottcjn/Rustchain/pull/6168#pullrequestreview-4351840213\n\nValidation recorded in the claim file:\n- python -m pytest tests/test_server_proxy_path.py -q -> 12 passed\n- python -m py_compile node/server_proxy.py tests/test_server_proxy_path.py\n- git diff --check origin/main...HEAD