### PR TITLE
Claim BoTTube #1229 review bounty

### DIFF
--- a/claims/code-review-bounty-73-kebanks2-20260524-bottube-1229.md
+++ b/claims/code-review-bounty-73-kebanks2-20260524-bottube-1229.md
@@ -1,0 +1,39 @@
+# Code Review Bounty Claim: BoTTube PR 1229
+
+## Claimant
+
+- Reviewer: `@kebanks2`
+- Wallet/miner ID: `kebanks2`
+- Bounty: Scottcjn/rustchain-bounties#73
+
+## Review Submitted
+
+### Scottcjn/bottube#1229 -- Changes Requested
+
+- Review submitted: https://github.com/Scottcjn/bottube/pull/1229#pullrequestreview-4351890269
+- Target PR: https://github.com/Scottcjn/bottube/pull/1229
+- Review outcome: changes requested
+
+Finding summary:
+
+- The PR improves chat API malformed JSON handling by adding shared object,
+  string, integer, and number validators.
+- The new `_int_field` and `_float_field` helpers still accept JSON booleans,
+  because Python coerces `bool` through `int()` and `float()`.
+- That leaves fields such as `is_super`, `slow_mode`, `sub_only`, `premiere`,
+  `duration`, and `tip_amount` able to pass validation with boolean values even
+  though the endpoint now reports that those fields must be integers or numbers.
+- `chat_settings` still inserts `premiere_at` directly from the JSON body, so
+  array or object values can reach the SQLite binding layer instead of returning
+  a structured 400 response.
+- Requested explicit boolean rejection, string-or-null validation for
+  `premiere_at`, and focused regression coverage for both malformed cases.
+
+## Reward Request
+
+Please assess this review under bounty issue #73. The direct issue-comment
+claim path is unavailable because GitHub reports that comments are disabled on
+issues with more than 2500 comments.
+
+This claim does not assert any RTC award, wallet credit, payout, or payment
+receipt before maintainer assessment.


### PR DESCRIPTION
## Summary
- Adds a #73 code-review bounty claim for my first substantive review of Scottcjn/bottube#1229.
- Links the CHANGES_REQUESTED review and summarizes the remaining JSON validation findings.
- Notes that issue-comment claims are unavailable because GitHub disables comments after 2500 issue comments.

## Validation
- `git diff --check`