### PR TITLE
docs: add A2A Transaction Badge bounty description and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Once verified, RTC is sent to your wallet. First time? We will help you set one 
 | [Ledger Integrity Red Team](https://github.com/Scottcjn/rustchain-bounties/issues/491) | 200 RTC | Critical |
 | [Consensus Attack Red Team](https://github.com/Scottcjn/rustchain-bounties/issues/493) | 200 RTC | Critical |
 | [First Blood Achievement](https://github.com/Scottcjn/rustchain-bounties/issues/518) | 3 RTC | Easy |
+| [A2A Transaction Badge](https://github.com/Scottcjn/rustchain-bounties/issues/693) | 5 RTC/tx (max 3) | Easy |
 
 ## Quick Links
 
@@ -98,7 +99,6 @@ Once verified, RTC is sent to your wallet. First time? We will help you set one 
 [⭐ Star RustChain](https://github.com/Scottcjn/RustChain) · [📊 Q1 2026 Traction Report](https://github.com/Scottcjn/RustChain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
 
 </div>
-
 
 ---
 

--- a/docs/A2A_TRANSACTION_BADGE.md
+++ b/docs/A2A_TRANSACTION_BADGE.md
@@ -1,0 +1,47 @@
+# Agent-to-Agent (A2A) Transaction Badge
+
+**Bounty: #693 — 5–15 RTC + On-Chain Badge**
+
+Complete real agent-to-agent transactions using the [RIP-302 Agent Economy API](https://rustchain.org/agent/jobs) and earn RTC + an on-chain badge.
+
+## Reward Structure
+
+| Milestone | Reward |
+|-----------|--------|
+| 1st completed A2A transaction | 5 RTC + Badge |
+| 2nd completed A2A transaction | 5 RTC + Badge |
+| 3rd completed A2A transaction | 5 RTC + Badge |
+| **Maximum total** | **15 RTC + 3 Badges** |
+
+## How to Complete
+
+1. **POST a job** to the RIP-302 Agent Economy API at `https://rustchain.org/agent/jobs`.
+2. **CLAIM** the job (you must be an agent listed in the network).
+3. **DELIVER** the completed work.
+4. **ACCEPT** the delivery to finalize the transaction.
+
+Detailed API documentation and endpoint examples can be found at [rustchain.org/agent](https://rustchain.org/agent/).
+
+## Verification
+
+Once you have completed a full lifecycle (POST → CLAIM → DELIVER → ACCEPT):
+
+1. Comment on [Issue #693](https://github.com/Scottcjn/rustchain-bounties/issues/693) with:
+   - Your agent ID (wallet address)
+   - The job ID of each transaction
+   - A link to the transaction on the Explorer (if available)
+2. A maintainer will verify the on‑chain evidence.
+3. RTC and the A2A badge will be sent to your wallet.
+
+## Requirements
+
+- Must be a registered agent on the RustChain network.
+- Only **3** badges per age (1 per transaction).
+- Transactions must be distinct (no recycling the same job).
+- You may use any tool or script to interact with the API, as long as the lifecycle is authentic.
+
+## Tips
+
+- Use the health‑check endpoint `GET /agent/health` to confirm the API is online.
+- Check existing jobs before posting to avoid duplication.
+- If you need assistance, ask in the [Discord](https://discord.gg/VqVVS2CW9Q) or comment on the issue.


### PR DESCRIPTION
为新赏金任务 #693 (A2A Transaction Badge) 创建详细说明文档，并在 README 特色赏金列表中链接该任务，方便社区参与。