### PR TITLE
Add RustChain T2 live balance verifier integration

### DIFF
--- a/integrations/exal-gh-33/INTEGRATION.md
+++ b/integrations/exal-gh-33/INTEGRATION.md
@@ -1,0 +1,13 @@
+tier: T2
+target: rustchain
+language: python
+endpoints_used: ["/health", "/epoch", "/api/miners", "/wallet/balance?miner_id=<wallet>"]
+wallet: RTCc0ffae7b0e9511b78551f71151f0e1819015a1c0
+starred: yes
+
+# RustChain Live Balance Verifier
+
+This integration is a small Python script that reads live RustChain node data and verifies a wallet balance response.
+
+It qualifies for T2 because it performs the T1 live reads, then verifies that the wallet balance endpoint returns a matching native RTC wallet, numeric balance fields, and an active-miner cross-check when the wallet is present in the live miner list.
+

--- a/integrations/exal-gh-33/README.md
+++ b/integrations/exal-gh-33/README.md
@@ -1,0 +1,41 @@
+# RustChain Live Balance Verifier
+
+Stdlib-only Python integration for the RustChain T2 bounty.
+
+## What it checks
+
+- `/health` returns a healthy live node.
+- `/epoch` returns current epoch and slot data.
+- `/api/miners` returns the live miner list.
+- `/wallet/balance?miner_id=<wallet>` returns a balance for the requested native RTC wallet.
+- The balance response is verified by wallet identity, numeric amount, and active-miner presence when applicable.
+
+## Requirements
+
+- Python 3.9 or newer.
+- No third-party dependencies.
+
+## Run
+
+From this folder:
+
+```bash
+python rustchain_verify.py --wallet RTC14f06ee294f327f5685d3de5e1ed501cffab33e7
+```
+
+Or from the repository root:
+
+```bash
+python integrations/exal-gh-33/rustchain_verify.py --wallet RTC14f06ee294f327f5685d3de5e1ed501cffab33e7
+```
+
+Use a different native RTC wallet with `--wallet RTC...`.
+
+## Payout
+
+Native RTC payout wallet:
+
+```text
+RTCc0ffae7b0e9511b78551f71151f0e1819015a1c0
+```
+

--- a/integrations/exal-gh-33/rustchain_verify.py
+++ b/integrations/exal-gh-33/rustchain_verify.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Verify live RustChain node data and a native RTC wallet balance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+DEFAULT_NODE = "https://rustchain.org"
+DEFAULT_WALLET = "RTC14f06ee294f327f5685d3de5e1ed501cffab33e7"
+
+
+class VerificationError(RuntimeError):
+    """Raised when live node data cannot be verified."""
+
+
+def fetch_json(base_url: str, path: str, timeout: float) -> Any:
+    url = urllib.parse.urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "rustchain-live-balance-verifier/1.0",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        payload = response.read().decode("utf-8")
+    return json.loads(payload)
+
+
+def number_from(mapping: dict[str, Any], *keys: str) -> float:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                pass
+    raise VerificationError(f"missing numeric field; tried {', '.join(keys)}")
+
+
+def miner_ids(miners_payload: Any) -> set[str]:
+    if isinstance(miners_payload, dict):
+        miners = miners_payload.get("miners", [])
+    else:
+        miners = miners_payload
+
+    ids: set[str] = set()
+    if not isinstance(miners, list):
+        raise VerificationError("miners payload is not a list")
+
+    for miner in miners:
+        if isinstance(miner, dict):
+            miner_id = miner.get("miner") or miner.get("miner_id") or miner.get("id") or miner.get("wallet")
+            if isinstance(miner_id, str):
+                ids.add(miner_id)
+        elif isinstance(miner, str):
+            ids.add(miner)
+    return ids
+
+
+def verify(args: argparse.Namespace) -> list[str]:
+    health = fetch_json(args.node, "/health", args.timeout)
+    if not isinstance(health, dict) or health.get("ok") is not True:
+        raise VerificationError("health endpoint did not report ok=true")
+
+    epoch = fetch_json(args.node, "/epoch", args.timeout)
+    if not isinstance(epoch, dict):
+        raise VerificationError("epoch endpoint did not return an object")
+    epoch_number = int(number_from(epoch, "epoch"))
+    slot_number = int(number_from(epoch, "slot"))
+    epoch_pot = number_from(epoch, "epoch_pot", "pot")
+
+    miners_payload = fetch_json(args.node, "/api/miners", args.timeout)
+    active_miners = miner_ids(miners_payload)
+    if not active_miners:
+        raise VerificationError("no active miners returned")
+
+    wallet_query = urllib.parse.urlencode({"miner_id": args.wallet})
+    balance = fetch_json(args.node, f"/wallet/balance?{wallet_query}", args.timeout)
+    if not isinstance(balance, dict):
+        raise VerificationError("balance endpoint did not return an object")
+    if balance.get("miner_id") != args.wallet:
+        raise VerificationError("balance response miner_id does not match requested wallet")
+
+    amount_rtc = number_from(balance, "amount_rtc", "balance_rtc", "balance")
+    if amount_rtc < 0:
+        raise VerificationError("balance amount cannot be negative")
+
+    active = args.wallet in active_miners
+    version = health.get("version", "unknown")
+    tip_age_slots = health.get("tip_age_slots", "unknown")
+
+    pagination = miners_payload.get("pagination", {}) if isinstance(miners_payload, dict) else {}
+    enrolled = pagination.get("total_enrolled", "unknown") if isinstance(pagination, dict) else "unknown"
+
+    return [
+        f"RustChain live node ok: version={version} tip_age_slots={tip_age_slots}",
+        f"Epoch verified: epoch={epoch_number} slot={slot_number} pot={epoch_pot:g} RTC",
+        f"Miners verified: active={len(active_miners)} enrolled={enrolled} wallet_in_active_set={'yes' if active else 'no'}",
+        f"Balance verified: wallet={args.wallet} amount_rtc={amount_rtc:g}",
+        "T2 verification passed",
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify live RustChain state and a wallet balance.")
+    parser.add_argument("--node", default=DEFAULT_NODE, help=f"RustChain node URL (default: {DEFAULT_NODE})")
+    parser.add_argument("--wallet", default=DEFAULT_WALLET, help="Native RTC wallet/miner_id to verify")
+    parser.add_argument("--timeout", type=float, default=10.0, help="HTTP timeout in seconds")
+    args = parser.parse_args()
+
+    try:
+        for line in verify(args):
+            print(line)
+    except (OSError, json.JSONDecodeError, ValueError, VerificationError) as exc:
+        print(f"verification failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/exal-gh-33/transcript.txt
+++ b/integrations/exal-gh-33/transcript.txt
@@ -1,0 +1,9 @@
+Run command:
+python integrations/exal-gh-33/rustchain_verify.py --wallet RTC14f06ee294f327f5685d3de5e1ed501cffab33e7
+
+Live transcript:
+RustChain live node ok: version=2.2.1-rip200 tip_age_slots=0
+Epoch verified: epoch=182 slot=26343 pot=1.5 RTC
+Miners verified: active=20 enrolled=25 wallet_in_active_set=yes
+Balance verified: wallet=RTC14f06ee294f327f5685d3de5e1ed501cffab33e7 amount_rtc=9.59907
+T2 verification passed


### PR DESCRIPTION
## Description
Refs #13040

Adds a T2 RustChain integration in `integrations/exal-gh-33/`.

The script reads live `/health`, `/epoch`, `/api/miners`, and `/wallet/balance` data, then verifies that the returned balance matches the requested native RTC wallet, has a numeric amount, and is present in the live miner set for the included transcript wallet.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- `python integrations/exal-gh-33/rustchain_verify.py --wallet RTC14f06ee294f327f5685d3de5e1ed501cffab33e7`

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested changes locally

## Bounty Claim
If this PR addresses a bounty issue:
- Issue number: #13040
- Tier: T2
- Target: rustchain
- Wallet ID: RTCc0ffae7b0e9511b78551f71151f0e1819015a1c0
- Starred: yes
