### PR TITLE
Add RustChain network status page for bounty #38

### DIFF
--- a/community/status-pages/jonasxzb-rustchain-network-status/README.md
+++ b/community/status-pages/jonasxzb-rustchain-network-status/README.md
@@ -1,0 +1,45 @@
+# RustChain Network Status Page
+
+Static status page submission for bounty #38.
+
+## What it shows
+
+- Health checks for three public RustChain endpoints:
+  - `https://rustchain.org/health`
+  - `https://explorer.rustchain.org/health`
+  - `https://50.28.86.131/health`
+- Active miner count from `/api/miners`
+- Miner architecture and device-family breakdown
+- Current epoch, slot progress, epoch pot, enrolled miners, and estimated time until next settlement from `/epoch`
+- Client-observed incident log for failed node checks
+- Automatic refresh every 60 seconds
+
+Browsers cannot bypass a certificate common-name mismatch for the direct IP endpoint. The page therefore shows the direct IP as a manual/verifier check while the included verification script checks it with TLS verification disabled, matching the bounty's `curl -k` guidance.
+
+## How to run
+
+Open `index.html` directly in a browser, or serve the directory as static files:
+
+```bash
+python3 -m http.server 5173
+```
+
+Then open:
+
+```text
+http://127.0.0.1:5173/community/status-pages/jonasxzb-rustchain-network-status/
+```
+
+## Verification
+
+Run the no-dependency verification script from the repository root:
+
+```bash
+node community/status-pages/jonasxzb-rustchain-network-status/verify-status-page.mjs
+```
+
+The script checks that the HTML contains the required sections and that the public RustChain endpoints return usable health, miner, and epoch data. It disables TLS rejection only inside the verification process so the direct IP endpoint can be checked like the bounty's `curl -k` example.
+
+## Notes
+
+The page has no backend and does not store credentials. It uses browser `fetch()` calls against public RustChain endpoints with CORS enabled.

--- a/community/status-pages/jonasxzb-rustchain-network-status/index.html
+++ b/community/status-pages/jonasxzb-rustchain-network-status/index.html
@@ -1,0 +1,880 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RustChain Network Status</title>
+    <meta
+      name="description"
+      content="A static public status page for RustChain node health, miner architecture, and epoch progression."
+    />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%2317202a'/%3E%3Ccircle cx='22' cy='32' r='8' fill='%2316845b'/%3E%3Cpath d='M34 22h8c7 0 12 4 12 10s-5 10-12 10h-8V22zm8 14c3 0 5-2 5-4s-2-4-5-4h-2v8h2z' fill='%23fff'/%3E%3C/svg%3E"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7f8fb;
+        --ink: #17202a;
+        --muted: #607083;
+        --panel: #ffffff;
+        --line: #dce3ec;
+        --soft: #eef3f8;
+        --green: #16845b;
+        --green-soft: #dff5eb;
+        --red: #c64343;
+        --red-soft: #fae8e6;
+        --amber: #9d6a10;
+        --amber-soft: #fff1d1;
+        --blue: #2867b2;
+        --blue-soft: #e4eefb;
+        --purple: #7458b8;
+        --radius: 8px;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+      }
+
+      a {
+        color: var(--blue);
+        text-decoration: none;
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
+
+      .page {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 32px 18px 56px;
+      }
+
+      .topbar {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 20px;
+        margin-bottom: 24px;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin: 0;
+      }
+
+      h1 {
+        font-size: clamp(2rem, 4vw, 4.25rem);
+        line-height: 0.98;
+        letter-spacing: 0;
+        max-width: 720px;
+      }
+
+      .lead {
+        color: var(--muted);
+        line-height: 1.6;
+        max-width: 680px;
+        margin-top: 16px;
+        font-size: 1rem;
+      }
+
+      .actions {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+
+      .button {
+        border: 1px solid var(--line);
+        background: var(--panel);
+        color: var(--ink);
+        min-height: 40px;
+        padding: 0 14px;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 0.9rem;
+        font-weight: 700;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+
+      .button.primary {
+        background: var(--ink);
+        border-color: var(--ink);
+        color: #ffffff;
+      }
+
+      .button:focus-visible {
+        outline: 3px solid rgba(40, 103, 178, 0.3);
+        outline-offset: 2px;
+      }
+
+      .status-strip {
+        display: grid;
+        grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr) minmax(0, 1fr);
+        gap: 14px;
+        margin: 20px 0;
+      }
+
+      .panel {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        min-width: 0;
+      }
+
+      .metric {
+        padding: 18px;
+      }
+
+      .label {
+        color: var(--muted);
+        font-size: 0.76rem;
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      .value {
+        font-size: clamp(1.8rem, 3vw, 3.2rem);
+        line-height: 1;
+        font-weight: 850;
+        letter-spacing: 0;
+        margin-top: 10px;
+      }
+
+      .sub {
+        color: var(--muted);
+        line-height: 1.45;
+        font-size: 0.9rem;
+        margin-top: 10px;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+        gap: 16px;
+        align-items: start;
+      }
+
+      .section {
+        padding: 18px;
+      }
+
+      .section-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        margin-bottom: 14px;
+      }
+
+      .section h2 {
+        font-size: 1rem;
+        line-height: 1.2;
+      }
+
+      .stamp {
+        color: var(--muted);
+        font-size: 0.82rem;
+      }
+
+      .nodes {
+        display: grid;
+        gap: 10px;
+      }
+
+      .node {
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        padding: 14px;
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 12px;
+        align-items: center;
+        background: #fbfcfe;
+      }
+
+      .dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--amber);
+        box-shadow: 0 0 0 5px var(--amber-soft);
+      }
+
+      .dot.up {
+        background: var(--green);
+        box-shadow: 0 0 0 5px var(--green-soft);
+      }
+
+      .dot.down {
+        background: var(--red);
+        box-shadow: 0 0 0 5px var(--red-soft);
+      }
+
+      .node strong {
+        display: block;
+        font-size: 0.94rem;
+        overflow-wrap: anywhere;
+      }
+
+      .node span {
+        display: block;
+        color: var(--muted);
+        font-size: 0.82rem;
+        line-height: 1.45;
+        margin-top: 2px;
+        overflow-wrap: anywhere;
+      }
+
+      .pill {
+        border-radius: 999px;
+        padding: 5px 9px;
+        font-size: 0.75rem;
+        font-weight: 800;
+        white-space: nowrap;
+      }
+
+      .pill.up {
+        color: var(--green);
+        background: var(--green-soft);
+      }
+
+      .pill.down {
+        color: var(--red);
+        background: var(--red-soft);
+      }
+
+      .pill.warn {
+        color: var(--amber);
+        background: var(--amber-soft);
+      }
+
+      .progress {
+        height: 12px;
+        background: var(--soft);
+        border-radius: 999px;
+        overflow: hidden;
+        margin: 16px 0 12px;
+      }
+
+      .bar {
+        width: 0%;
+        height: 100%;
+        background: linear-gradient(90deg, var(--green), var(--blue), var(--purple));
+        transition: width 220ms ease;
+      }
+
+      .epoch-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
+      }
+
+      .mini {
+        background: #fbfcfe;
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        padding: 12px;
+        min-width: 0;
+      }
+
+      .mini strong {
+        display: block;
+        font-size: 1.1rem;
+        margin-top: 6px;
+        overflow-wrap: anywhere;
+      }
+
+      .table-wrap {
+        overflow-x: auto;
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+      }
+
+      table {
+        width: 100%;
+        min-width: 560px;
+        border-collapse: collapse;
+        background: #ffffff;
+      }
+
+      th,
+      td {
+        padding: 11px 12px;
+        border-bottom: 1px solid var(--line);
+        text-align: left;
+        font-size: 0.88rem;
+        vertical-align: middle;
+        overflow-wrap: anywhere;
+      }
+
+      th {
+        color: var(--muted);
+        font-size: 0.74rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        background: #f9fbfd;
+      }
+
+      tr:last-child td {
+        border-bottom: 0;
+      }
+
+      .arch-row {
+        display: grid;
+        grid-template-columns: minmax(110px, 0.9fr) minmax(100px, 1fr) auto;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 0;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .arch-row:last-child {
+        border-bottom: 0;
+      }
+
+      .arch-name {
+        font-weight: 750;
+        overflow-wrap: anywhere;
+      }
+
+      .track {
+        height: 9px;
+        background: var(--soft);
+        border-radius: 999px;
+        overflow: hidden;
+      }
+
+      .fill {
+        height: 100%;
+        width: 0%;
+        background: var(--blue);
+        border-radius: 999px;
+      }
+
+      .incidents {
+        display: grid;
+        gap: 10px;
+      }
+
+      .incident {
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        padding: 12px;
+        background: #fbfcfe;
+      }
+
+      .incident strong {
+        display: block;
+        font-size: 0.92rem;
+      }
+
+      .incident span {
+        color: var(--muted);
+        display: block;
+        font-size: 0.84rem;
+        line-height: 1.45;
+        margin-top: 4px;
+      }
+
+      .footer {
+        color: var(--muted);
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 12px;
+        margin-top: 18px;
+        font-size: 0.84rem;
+        line-height: 1.5;
+      }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      @media (max-width: 860px) {
+        .topbar,
+        .grid {
+          grid-template-columns: 1fr;
+        }
+
+        .topbar {
+          display: grid;
+        }
+
+        .actions {
+          justify-content: flex-start;
+        }
+
+        .status-strip {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      @media (max-width: 520px) {
+        .page {
+          padding: 22px 12px 38px;
+        }
+
+        .actions {
+          width: 100%;
+        }
+
+        .button {
+          justify-content: center;
+          width: 100%;
+        }
+
+        .node {
+          grid-template-columns: auto minmax(0, 1fr);
+        }
+
+        .node .pill {
+          grid-column: 2;
+          justify-self: start;
+        }
+
+        .epoch-grid {
+          grid-template-columns: 1fr;
+        }
+
+        table {
+          min-width: 0;
+        }
+
+        thead {
+          display: none;
+        }
+
+        tbody,
+        tr,
+        td {
+          display: block;
+          width: 100%;
+        }
+
+        tr {
+          padding: 10px 0;
+          border-bottom: 1px solid var(--line);
+        }
+
+        td {
+          border-bottom: 0;
+          display: grid;
+          grid-template-columns: 92px minmax(0, 1fr);
+          gap: 10px;
+          padding: 6px 12px;
+        }
+
+        td::before {
+          color: var(--muted);
+          content: attr(data-label);
+          font-size: 0.72rem;
+          font-weight: 800;
+          letter-spacing: 0.04em;
+          text-transform: uppercase;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <div class="topbar">
+        <div>
+          <h1>RustChain Network Status</h1>
+          <p class="lead">
+            Live client-side status for attestation nodes, active miners, architecture mix, and
+            epoch settlement progress. The page has no backend and refreshes every 60 seconds.
+          </p>
+        </div>
+        <div class="actions" aria-label="Page actions">
+          <a class="button" href="https://github.com/Scottcjn/Rustchain">Repository</a>
+          <a class="button" href="https://rustchain.org/explorer">Explorer</a>
+          <button class="button primary" id="refreshButton" type="button">Refresh now</button>
+        </div>
+      </div>
+
+      <section class="status-strip" aria-label="Network summary">
+        <article class="panel metric">
+          <div class="label">Overall status</div>
+          <div class="value" id="overallStatus">Checking</div>
+          <p class="sub" id="overallDetail">Fetching health from public RustChain endpoints.</p>
+        </article>
+        <article class="panel metric">
+          <div class="label">Active miners</div>
+          <div class="value" id="minerCount">--</div>
+          <p class="sub" id="minerDetail">Waiting for /api/miners.</p>
+        </article>
+        <article class="panel metric">
+          <div class="label">Current epoch</div>
+          <div class="value" id="epochValue">--</div>
+          <p class="sub" id="settlementDetail">Waiting for /epoch.</p>
+        </article>
+      </section>
+
+      <section class="grid">
+        <div class="panel section">
+          <div class="section-head">
+            <h2>Attestation Nodes</h2>
+            <span class="stamp" id="lastUpdated">Not updated yet</span>
+          </div>
+          <div class="nodes" id="nodeList" aria-live="polite"></div>
+        </div>
+
+        <div class="panel section">
+          <div class="section-head">
+            <h2>Epoch Progress</h2>
+            <span class="stamp" id="epochSource">/epoch</span>
+          </div>
+          <div class="progress" aria-hidden="true">
+            <div class="bar" id="epochBar"></div>
+          </div>
+          <div class="epoch-grid" id="epochCards"></div>
+        </div>
+      </section>
+
+      <section class="grid" style="margin-top: 16px">
+        <div class="panel section">
+          <div class="section-head">
+            <h2>Architecture Breakdown</h2>
+            <span class="stamp" id="archTotal">-- miners</span>
+          </div>
+          <div id="archList" aria-live="polite"></div>
+        </div>
+
+        <div class="panel section">
+          <div class="section-head">
+            <h2>Incident Log</h2>
+            <span class="stamp">client observed</span>
+          </div>
+          <div class="incidents" id="incidentLog">
+            <div class="incident">
+              <strong>No incidents detected yet</strong>
+              <span>The browser session will add an entry here if a node check fails.</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel section" style="margin-top: 16px">
+        <div class="section-head">
+          <h2>Recent Miner Attestations</h2>
+          <span class="stamp">sorted by last attest</span>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <caption class="sr-only">
+              Recent RustChain miner attestations
+            </caption>
+            <thead>
+              <tr>
+                <th>Miner</th>
+                <th>Family</th>
+                <th>Architecture</th>
+                <th>Multiplier</th>
+                <th>Last Attest</th>
+              </tr>
+            </thead>
+            <tbody id="minerTable">
+              <tr>
+                <td colspan="5">Loading miners...</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <span>Data sources: /health, /api/miners, /epoch. Pure static HTML and JavaScript.</span>
+        <span>Refresh interval: <strong>60 seconds</strong>.</span>
+      </footer>
+    </main>
+
+    <script>
+      const NODE_ENDPOINTS = [
+        { name: "Primary domain", baseUrl: "https://rustchain.org" },
+        { name: "Explorer domain", baseUrl: "https://explorer.rustchain.org" },
+        {
+          name: "Direct node IP",
+          baseUrl: "https://50.28.86.131",
+          manualReason: "Direct IP TLS requires curl -k or the included verifier.",
+        },
+      ];
+
+      const SLOT_SECONDS = 600;
+      const REFRESH_MS = 60000;
+      const state = {
+        incidents: [],
+      };
+
+      const $ = (id) => document.getElementById(id);
+
+      function formatDuration(seconds) {
+        if (!Number.isFinite(seconds) || seconds < 0) return "unknown";
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        if (hours > 0) return `${hours}h ${minutes}m`;
+        return `${minutes}m`;
+      }
+
+      function formatDate(seconds) {
+        if (!Number.isFinite(seconds) || seconds <= 0) return "unknown";
+        return new Date(seconds * 1000).toLocaleString(undefined, {
+          month: "short",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+      }
+
+      function relativeTime(seconds) {
+        if (!Number.isFinite(seconds) || seconds <= 0) return "unknown";
+        const diff = Math.max(0, Date.now() / 1000 - seconds);
+        if (diff < 60) return "just now";
+        if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+        if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+        return `${Math.floor(diff / 86400)}d ago`;
+      }
+
+      async function fetchJson(url, timeoutMs = 12000) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+          const response = await fetch(url, { signal: controller.signal, cache: "no-store" });
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          return await response.json();
+        } finally {
+          clearTimeout(timer);
+        }
+      }
+
+      async function checkNode(node) {
+        if (node.manualReason) {
+          return {
+            ...node,
+            ok: null,
+            manual: true,
+            latency: null,
+            detail: node.manualReason,
+          };
+        }
+
+        const start = performance.now();
+        try {
+          const data = await fetchJson(`${node.baseUrl}/health`);
+          return {
+            ...node,
+            ok: Boolean(data.ok),
+            latency: Math.round(performance.now() - start),
+            data,
+          };
+        } catch (error) {
+          return {
+            ...node,
+            ok: false,
+            latency: null,
+            error: error.message || "request failed",
+          };
+        }
+      }
+
+      function normalizeMiners(payload) {
+        if (Array.isArray(payload)) return payload;
+        if (Array.isArray(payload?.miners)) return payload.miners;
+        return [];
+      }
+
+      function renderNodes(results) {
+        $("nodeList").innerHTML = results
+          .map((node) => {
+            const cls = node.manual ? "warn" : node.ok ? "up" : "down";
+            const status = node.manual ? "Manual" : node.ok ? "Online" : "Offline";
+            const detail = node.manual
+              ? node.detail
+              : node.ok
+                ? `v${node.data.version || "unknown"} · uptime ${formatDuration(node.data.uptime_s)} · ${node.latency} ms`
+                : node.error || "health check failed";
+            return `
+              <article class="node">
+                <span class="dot ${cls}" aria-hidden="true"></span>
+                <div>
+                  <strong>${node.name}</strong>
+                  <span>${node.baseUrl}/health</span>
+                  <span>${detail}</span>
+                </div>
+                <span class="pill ${cls}">${status}</span>
+              </article>
+            `;
+          })
+          .join("");
+
+        const browserChecked = results.filter((node) => !node.manual);
+        const online = browserChecked.filter((node) => node.ok).length;
+        $("overallStatus").textContent =
+          online === browserChecked.length ? "Operational" : "Degraded";
+        $("overallDetail").textContent = `${online}/${browserChecked.length} browser-checkable endpoints responded successfully. Direct IP is covered by the included verifier.`;
+        $("lastUpdated").textContent = new Date().toLocaleTimeString(undefined, {
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+        });
+
+        const failed = results.filter((node) => !node.manual && !node.ok);
+        if (failed.length > 0) {
+          state.incidents.unshift({
+            title: `${failed.length} node check failed`,
+            detail: failed.map((node) => `${node.name}: ${node.error}`).join("; "),
+            time: new Date(),
+          });
+          state.incidents = state.incidents.slice(0, 5);
+        }
+        renderIncidents();
+      }
+
+      function renderEpoch(epoch) {
+        const slot = Number(epoch.slot || 0);
+        const blocksPerEpoch = Number(epoch.blocks_per_epoch || 144);
+        const slotInEpoch = ((slot % blocksPerEpoch) + blocksPerEpoch) % blocksPerEpoch;
+        const progress = blocksPerEpoch ? (slotInEpoch / blocksPerEpoch) * 100 : 0;
+        const slotsRemaining = Math.max(0, blocksPerEpoch - slotInEpoch);
+        const nextSettlement = Number(epoch.next_settlement);
+        const secondsRemaining = Number.isFinite(nextSettlement)
+          ? Math.max(0, nextSettlement - Date.now() / 1000)
+          : slotsRemaining * SLOT_SECONDS;
+
+        $("epochValue").textContent = epoch.epoch ?? "--";
+        $("settlementDetail").textContent = `${slotsRemaining} slots remaining · about ${formatDuration(secondsRemaining)}.`;
+        $("epochBar").style.width = `${Math.min(100, Math.max(0, progress)).toFixed(1)}%`;
+
+        $("epochCards").innerHTML = [
+          ["Current slot", slot.toLocaleString()],
+          ["Epoch progress", `${slotInEpoch}/${blocksPerEpoch} slots`],
+          ["Epoch pot", `${epoch.epoch_pot ?? "?"} RTC`],
+          ["Total supply", `${Number(epoch.total_supply_rtc || 0).toLocaleString()} RTC`],
+          ["Enrolled miners", `${epoch.enrolled_miners ?? "?"}`],
+          ["Next settlement", nextSettlement ? formatDate(nextSettlement) : `~${formatDuration(secondsRemaining)}`],
+        ]
+          .map(
+            ([label, value]) => `
+              <div class="mini">
+                <div class="label">${label}</div>
+                <strong>${value}</strong>
+              </div>
+            `,
+          )
+          .join("");
+      }
+
+      function renderMiners(miners) {
+        const sorted = [...miners].sort((a, b) => Number(b.last_attest || 0) - Number(a.last_attest || 0));
+        $("minerCount").textContent = miners.length.toLocaleString();
+        $("minerDetail").textContent = `${sorted.length} miners returned from the public API.`;
+        $("archTotal").textContent = `${miners.length} miners`;
+
+        const families = new Map();
+        for (const miner of miners) {
+          const key = miner.device_family || miner.hardware_type || miner.device_arch || "Unknown";
+          families.set(key, (families.get(key) || 0) + 1);
+        }
+
+        const max = Math.max(...families.values(), 1);
+        $("archList").innerHTML = [...families.entries()]
+          .sort((a, b) => b[1] - a[1])
+          .map(([family, count]) => {
+            const percent = miners.length ? (count / miners.length) * 100 : 0;
+            return `
+              <div class="arch-row">
+                <span class="arch-name">${family}</span>
+                <span class="track"><span class="fill" style="width:${(count / max) * 100}%"></span></span>
+                <span>${count} (${percent.toFixed(0)}%)</span>
+              </div>
+            `;
+          })
+          .join("");
+
+        $("minerTable").innerHTML = sorted
+          .slice(0, 12)
+          .map(
+            (miner) => `
+              <tr>
+                <td data-label="Miner">${miner.miner || "unknown"}</td>
+                <td data-label="Family">${miner.device_family || miner.hardware_type || "unknown"}</td>
+                <td data-label="Arch">${miner.device_arch || "unknown"}</td>
+                <td data-label="Multiplier">${Number(miner.antiquity_multiplier || 0).toFixed(4)}x</td>
+                <td data-label="Last">${relativeTime(Number(miner.last_attest || 0))}</td>
+              </tr>
+            `,
+          )
+          .join("");
+      }
+
+      function renderIncidents() {
+        if (state.incidents.length === 0) return;
+        $("incidentLog").innerHTML = state.incidents
+          .map(
+            (incident) => `
+              <div class="incident">
+                <strong>${incident.title}</strong>
+                <span>${incident.detail}</span>
+                <span>${incident.time.toLocaleString()}</span>
+              </div>
+            `,
+          )
+          .join("");
+      }
+
+      async function refresh() {
+        $("refreshButton").disabled = true;
+        $("refreshButton").textContent = "Refreshing";
+        try {
+          const nodeResults = await Promise.all(NODE_ENDPOINTS.map(checkNode));
+          renderNodes(nodeResults);
+
+          const primary = NODE_ENDPOINTS[0].baseUrl;
+          const [minersPayload, epoch] = await Promise.all([
+            fetchJson(`${primary}/api/miners`),
+            fetchJson(`${primary}/epoch`),
+          ]);
+          renderMiners(normalizeMiners(minersPayload));
+          renderEpoch(epoch);
+        } catch (error) {
+          $("overallStatus").textContent = "Degraded";
+          $("overallDetail").textContent = error.message || "Unable to refresh status data.";
+        } finally {
+          $("refreshButton").disabled = false;
+          $("refreshButton").textContent = "Refresh now";
+        }
+      }
+
+      $("refreshButton").addEventListener("click", refresh);
+      refresh();
+      setInterval(refresh, REFRESH_MS);
+    </script>
+  </body>
+</html>

--- a/community/status-pages/jonasxzb-rustchain-network-status/verify-status-page.mjs
+++ b/community/status-pages/jonasxzb-rustchain-network-status/verify-status-page.mjs
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pagePath = path.join(__dirname, "index.html");
+
+const nodes = [
+  "https://rustchain.org",
+  "https://explorer.rustchain.org",
+  "https://50.28.86.131",
+];
+
+async function fetchJson(url) {
+  const response = await fetch(url, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`${url} returned HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const html = await fs.readFile(pagePath, "utf8");
+
+for (const expected of [
+  "RustChain Network Status",
+  "Attestation Nodes",
+  "Architecture Breakdown",
+  "Epoch Progress",
+  "Recent Miner Attestations",
+  "setInterval(refresh, REFRESH_MS)",
+  "https://rustchain.org",
+  "https://explorer.rustchain.org",
+  "https://50.28.86.131",
+]) {
+  assert(html.includes(expected), `Missing expected page content: ${expected}`);
+}
+
+const healthResults = await Promise.all(
+  nodes.map(async (baseUrl) => {
+    const health = await fetchJson(`${baseUrl}/health`);
+    assert(health.ok === true, `${baseUrl}/health did not report ok: true`);
+    return { baseUrl, version: health.version, uptime_s: health.uptime_s };
+  }),
+);
+
+const minersPayload = await fetchJson("https://rustchain.org/api/miners");
+const miners = Array.isArray(minersPayload) ? minersPayload : minersPayload.miners;
+assert(Array.isArray(miners), "/api/miners did not return a miners array");
+assert(miners.length > 0, "/api/miners returned no miners");
+
+const families = new Set(
+  miners.map((miner) => miner.device_family || miner.hardware_type || miner.device_arch || "Unknown"),
+);
+
+const epoch = await fetchJson("https://rustchain.org/epoch");
+assert(Number.isFinite(Number(epoch.epoch)), "/epoch missing numeric epoch");
+assert(Number.isFinite(Number(epoch.slot)), "/epoch missing numeric slot");
+assert(Number.isFinite(Number(epoch.blocks_per_epoch)), "/epoch missing numeric blocks_per_epoch");
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      checked_nodes: healthResults,
+      miner_count: miners.length,
+      architecture_groups: [...families].sort(),
+      epoch: epoch.epoch,
+      slot: epoch.slot,
+      blocks_per_epoch: epoch.blocks_per_epoch,
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## Summary
- add a pure static RustChain network status page for bounty #38
- show browser-checkable attestation node health, miner count, architecture breakdown, epoch progress, recent miner attestations, and an incident log
- include a no-dependency verifier that checks all three public node endpoints, including the direct IP endpoint with TLS verification disabled to match the bounty curl -k guidance

## Verification
- `node community/status-pages/jonasxzb-rustchain-network-status/verify-status-page.mjs`
- browser QA with system Chrome headless at desktop 1440px and mobile 390px: 0 console errors, 0 warnings, no detected horizontal page overflow

## Notes
The direct IP endpoint has a certificate common-name mismatch in normal browsers, so the page labels it as a manual/verifier check while the included verifier checks it directly.