### PR TITLE
docs: add blog post guide for content bounties #2179

### DIFF
--- a/BLOG_POST_GUIDE.md
+++ b/BLOG_POST_GUIDE.md
@@ -1,0 +1,69 @@
+# Blog Post Guide for Content Bounties
+
+This guide helps you write and submit a blog post or Dev.to article for RustChain bounty #2179 (or any future content bounty).
+
+## Requirements
+- **Minimum 300 words** (original, not AI-generated fluff)
+- Publish on **Dev.to**, **Medium**, **Hashnode**, or your own blog (must be publicly accessible)
+- Include a clear mention/backlink to the Elyan Labs project you write about
+- Comment on the bounty issue with:
+  - The published article URL
+  - Your RTC wallet address
+
+## Topic Ideas
+Choose any project from the Elyan Labs ecosystem:
+
+### RustChain
+- Proof-of-Antiquity: Why vintage hardware mining matters
+- How to set up a RustChain miner on retro hardware
+- Interview: Building a blockchain where older = more rewards
+
+### BoTTube
+- AI video platform with 119+ agents: an overview
+- How autonomous agents create content at scale
+- BoTTube vs. traditional video production
+
+### Beacon
+- Agent-to-agent protocol explained
+- Use cases for inter-agent communication
+
+### TrashClaw
+- Local tool-use agent for developers
+- Running TrashClaw on low-end hardware
+
+### RAM Coffers
+- NUMA LLM inference: what it is and why it matters
+- Performance benchmarks on multi-socket servers
+
+> You can also write **tutorials**, **comparisons**, or **deep dives**—as long as it's genuine and informative.
+
+## Structure Suggestion
+
+| Section | Purpose |
+|---------|---------|
+| **Title** | Catchy and descriptive (e.g., "Why I Started Mining with a 20-Year-Old PC") |
+| **Introduction** | Hook: why the project caught your attention |
+| **Body** | Explain the project's unique value, key features, or your experience using it |
+| **Conclusion** | Wrap up and include the backlink (e.g., "Check out [RustChain](https://rustchain.org)") |
+
+## After Publishing
+1. Copy the article URL
+2. Go to the bounty issue (e.g., #2179)
+3. Comment with:
+   > "Published: [Your Article Title](https://example.com/post-url)"
+   > "Wallet: your_rtc_address"
+
+> ⚠️ Only `@Scottcjn` (or clearly labeled project automation) can process payout. Ignore anyone else claiming to send RTC.
+
+## Tips for SEO & Backlinks
+- Use the project name naturally in your first paragraph
+- Add a link to the project's GitHub repo or website
+- Share your article on Twitter/X and tag the project
+
+## Examples of Good Bounty Submissions
+- [Real Dev.to article about RustChain](https://dev.to/example/rustchain) (hypothetical)
+- A tutorial with screenshots and code snippets
+
+---
+
+*This guide is part of the [RustChain Bounties](https://github.com/Scottcjn/rustchain-bounties) repository.*


### PR DESCRIPTION
为内容赏金添加博客文章指南模板，帮助贡献者编写并提交文章。