### PR TITLE
fix: read hyphenated rtc-reward action inputs

### DIFF
--- a/actions/rtc-reward/dist/index.js
+++ b/actions/rtc-reward/dist/index.js
@@ -7,7 +7,10 @@ const path = require('path');
 // ---- helpers ----
 
 function getInput(name, opts = {}) {
-  const key = `INPUT_${name.replace(/-/g, '_').toUpperCase()}`;
+  // Match @actions/core.getInput's environment variable contract:
+  // spaces become underscores, but hyphens remain hyphens. GitHub sets
+  // `node-url` as `INPUT_NODE-URL`, not `INPUT_NODE_URL`.
+  const key = `INPUT_${name.replace(/ /g, '_').toUpperCase()}`;
   const val = process.env[key];
   if (opts.required && (val === undefined || val === '')) {
     throw new Error(`Input required and not supplied: ${name}`);
@@ -202,4 +205,8 @@ async function sendRTC(nodeUrl, from, to, amount, adminKey, memo) {
   return resp.json();
 }
 
-run();
+if (require.main === module) {
+  run();
+}
+
+module.exports = { getInput, extractWallet };

--- a/actions/rtc-reward/test-input-env.js
+++ b/actions/rtc-reward/test-input-env.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const { getInput } = require('./dist/index.js');
+
+const previous = { ...process.env };
+
+try {
+  process.env['INPUT_NODE-URL'] = 'https://rustchain.org';
+  delete process.env.INPUT_NODE_URL;
+  assert.strictEqual(getInput('node-url', { required: true }), 'https://rustchain.org');
+
+  process.env.INPUT_WALLET_FROM = 'wrong-key';
+  process.env['INPUT_WALLET-FROM'] = 'founder_community';
+  assert.strictEqual(getInput('wallet-from', { required: true }), 'founder_community');
+
+  process.env.INPUT_COMMENT_TEMPLATE = 'space-normalized';
+  assert.strictEqual(getInput('comment template'), 'space-normalized');
+
+  console.log('rtc-reward input env tests passed');
+} finally {
+  process.env = previous;
+}


### PR DESCRIPTION
## Summary
- match @actions/core input env normalization for hyphenated inputs
- keep the action executable while exporting helpers for focused regression tests
- add a Node regression test covering INPUT_NODE-URL and INPUT_WALLET-FROM

Fixes #13202

## Test Plan
- node actions/rtc-reward/test-input-env.js
- git diff --check