### PR TITLE
fix: preserve hyphens in rtc-reward action inputs

### DIFF
--- a/actions/rtc-reward/dist/index.js
+++ b/actions/rtc-reward/dist/index.js
@@ -7,7 +7,7 @@ const path = require('path');
 // ---- helpers ----
 
 function getInput(name, opts = {}) {
-  const key = `INPUT_${name.replace(/-/g, '_').toUpperCase()}`;
+  const key = `INPUT_${name.replace(/ /g, '_').toUpperCase()}`;
   const val = process.env[key];
   if (opts.required && (val === undefined || val === '')) {
     throw new Error(`Input required and not supplied: ${name}`);

--- a/tests/test_rtc_reward_action.py
+++ b/tests/test_rtc_reward_action.py
@@ -1,0 +1,40 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTION_ENTRYPOINT = ROOT / "actions" / "rtc-reward" / "dist" / "index.js"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required")
+def test_action_reads_github_hyphenated_input_environment(tmp_path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text("{}", encoding="utf-8")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "INPUT_NODE-URL": "https://example.invalid",
+            "INPUT_AMOUNT": "5",
+            "INPUT_WALLET-FROM": "founder_community",
+            "INPUT_ADMIN-KEY": "test-only-key",
+            "GITHUB_TOKEN": "test-token",
+            "GITHUB_EVENT_PATH": str(event_path),
+            "GITHUB_REPOSITORY": "owner/repo",
+        }
+    )
+
+    result = subprocess.run(
+        [shutil.which("node"), str(ACTION_ENTRYPOINT)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "No merged PR found for this event. Skipping." in result.stdout


### PR DESCRIPTION
Fixes #13202.

## Summary

- matches the official `@actions/core.getInput` environment-key convention
- preserves hyphens in input names such as `node-url`, `wallet-from`, and `admin-key`
- adds a regression test that executes the real action entrypoint with GitHub-style `INPUT_*` environment variables

## Impact

The previous normalization looked for `INPUT_NODE_URL`, but GitHub Actions exposes `node-url` as `INPUT_NODE-URL`. This caused the live reward runs for Rustchain PRs #6856 and #6875 to exit before creating their 5 RTC transfers. Their workflows appeared green because the calling step used `continue-on-error`.

Evidence:
- https://github.com/Scottcjn/Rustchain/actions/runs/27042154363
- https://github.com/Scottcjn/Rustchain/actions/runs/27035854180

## Validation

```text
python -m pytest -q tests/test_rtc_reward_action.py
1 passed

node --check actions/rtc-reward/dist/index.js
python -m py_compile tests/test_rtc_reward_action.py
git diff --check -- actions/rtc-reward/dist/index.js tests/test_rtc_reward_action.py
```

RTC wallet: `RTCf69dd944558d4e843a4a676495a97638055caea2`