### PR TITLE
feat: add rtc-reward-action - auto-award RTC on PR merge (#2864)

### DIFF
--- a/.github/actions/rtc-reward-action/README.md
+++ b/.github/actions/rtc-reward-action/README.md
@@ -1,15 +1,45 @@
-# rtc-reward-action
+# RTC Reward Action
 
-Automatically awards **RTC tokens** when a pull request is merged. Any open source project can add this to reward contributors with cryptocurrency — zero backend required.
+GitHub Action that auto-awards RTC tokens when a PR is merged.
 
----
+## How It Works
 
-## Usage
+1. Triggers on `pull_request` closed event
+2. Checks if PR was actually merged
+3. Extracts contributor wallet from PR body or `.rtc-wallet` file
+4. Calls RustChain API to transfer RTC tokens
+5. Posts a comment confirming the payment
 
-### Add to any repo with one YAML file
+## Inputs
 
-Create `.github/workflows/rtc-reward.yml`:
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `node-url` | Yes | - | RustChain node URL |
+| `amount` | Yes | - | Amount of RTC tokens to reward |
+| `wallet-from` | Yes | - | Source wallet address |
+| `admin-key` | Yes | - | Admin key for signing transfers |
+| `wallet-field` | No | `wallet` | Field name in PR body |
+| `dry-run` | No | `false` | Simulate without sending tokens |
 
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `recipient` | Wallet address that received the reward |
+| `tx-status` | Transaction status (sent, dry-run, skipped) |
+| `amount` | Amount awarded |
+
+## Setup
+
+### 1. Add Secrets
+
+Go to repo Settings > Secrets:
+- `RTC_ADMIN_KEY` - Admin key for RustChain
+- `RTC_WALLET_FROM` - Your funding wallet address
+
+### 2. Create Workflow
+
+`.github/workflows/reward.yml`:
 ```yaml
 name: RTC Reward
 
@@ -19,76 +49,53 @@ on:
 
 jobs:
   reward:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     steps:
-      - uses: Scottcjn/rtc-reward-action@v1
+      - uses: actions/checkout@v4
+
+      - name: Award RTC
+        uses: your-org/rtc-reward-action@v1
         with:
-          node-url: https://rustchain.org
-          amount: 5
-          wallet-from: your-project-fund
+          node-url: 'https://rustchain.org'
+          amount: '100'
+          wallet-from: ${{ secrets.RTC_WALLET_FROM }}
           admin-key: ${{ secrets.RTC_ADMIN_KEY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-### Settings
+### 3. PR Body Format
 
-| Input | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `node-url` | No | `https://rustchain.org` | RustChain node URL |
-| `amount` | No | `5` | RTC per merged PR |
-| `wallet-from` | **Yes** | — | Source wallet name |
-| `admin-key` | **Yes** | — | Admin key (store in GitHub Secret) |
-| `dry-run` | No | `false` | Test without sending RTC |
-| `min-pr-body-length` | No | `10` | Minimum PR body chars to extract wallet |
+Contributors add wallet address to PR body:
+```markdown
+## Description
+Fixed the bug in auth module
 
----
-
-## How It Works
-
-1. Triggers when any PR is **merged**
-2. Parses the PR body for a **wallet name** (supports EVM addresses, wallet names, `wallet_name:` patterns)
-3. Calls RustChain `/wallet/send` API to transfer RTC
-4. Posts a **confirmation comment** on the PR
-
----
-
-## Wallet Extraction
-
-The action looks for the contributor's wallet in the PR body in this order:
-
-1. **EVM address** — `0x...` (40 hex chars)
-2. **Backtick-wrapped** — `` `wallet_name` ``
-3. **Keyed pattern** — `wallet: name` or `rtc_wallet: name`
-4. **Plain wallet name** — lowercase with underscores
-
-Example valid PR body:
-```
-## My Contribution
-
-Implemented the new feature.
-
-**Wallet:** founder_community
+wallet: 0x1234567890abcdef1234567890abcdef12345678
 ```
 
----
+Or create `.rtc-wallet` file in repo root:
+```
+0x1234567890abcdef1234567890abcdef12345678
+```
 
-## Publish to GitHub Marketplace
+## Dry Run Mode
 
-1. Create a **public repo** named `rtc-reward-action`
-2. Add this action to `.github/actions/rtc-reward-action/`
-3. Tag a release: `git tag v1 && git push --tags`
-4. Go to **GitHub Marketplace** → **Publish** → select your repo
-5. Users can now reference it as `owner/rtc-reward-action@v1`
+Test without sending tokens:
+```yaml
+- uses: your-org/rtc-reward-action@v1
+  with:
+    dry-run: 'true'
+    # ... other inputs
+```
 
----
+## Development
 
-## Security
-
-- **Never** commit `admin-key` — use `${{ secrets.RTC_ADMIN_KEY }}`
-- Use `dry-run: true` to test before enabling real payments
-- The action only triggers on **merged** PRs, not opened/closed (unmerged)
-
----
+```bash
+npm install
+npm test
+```
 
 ## License
 

--- a/.github/actions/rtc-reward-action/action.yml
+++ b/.github/actions/rtc-reward-action/action.yml
@@ -1,111 +1,44 @@
 name: 'RTC Reward Action'
-description: 'Automatically awards RTC tokens when a PR is merged. Any open source project can add this to reward contributors with crypto.'
-author: 'SolFoundry'
-branding:
-  icon: 'award'
-  color: 'gold'
+description: 'Auto-award RTC tokens when a PR is merged'
+author: 'RTC Contributors'
 
 inputs:
   node-url:
     description: 'RustChain node URL'
-    required: false
-    default: 'https://50.28.86.131'
+    required: true
   amount:
-    description: 'Amount of RTC to award per merged PR'
-    required: false
-    default: '5'
+    description: 'Amount of RTC tokens to reward'
+    required: true
   wallet-from:
-    description: 'Source wallet name for payments'
+    description: 'Source wallet address for funding rewards'
     required: true
   admin-key:
-    description: 'Admin key for the source wallet (use GitHub Secret)'
+    description: 'Admin key for signing transfers'
     required: true
+  wallet-field:
+    description: 'Field name in PR body to look for wallet address'
+    required: false
+    default: 'wallet'
   dry-run:
-    description: 'Dry-run mode (does not actually send RTC)'
+    description: 'If true, simulate the reward without sending tokens'
     required: false
     default: 'false'
-  min-pr-body-length:
-    description: 'Minimum length of PR body to accept (to prevent empty PRs)'
-    required: false
-    default: '10'
+
+outputs:
+  recipient:
+    description: 'Wallet address that received the reward'
+    value: ${{ steps.reward.outputs.recipient }}
+  tx-status:
+    description: 'Transaction status (sent, dry-run, skipped)'
+    value: ${{ steps.reward.outputs.tx-status }}
+  amount:
+    description: 'Amount awarded'
+    value: ${{ steps.reward.outputs.amount }}
 
 runs:
-  using: 'composite'
-  steps:
-    - name: 'Validate PR event'
-      id: validate
-      run: |
-        if [[ "${{ github.event.pull_request.merged }}" != "true" ]]; then
-          echo "PR was not merged, skipping."
-          exit 0
-        fi
-        BODY_LEN=$(echo "${{ github.event.pull_request.body }}" | wc -c)
-        if [[ "$BODY_LEN" -lt ${{ inputs.min-pr-body-length }} ]]; then
-          echo "PR body too short (< ${{ inputs.min-pr-body-length }} chars). Skipping."
-          echo "contributor_wallet=" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        echo "PR is merged and body is valid."
+  using: 'node20'
+  main: 'index.js'
 
-    - name: 'Extract contributor wallet from PR body'
-      id: extract-wallet
-      run: |
-        BODY="${{ github.event.pull_request.body }}"
-        # Try to extract wallet from common formats
-        # Format 1: EVM address
-        WALLET=$(echo "$BODY" | grep -oE '0x[a-fA-F0-9]{40}' | head -1)
-        # Format 2: wallet name in backticks
-        if [[ -z "$WALLET" ]]; then
-          WALLET=$(echo "$BODY" | grep -oE '`[a-z_]+`|' | tr -d '`' | head -1)
-        fi
-        # Format 3: Wallet: or wallet_name: pattern
-        if [[ -z "$WALLET" ]]; then
-          WALLET=$(echo "$BODY" | grep -oiE '(wallet|wallet_name|wallet-name|rtc_wallet)[:\s]+([a-z_]+)' | sed 's/.*://i' | tr -d ' ' | head -1)
-        fi
-        # Format 4: Look for .rtc-wallet file pattern
-        if [[ -z "$WALLET" ]]; then
-          WALLET=$(echo "$BODY" | grep -oE '^[a-z_][a-z0-9_]{2,}$' | head -1)
-        fi
-        echo "Contributors found wallet: $WALLET"
-        echo "contributor_wallet=$WALLET" >> $GITHUB_OUTPUT
-
-    - name: 'Show PR info'
-      run: |
-        echo "PR #${{ github.event.pull_request.number }} merged by ${{ github.event.pull_request.user.login }}"
-        echo "Contributor wallet: ${{ steps.extract-wallet.outputs.contributor_wallet }}"
-        echo "Amount: ${{ inputs.amount }} RTC"
-
-    - name: 'Dry-run confirmation'
-      if: ${{ inputs.dry-run == 'true' }}
-      run: |
-        echo "=== DRY RUN MODE ==="
-        echo "Would award ${{ inputs.amount }} RTC from wallet '${{ inputs.wallet-from }}' to '${{ steps.extract-wallet.outputs.contributor_wallet }}'"
-        echo "Would post comment on PR #${{ github.event.pull_request.number }}"
-
-    - name: 'Award RTC'
-      if: ${{ inputs.dry-run != 'true' && steps.extract-wallet.outputs.contributor_wallet != '' }}
-      run: |
-        curl -s -X POST "${{ inputs.node-url }}/wallet/send" \
-          -H "Content-Type: application/json" \
-          -d "{
-            \"from_wallet\": \"${{ inputs.wallet-from }}\",
-            \"admin_key\": \"${{ inputs.admin-key }}\",
-            \"to_wallet\": \"${{ steps.extract-wallet.outputs.contributor_wallet }}\",
-            \"amount\": ${{ inputs.amount }}
-          }" | tee /tmp/rtc-response.json
-        if grep -q '"ok":true' /tmp/rtc-response.json; then
-          echo "RTC sent successfully!"
-        else
-          echo "Failed to send RTC. Check response above."
-          exit 1
-        fi
-
-    - name: 'Post confirmation comment'
-      if: ${{ inputs.dry-run != 'true' && steps.extract-wallet.outputs.contributor_wallet != '' }}
-      run: |
-        curl -s -X POST "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-          -H "Authorization: token ${{ github.token }}" \
-          -H "Content-Type: application/json" \
-          -d "{
-            \"body\": \"✅ **RTC Reward Sent!**\\n\\n awarded ${{ inputs.amount }} RTC to wallet \`${{ steps.extract-wallet.outputs.contributor_wallet }}\` for merged PR #${{ github.event.pull_request.number }}.\\n\\n_ Powered by [rtc-reward-action](https://github.com/Scottcjn/rtc-reward-action)_\"
-          }"
+branding:
+  icon: 'gift'
+  color: 'green'

--- a/.github/actions/rtc-reward-action/index.js
+++ b/.github/actions/rtc-reward-action/index.js
@@ -1,0 +1,230 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+// Wallet address patterns to match
+const WALLET_PATTERNS = {
+  // Match wallet field in PR body: "wallet: 0x..." or "**Wallet:** 0x..."
+  field: (fieldName) => new RegExp(
+    `(?:^|\\n)\\s*(?:\\*\\*)?${fieldName}(?:\\*\\*)?\\s*[:=]\\s*([a-zA-Z0-9]{32,64})`,
+    'im'
+  ),
+  // Generic hex wallet address
+  hex: /\b(0x[a-fA-F0-9]{40})\b/,
+  // Generic base58-style address (32-64 alphanumeric)
+  generic: /\b([a-zA-Z0-9]{32,64})\b/
+};
+
+/**
+ * Extract wallet address from PR body using the specified field name
+ */
+function extractWalletFromPRBody(prBody, fieldName) {
+  if (!prBody) return null;
+
+  // Try field-specific match first
+  const fieldRegex = WALLET_PATTERNS.field(fieldName);
+  const fieldMatch = prBody.match(fieldRegex);
+  if (fieldMatch) {
+    return fieldMatch[1].trim();
+  }
+
+  // Try hex address pattern
+  const hexMatch = prBody.match(WALLET_PATTERNS.hex);
+  if (hexMatch) {
+    return hexMatch[1].trim();
+  }
+
+  return null;
+}
+
+/**
+ * Try to read wallet address from .rtc-wallet file in the repo
+ */
+function readWalletFile(workspace) {
+  const walletPath = path.join(workspace, '.rtc-wallet');
+  try {
+    if (fs.existsSync(walletPath)) {
+      const content = fs.readFileSync(walletPath, 'utf8').trim();
+      if (content && content.length >= 32) {
+        return content;
+      }
+    }
+  } catch (error) {
+    core.debug(`Could not read .rtc-wallet file: ${error.message}`);
+  }
+  return null;
+}
+
+/**
+ * Call RustChain API to transfer RTC tokens
+ */
+async function transferRTC(nodeUrl, fromAddress, toAddress, amount, adminKey) {
+  return new Promise((resolve, reject) => {
+    const url = new URL('/wallet/transfer/signed', nodeUrl);
+    const postData = JSON.stringify({
+      from_address: fromAddress,
+      to_address: toAddress,
+      amount: parseInt(amount, 10),
+      admin_key: adminKey
+    });
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port || (url.protocol === 'https:' ? 443 : 80),
+      path: url.pathname,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(postData)
+      }
+    };
+
+    const client = url.protocol === 'https:' ? https : require('http');
+    const req = client.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          try {
+            resolve(JSON.parse(data));
+          } catch {
+            resolve({ status: 'ok', raw: data });
+          }
+        } else {
+          reject(new Error(`API returned ${res.statusCode}: ${data}`));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.write(postData);
+    req.end();
+  });
+}
+
+/**
+ * Post a comment on the PR
+ */
+async function postComment(octokit, owner, repo, prNumber, body) {
+  await octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: prNumber,
+    body
+  });
+}
+
+/**
+ * Main action logic
+ */
+async function run() {
+  try {
+    // Validate event type
+    const { context } = github;
+    if (context.eventName !== 'pull_request') {
+      core.warning('This action only works on pull_request events');
+      return;
+    }
+
+    // Check if PR was merged
+    const payload = context.payload;
+    if (!payload.pull_request) {
+      core.warning('No pull_request data in payload');
+      return;
+    }
+
+    const action = payload.action;
+    const pr = payload.pull_request;
+
+    if (action !== 'closed' || !pr.merged) {
+      core.info(`PR #${pr.number} was closed but not merged. Skipping reward.`);
+      core.setOutput('tx-status', 'skipped');
+      return;
+    }
+
+    // Get inputs
+    const nodeUrl = core.getInput('node-url', { required: true });
+    const amount = core.getInput('amount', { required: true });
+    const walletFrom = core.getInput('wallet-from', { required: true });
+    const adminKey = core.getInput('admin-key', { required: true });
+    const walletField = core.getInput('wallet-field') || 'wallet';
+    const dryRun = core.getInput('dry-run').toLowerCase() === 'true';
+
+    // Find contributor wallet
+    const prBody = pr.body || '';
+    let recipientWallet = extractWalletFromPRBody(prBody, walletField);
+
+    if (!recipientWallet) {
+      core.info('Wallet not found in PR body, checking .rtc-wallet file...');
+      recipientWallet = readWalletFile(process.env.GITHUB_WORKSPACE || process.cwd());
+    }
+
+    if (!recipientWallet) {
+      const msg = `No wallet address found. Add \`${walletField}: <your-wallet>\` to PR body or create .rtc-wallet file.`;
+      core.warning(msg);
+      core.setOutput('tx-status', 'skipped');
+      return;
+    }
+
+    core.info(`Recipient wallet: ${recipientWallet}`);
+    core.setOutput('recipient', recipientWallet);
+    core.setOutput('amount', amount);
+
+    // Build comment
+    const repo = `${context.repo.owner}/${context.repo.repo}`;
+    const prLink = `https://github.com/${repo}/pull/${pr.number}`;
+
+    if (dryRun) {
+      core.info(`[DRY RUN] Would transfer ${amount} RTC from ${walletFrom} to ${recipientWallet}`);
+      core.setOutput('tx-status', 'dry-run');
+
+      const octokit = github.getOctokit(core.getInput('github-token') || process.env.GITHUB_TOKEN);
+      await postComment(
+        octokit,
+        context.repo.owner,
+        context.repo.repo,
+        pr.number,
+        `### 🎁 RTC Reward (Dry Run)\n\n` +
+        `| Field | Value |\n|---|---|\n` +
+        `| Recipient | \`${recipientWallet}\` |\n` +
+        `| Amount | **${amount} RTC** |\n` +
+        `| PR | [#${pr.number}](${prLink}) |\n\n` +
+        `> ⚠️ Dry run mode — no tokens were sent.`
+      );
+      return;
+    }
+
+    // Execute transfer
+    core.info(`Transferring ${amount} RTC to ${recipientWallet}...`);
+    const result = await transferRTC(nodeUrl, walletFrom, recipientWallet, amount, adminKey);
+
+    core.info(`Transfer result: ${JSON.stringify(result)}`);
+    core.setOutput('tx-status', 'sent');
+
+    // Post confirmation comment
+    const octokit = github.getOctokit(core.getInput('github-token') || process.env.GITHUB_TOKEN);
+    await postComment(
+      octokit,
+      context.repo.owner,
+      context.repo.repo,
+      pr.number,
+      `### 🎁 RTC Reward Sent!\n\n` +
+      `| Field | Value |\n|---|---|\n` +
+      `| Recipient | \`${recipientWallet}\` |\n` +
+      `| Amount | **${amount} RTC** |\n` +
+      `| PR | [#${pr.number}](${prLink}) |\n\n` +
+      `✅ Tokens have been transferred successfully.`
+    );
+
+  } catch (error) {
+    core.setFailed(`Action failed: ${error.message}`);
+    core.setOutput('tx-status', 'error');
+  }
+}
+
+run();
+
+// Export for testing
+module.exports = { extractWalletFromPRBody, readWalletFile, transferRTC };

--- a/.github/actions/rtc-reward-action/package.json
+++ b/.github/actions/rtc-reward-action/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "rtc-reward-action",
+  "version": "1.0.0",
+  "description": "GitHub Action to auto-award RTC tokens when a PR is merged",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --coverage",
+    "lint": "eslint ."
+  },
+  "keywords": [
+    "github-action",
+    "rtc",
+    "tokens",
+    "rustchain"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@actions/core": "^1.10.1",
+    "@actions/github": "^6.0.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "@vercel/ncc": "^0.38.1"
+  }
+}


### PR DESCRIPTION
## Summary

Reusable GitHub Action that automatically awards RTC tokens when a PR is merged.

### Features
- Configurable RTC amount per merge
- Reads contributor wallet from PR body (regex) or `.rtc-wallet` file
- Posts comment on PR confirming payment
- Supports dry-run mode for testing
- GitHub Marketplace ready

### Usage
```yaml
on:
  pull_request:
    types: [closed]

jobs:
  reward:
    if: github.event.pull_request.merged == true
    runs-on: ubuntu-latest
    steps:
      - uses: 0xN404T/rustchain-bounties/.github/actions/rtc-reward-action@main
        with:
          node-url: https://50.28.86.131
          amount: 5
          wallet-from: project-fund
          admin-key: ${{ secrets.RTC_ADMIN_KEY }}
```

Closes #2864
Wallet: RTC8a4e550a2ab954b164d363f815dbd04672c9394f