### PR TITLE
feat(actions): RTC Reward Action — award RTC on merged PRs (#2864)

### DIFF
--- a/actions/rtc-reward-action/README.md
+++ b/actions/rtc-reward-action/README.md
@@ -1,0 +1,76 @@
+# RTC Reward Action
+
+A reusable GitHub Action that awards [RustChain](https://rustchain.org) **RTC** to a
+contributor automatically when their pull request is merged. Turns any repo into a
+bounty platform with a single workflow file.
+
+Implements bounty [#2864](https://github.com/Scottcjn/rustchain-bounties/issues/2864).
+
+## What it does
+
+On a merged PR it:
+1. Resolves the contributor's wallet — a labelled `rtc-wallet: RTC…` / `wallet: RTC…`
+   line in the PR body wins; otherwise the first `RTC<40-hex>` address in the body;
+   otherwise the first address in a committed `.rtc-wallet` file.
+2. In **dry-run** (default) posts a comment showing the intended payout — no transfer.
+3. With `dry-run: false` calls the node's `/wallet/transfer` and posts a confirmation
+   comment with the `tx_hash`/`pending_id`.
+
+If no wallet is found it does nothing (a no-op, never an error), so it's safe to enable
+repo-wide.
+
+## Usage
+
+```yaml
+# .github/workflows/reward.yml
+name: Reward merged PRs
+on:
+  pull_request:
+    types: [closed]
+permissions:
+  pull-requests: write   # to post the confirmation comment
+jobs:
+  reward:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4          # needed only if you use a .rtc-wallet file
+      - uses: Scottcjn/rtc-reward-action@v1
+        with:
+          amount: "5"
+          dry-run: "false"
+          node-url: "https://rustchain.org"
+          wallet-from: ${{ secrets.RTC_PAYOUT_WALLET }}
+          admin-key: ${{ secrets.RTC_ADMIN_KEY }}
+```
+
+## Inputs
+
+| input | default | description |
+|-------|---------|-------------|
+| `node-url` | `https://rustchain.org` | RustChain node base URL |
+| `amount` | `1` | RTC awarded per merged PR |
+| `wallet-from` | `""` | Funding wallet/account on the node |
+| `admin-key` | `""` | Payout authorization key — **store as a repo secret** |
+| `dry-run` | `true` | When true, only logs/comments the intended payout |
+| `github-token` | `${{ github.token }}` | Token used to post the comment |
+
+## Outputs
+
+| output | description |
+|--------|-------------|
+| `awarded` | `true` if a real transfer was made |
+| `wallet` | resolved recipient RTC wallet (empty if none) |
+| `tx` | transfer id/hash when a real transfer was made |
+
+## Security notes
+
+- Never hard-code `admin-key`; pass it via `secrets`.
+- Default `dry-run: true` prevents accidental payouts before you've configured funding.
+- The action makes no transfer when no wallet is present, so a forgetful contributor
+  simply isn't paid rather than the workflow failing.
+
+## Tests
+
+`python3 test_award_rtc.py` — 9 offline unit tests covering wallet extraction
+precedence, malformed-address rejection, and the dry-run end-to-end path.

--- a/actions/rtc-reward-action/action.yml
+++ b/actions/rtc-reward-action/action.yml
@@ -1,0 +1,56 @@
+name: "RTC Reward Action"
+description: "Award RustChain RTC to a contributor when their pull request merges."
+branding:
+  icon: "award"
+  color: "purple"
+inputs:
+  node-url:
+    description: "RustChain node base URL"
+    required: false
+    default: "https://rustchain.org"
+  amount:
+    description: "RTC to award per merged PR"
+    required: false
+    default: "1"
+  wallet-from:
+    description: "Funding (sender) wallet/account on the node"
+    required: false
+    default: ""
+  admin-key:
+    description: "Payout authorization key (store as a repo secret)"
+    required: false
+    default: ""
+  dry-run:
+    description: "If true, only logs/comments the intended payout (no transfer)"
+    required: false
+    default: "true"
+  github-token:
+    description: "Token used to post the confirmation comment"
+    required: false
+    default: ${{ github.token }}
+outputs:
+  awarded:
+    description: "true if a real transfer was made"
+    value: ${{ steps.award.outputs.awarded }}
+  wallet:
+    description: "Resolved recipient RTC wallet (empty if none found)"
+    value: ${{ steps.award.outputs.wallet }}
+  tx:
+    description: "Transfer id/hash when a real transfer was made"
+    value: ${{ steps.award.outputs.tx }}
+runs:
+  using: "composite"
+  steps:
+    - id: award
+      shell: bash
+      run: python3 "${{ github.action_path }}/award_rtc.py"
+      env:
+        INPUT_NODE_URL: ${{ inputs.node-url }}
+        INPUT_AMOUNT: ${{ inputs.amount }}
+        INPUT_WALLET_FROM: ${{ inputs.wallet-from }}
+        INPUT_ADMIN_KEY: ${{ inputs.admin-key }}
+        INPUT_DRY_RUN: ${{ inputs.dry-run }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_REPO: ${{ github.repository }}
+        INPUT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        INPUT_PR_BODY: ${{ github.event.pull_request.body }}

--- a/actions/rtc-reward-action/award_rtc.py
+++ b/actions/rtc-reward-action/award_rtc.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Award RTC to a merged PR's contributor.
+
+Resolves the recipient wallet from the PR body (an `RTC<40-hex>` address or a
+`rtc-wallet: <addr>` line) or, failing that, a committed `.rtc-wallet` file.
+Posts a confirmation comment and (unless --dry-run) asks the node to transfer.
+
+Designed to run inside a GitHub Action; all inputs arrive via env vars so the
+file stays import-clean and unit-testable. See action.yml.
+"""
+import json
+import os
+import re
+import sys
+import urllib.request
+import urllib.error
+
+RTC_ADDRESS_RE = re.compile(r"\bRTC[0-9a-fA-F]{40}\b")
+# Explicit "rtc-wallet: <addr>" / "wallet: <addr>" lines win over a bare match.
+RTC_LABELLED_RE = re.compile(
+    r"(?im)^\s*(?:rtc[-_ ]?wallet|wallet)\s*[:=]\s*(RTC[0-9a-fA-F]{40})\b"
+)
+
+
+def extract_wallet(pr_body, rtc_wallet_file=None):
+    """Return the recipient RTC address, or None.
+
+    Precedence: a labelled `wallet:` line in the PR body, then the first bare
+    RTC address in the body, then the `.rtc-wallet` file's first address.
+    """
+    for source in (pr_body or "",):
+        m = RTC_LABELLED_RE.search(source)
+        if m:
+            return m.group(1)
+    for source in (pr_body or "",):
+        m = RTC_ADDRESS_RE.search(source)
+        if m:
+            return m.group(0)
+    if rtc_wallet_file:
+        m = RTC_ADDRESS_RE.search(rtc_wallet_file)
+        if m:
+            return m.group(0)
+    return None
+
+
+def _post_json(url, payload, headers, timeout=30):
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read()
+        return resp.status, (json.loads(raw) if raw else {})
+
+
+def post_pr_comment(repo, pr_number, token, body):
+    url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "rtc-reward-action",
+        "Content-Type": "application/json",
+    }
+    try:
+        status, _ = _post_json(url, {"body": body}, headers)
+        return status in (200, 201)
+    except urllib.error.HTTPError as e:
+        print(f"::warning::could not post PR comment: {e.code} {e.read()[:200]!r}")
+        return False
+
+
+def transfer_rtc(node_url, payload, timeout=30):
+    """POST the transfer to the node. Returns (ok, response_dict)."""
+    url = node_url.rstrip("/") + "/wallet/transfer"
+    headers = {"Content-Type": "application/json", "User-Agent": "rtc-reward-action"}
+    # Self-signed certs on some nodes; mirror the project's documented posture.
+    import ssl
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            raw = resp.read()
+            return True, (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as e:
+        return False, {"error": e.code, "detail": e.read().decode("utf-8", "replace")[:300]}
+    except Exception as e:  # noqa: BLE001 - surface any transport error to the log
+        return False, {"error": str(e)}
+
+
+def _bool(v):
+    return str(v).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def main():
+    repo = os.environ.get("INPUT_REPO") or os.environ.get("GITHUB_REPOSITORY", "")
+    pr_number = os.environ.get("INPUT_PR_NUMBER", "")
+    pr_body = os.environ.get("INPUT_PR_BODY", "")
+    token = os.environ.get("INPUT_GITHUB_TOKEN", "")
+    node_url = os.environ.get("INPUT_NODE_URL", "https://rustchain.org")
+    amount = os.environ.get("INPUT_AMOUNT", "1")
+    wallet_from = os.environ.get("INPUT_WALLET_FROM", "")
+    admin_key = os.environ.get("INPUT_ADMIN_KEY", "")
+    dry_run = _bool(os.environ.get("INPUT_DRY_RUN", "true"))
+
+    rtc_wallet_file = None
+    if os.path.exists(".rtc-wallet"):
+        with open(".rtc-wallet", "r", encoding="utf-8", errors="replace") as fh:
+            rtc_wallet_file = fh.read()
+
+    wallet = extract_wallet(pr_body, rtc_wallet_file)
+    if not wallet:
+        print("::notice::no RTC wallet found in PR body or .rtc-wallet; nothing to award")
+        _set_output("awarded", "false")
+        _set_output("wallet", "")
+        return 0
+
+    try:
+        amount_f = float(amount)
+    except ValueError:
+        print(f"::error::invalid amount: {amount!r}")
+        return 1
+
+    print(f"recipient wallet: {wallet}")
+    print(f"amount: {amount_f} RTC  dry_run={dry_run}")
+
+    if dry_run:
+        msg = (f"\U0001F9EA **RTC reward (dry-run)** — would send **{amount_f} RTC** "
+               f"to `{wallet}` for this merged PR. Set `dry-run: false` to enable real payouts.")
+        if repo and pr_number and token:
+            post_pr_comment(repo, pr_number, token, msg)
+        _set_output("awarded", "false")
+        _set_output("wallet", wallet)
+        print("dry-run complete")
+        return 0
+
+    payload = {
+        "from": wallet_from,
+        "to": wallet,
+        "amount_rtc": amount_f,
+        "admin_key": admin_key,
+        "memo": f"PR reward {repo}#{pr_number}",
+    }
+    ok, resp = transfer_rtc(node_url, payload)
+    if ok and resp.get("ok", True):
+        tx = resp.get("tx_hash") or resp.get("pending_id") or "(pending)"
+        msg = (f"✅ **RTC reward sent** — **{amount_f} RTC** to `{wallet}` "
+               f"for this merged PR. tx: `{tx}`")
+        if repo and pr_number and token:
+            post_pr_comment(repo, pr_number, token, msg)
+        _set_output("awarded", "true")
+        _set_output("wallet", wallet)
+        _set_output("tx", str(tx))
+        print(f"transfer ok: {tx}")
+        return 0
+
+    print(f"::error::transfer failed: {resp}")
+    if repo and pr_number and token:
+        post_pr_comment(repo, pr_number, token,
+                        f"⚠️ RTC reward to `{wallet}` failed: `{resp}`")
+    _set_output("awarded", "false")
+    return 1
+
+
+def _set_output(key, value):
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as fh:
+            fh.write(f"{key}={value}\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/actions/rtc-reward-action/award_rtc.py
+++ b/actions/rtc-reward-action/award_rtc.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Award RTC to a merged PR's contributor.
 
 Resolves the recipient wallet from the PR body (an `RTC<40-hex>` address or a

--- a/actions/rtc-reward-action/test_award_rtc.py
+++ b/actions/rtc-reward-action/test_award_rtc.py
@@ -1,0 +1,65 @@
+"""Unit tests for wallet extraction + dry-run behavior (no network)."""
+import os, tempfile, subprocess, sys
+from award_rtc import extract_wallet, _bool
+
+ADDR = "RTC51a782cf006436e5134e08049b289639bd8e2116"
+ADDR2 = "RTC0000111122223333444455556666777788889999"
+
+
+def test_bare_address_in_body():
+    assert extract_wallet(f"Thanks! Please pay {ADDR} for this work.") == ADDR
+
+def test_labelled_line_wins_over_bare():
+    body = f"random {ADDR2} text\nrtc-wallet: {ADDR}\n"
+    assert extract_wallet(body) == ADDR
+
+def test_wallet_equals_syntax():
+    assert extract_wallet(f"wallet = {ADDR}") == ADDR
+
+def test_falls_back_to_file():
+    assert extract_wallet("no wallet here", rtc_wallet_file=f"{ADDR}\n") == ADDR
+
+def test_body_beats_file():
+    assert extract_wallet(f"pay {ADDR}", rtc_wallet_file=ADDR2) == ADDR
+
+def test_none_when_absent():
+    assert extract_wallet("no address at all", rtc_wallet_file="still none") is None
+
+def test_rejects_short_or_malformed():
+    assert extract_wallet("RTCdeadbeef") is None          # too short
+    assert extract_wallet("RTC" + "g" * 40) is None        # non-hex
+
+def test_bool_parsing():
+    assert _bool("true") and _bool("1") and _bool("YES")
+    assert not _bool("false") and not _bool("0") and not _bool("")
+
+
+def test_dry_run_end_to_end(tmp_path=None):
+    """Running the script in dry-run mode resolves the wallet and exits 0."""
+    d = tempfile.mkdtemp()
+    out = os.path.join(d, "ghout")
+    open(out, "w").close()
+    env = dict(os.environ)
+    env.update({
+        "INPUT_DRY_RUN": "true",
+        "INPUT_PR_BODY": f"please reward {ADDR}",
+        "INPUT_AMOUNT": "2",
+        "INPUT_REPO": "", "INPUT_PR_NUMBER": "", "INPUT_GITHUB_TOKEN": "",
+        "GITHUB_OUTPUT": out,
+    })
+    r = subprocess.run([sys.executable, os.path.join(os.path.dirname(__file__), "award_rtc.py")],
+                       env=env, capture_output=True, text=True, cwd=d)
+    assert r.returncode == 0, r.stderr
+    outputs = open(out).read()
+    assert f"wallet={ADDR}" in outputs
+    assert "awarded=false" in outputs
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in fns:
+        fn()
+        print(f"PASS {fn.__name__}")
+        passed += 1
+    print(f"\n{passed}/{len(fns)} tests passed")

--- a/actions/rtc-reward-action/test_award_rtc.py
+++ b/actions/rtc-reward-action/test_award_rtc.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Unit tests for wallet extraction + dry-run behavior (no network)."""
 import os, tempfile, subprocess, sys
 from award_rtc import extract_wallet, _bool


### PR DESCRIPTION
## Bounty #2864 — GitHub Action that awards RTC for merged PRs

Reusable **composite** action under `actions/rtc-reward-action/`. On a merged PR it resolves the contributor wallet (labelled `rtc-wallet:` line > first `RTC<40hex>` in the body > `.rtc-wallet` file), supports **dry-run** (default, safe), posts a confirmation comment, and calls `/wallet/transfer` with configurable `node-url`/`amount`/`wallet-from`/`admin-key`.

- Inputs/outputs documented in `action.yml` + `README.md`
- **9 offline unit tests** in `test_award_rtc.py` (wallet-extraction precedence, malformed-address rejection, dry-run end-to-end) — all green
- No-op (never fails the workflow) when no wallet is present; `dry-run` default prevents accidental payouts
- Marketplace-ready (`branding` set); promote under `Scottcjn/rtc-reward-action@v1` to publish

Claiming bounty #2864. Payout wallet: `RTC51a782cf006436e5134e08049b289639bd8e2116`