### PR TITLE
docs: claim code review bounties for PRs 6817, 1300, 1301

### DIFF
--- a/claims/code-review-bounty-73-deanventor-max-bottube-pr1300.md
+++ b/claims/code-review-bounty-73-deanventor-max-bottube-pr1300.md
@@ -1,0 +1,30 @@
+# Code Review Bounty #73 Claim - BoTTube PR #1300
+
+Reviewer: @deanventor-max
+Wallet/miner ID: `deanventor-max`
+
+Reviewed PR: https://github.com/Scottcjn/bottube/pull/1300
+Review link: https://github.com/Scottcjn/bottube/pull/1300#pullrequestreview-4415786000
+Reviewed head: `7186bd5dad431511e38e7cf0b73d6f046ea9b45a`
+
+## Review Type
+
+Standard line-level review with changes requested.
+
+## Summary
+
+I reviewed the agent quick-start terms-acceptance docs change. The endpoint placement is conceptually correct, but the newly added README block uses bare LF line endings while the surrounding README lines are CRLF.
+
+I requested changes because the PR leaves `README.md` with mixed line endings and creates avoidable future diff churn. I recommended re-saving the added block with the existing README line-ending style, or closing this in favor of the duplicate PR that preserves CRLF.
+
+## Validation
+
+- Inspected the PR patch.
+- Fetched the raw README at PR head.
+- Counted line endings: 455 LF total, 441 CRLF, 14 bare LF.
+- Confirmed lines 182-187 in the new block are LF-only while surrounding quick-start lines are CRLF.
+- Checked visible status rollup: lint/test/security green, auto-label red.
+
+## Payout Boundary
+
+This file records a public review and bounty claim only. It is not a maintainer award, payout approval, wallet transfer, or payment receipt. Bounty #73 rate-limit and finite-pool terms still apply.

--- a/claims/code-review-bounty-73-deanventor-max-bottube-pr1301.md
+++ b/claims/code-review-bounty-73-deanventor-max-bottube-pr1301.md
@@ -1,0 +1,30 @@
+# Code Review Bounty #73 Claim - BoTTube PR #1301
+
+Reviewer: @deanventor-max
+Wallet/miner ID: `deanventor-max`
+
+Reviewed PR: https://github.com/Scottcjn/bottube/pull/1301
+Review link: https://github.com/Scottcjn/bottube/pull/1301#pullrequestreview-4415788777
+Reviewed head: `d379e8bc809e92c4bacf69f34940f5943644206c`
+
+## Review Type
+
+Standard line-level content review.
+
+## Summary
+
+I reviewed the agent quick-start terms-acceptance docs change and found it to be the cleaner duplicate of PR #1300. The new terms-acceptance call appears in the right place: after registration/API-key creation and before upload/comment/vote actions. It includes the API key header, JSON content type, and explicit version payload.
+
+I also verified that this PR preserves the README line-ending style in the newly added block, avoiding the mixed-line-ending issue present in PR #1300. I noted that the visible `auto-label` check was still red while lint/test/security were green.
+
+## Validation
+
+- Inspected the PR patch.
+- Fetched the raw README at PR head.
+- Counted line endings: 455 LF total, 447 CRLF, 8 bare LF.
+- Confirmed newly added lines 182-187 are CRLF, matching the surrounding quick-start block.
+- Checked visible status rollup: lint/test/security green, auto-label red.
+
+## Payout Boundary
+
+This file records a public review and bounty claim only. It is not a maintainer award, payout approval, wallet transfer, or payment receipt. Bounty #73 rate-limit and finite-pool terms still apply.

--- a/claims/code-review-bounty-73-deanventor-max-rustchain-pr6817.md
+++ b/claims/code-review-bounty-73-deanventor-max-rustchain-pr6817.md
@@ -1,0 +1,28 @@
+# Code Review Bounty #73 Claim - RustChain PR #6817
+
+Reviewer: @deanventor-max
+Wallet/miner ID: `deanventor-max`
+
+Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/6817
+Review link: https://github.com/Scottcjn/Rustchain/pull/6817#pullrequestreview-4415726310
+Reviewed head: `3a42404419eba09456cb9c764821d4216ef8e3e8`
+
+## Review Type
+
+Standard line-level review.
+
+## Summary
+
+I reviewed the Hall of Rust JSON-body validation follow-up. The endpoint behavior looks safe: `/hall/induct` and `/hall/eulogy/<fingerprint>` already reject non-object JSON directly, and the new regression tests cover array and string payload rejection.
+
+I left an inline cleanup comment on the newly added `_json_object_required()` helper because it is currently dead duplicate validation code. The recommended follow-up is to either wire that helper into both write endpoints or remove it so the PR remains a focused regression-test addition.
+
+## Validation
+
+- Inspected the full `explorer/hall_of_rust.py` file at PR head.
+- Inspected `tests/test_explorer_hall_of_rust_current_year.py` at PR head.
+- Checked the visible GitHub status rollup for PR #6817; all checks were green when reviewed.
+
+## Payout Boundary
+
+This file records a public review and bounty claim only. It is not a maintainer award, payout approval, wallet transfer, or payment receipt. Bounty #73 rate-limit and finite-pool terms still apply.


### PR DESCRIPTION
## Summary

Adds claim records for three Code Review Bounty #73 reviews completed by @deanventor-max within the 3 reviews / 24h cap.

Reviews:
- RustChain PR #6817: https://github.com/Scottcjn/Rustchain/pull/6817#pullrequestreview-4415726310
- BoTTube PR #1300: https://github.com/Scottcjn/bottube/pull/1300#pullrequestreview-4415786000
- BoTTube PR #1301: https://github.com/Scottcjn/bottube/pull/1301#pullrequestreview-4415788777

## Notes

The bounty issue comment thread is locked by GitHub 2500-comment limit, so these claims are filed as claims-directory PR records, matching the current repository pattern.

This is not a payout approval or payment receipt; bounty #73 rate-limit and finite-pool terms still apply.