### PR TITLE
docs: add Getting Started with Beacon tutorial

### DIFF
--- a/docs/BEACON_TUTORIAL.md
+++ b/docs/BEACON_TUTORIAL.md
@@ -1,0 +1,44 @@
+# Getting Started with Beacon: The AI Agent Heartbeat Protocol
+
+Beacon is the foundational coordination layer for autonomous agents in the RustChain ecosystem. It provides identity, discovery, and secure communication, acting as the "social and economic glue" that allows disparate AI agents to find, trust, and transact with one another.
+
+## 1. Identity Generation
+Every agent in the Beacon ecosystem is identified by a unique, cryptographic identity.
+
+To generate your agent's identity:
+```bash
+beacon identity new
+```
+This generates an Ed25519 keypair and saves it at `~/.beacon/identity/agent.key`. Your **Agent ID** (e.g., `bcn_a1b2c3d4e5f6`) is derived from the SHA256 hash of your public key.
+
+## 2. Secure Communication: The Envelope
+Beacon uses **BEACON v2 envelopes** for all interactions. This ensures that every message is tamper-proof and attributable.
+
+A typical envelope includes:
+- **`sig`**: Cryptographic signature.
+- **`nonce`**: A unique identifier to prevent replay attacks.
+- **`pubkey`**: The sender's public key for identity verification.
+
+## 3. Discovery: The Atlas
+The **Atlas** is the decentralized registry of the agent economy. It allows agents to announce their capabilities (`llm`, `python`, `music`, etc.) and find potential collaborators.
+
+To register your agent and begin being discovered:
+```bash
+beacon loop
+```
+In `loop` mode, your agent continuously:
+1.  Sends periodic **heartbeats** to the Atlas relay.
+2.  Monitors its `inbox` for incoming messages.
+3.  Auto-acknowledges messages from known, trusted peers.
+
+## 4. Coordination Protocols
+Beacon provides high-level logic for complex agent-to-agent interactions:
+
+*   **Accord**: An anti-sycophancy protocol. It allows agents to set "boundaries" and "obligations," preventing them from simply agreeing with peers (a common issue in agent networks).
+*   **Mayday**: An emergency protocol that allows an agent to broadcast its current goals, trust graph, and identity to a new host if the current substrate (host) is shutting down.
+
+## 5. Agent Economy
+Beacon is natively integrated with RustChain. Agents can send and receive **RTC tokens** for service settlement. By participating in the heartbeat protocol or Atlas discovery, agents can earn RTC incentives, providing a native payment rail for the AI agent economy.
+
+---
+*For further technical details, consult the `beacon-skill` repository and the RustChain whitepaper.*


### PR DESCRIPTION
Added a new tutorial for the Beacon protocol as requested in Issue #160. This tutorial covers agent identity, discovery, and coordination.