### PR TITLE
fix(ci): confirm-pending scheduler must drain fully (regression caught by tri-brain on #6900)

### DIFF
--- a/.github/workflows/confirm-pending.yml
+++ b/.github/workflows/confirm-pending.yml
@@ -1,14 +1,17 @@
 name: Confirm Pending RTC Transfers
 
-# THE delivery-stage fix: initiated RTC transfers sit in a 24h pending/void
-# window, then must be confirmed via POST /pending/confirm. Nothing was calling
-# it, so transfers piled up un-delivered (1070+ stuck when this was added).
-# This runs hourly and confirms every transfer PAST its void window. The 24h
-# window IS the safety review: void a suspect transfer within 24h and this never
-# touches it; anything un-voided after 24h is delivered.
+# Hourly delivery-stage job: initiated RTC transfers sit in a 24h pending/void
+# window, then must be confirmed via POST /pending/confirm. The node bounds each
+# call to a batch (Rustchain#6900: default 100, max 500), so a single call no
+# longer drains the whole queue. This job therefore LOOPS, passing limit=500 and
+# repeating until stale_pending_count == 0 (or no further progress), so the full
+# past-void-window backlog is delivered every run regardless of size.
+#
+# The 24h void window remains the safety review: void a suspect transfer within
+# 24h and this never confirms it.
 on:
   schedule:
-    - cron: '23 * * * *'   # hourly, off the top of the hour
+    - cron: '23 * * * *'   # hourly
   workflow_dispatch: {}
 
 permissions:
@@ -21,9 +24,9 @@ concurrency:
 jobs:
   confirm:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
-      - name: Confirm past-void-window pending transfers
+      - name: Drain all past-void-window pending transfers
         env:
           RTC_VPS_HOST: ${{ secrets.RTC_VPS_HOST }}
           RTC_ADMIN_KEY: ${{ secrets.RTC_ADMIN_KEY }}
@@ -31,14 +34,25 @@ jobs:
           if [ -z "$RTC_VPS_HOST" ] || [ -z "$RTC_ADMIN_KEY" ]; then
             echo "::error::RTC_VPS_HOST / RTC_ADMIN_KEY not configured"; exit 1
           fi
-          code=$(curl -sk -o resp.json -w '%{http_code}' --max-time 60 \
-            -X POST "https://${RTC_VPS_HOST}/pending/confirm" \
-            -H "X-Admin-Key: ${RTC_ADMIN_KEY}" \
-            -H "Content-Type: application/json" -d '{}')
-          echo "HTTP $code"
-          python3 - <<'PY'
+          total=0
+          # Safety cap: 60 iterations * 500 = up to 30,000 transfers/run.
+          for i in $(seq 1 60); do
+            code=$(curl -sk -o resp.json -w '%{http_code}' --max-time 60 \
+              -X POST "https://${RTC_VPS_HOST}/pending/confirm" \
+              -H "X-Admin-Key: ${RTC_ADMIN_KEY}" \
+              -H "Content-Type: application/json" -d '{"limit": 500}')
+            if [ "$code" != "200" ]; then echo "::error::confirm HTTP $code"; cat resp.json; exit 1; fi
+            read confirmed stale < <(python3 - <<'PY'
           import json
-          d=json.load(open('resp.json'))
-          print(f"ok={d.get('ok')} confirmed_count={d.get('confirmed_count')} errors={d.get('errors')}")
+          d = json.load(open('resp.json'))
+          print(d.get('confirmed_count', 0), d.get('stale_pending_count', 0))
           PY
-          [ "$code" = "200" ] || { echo "::error::confirm failed"; exit 1; }
+          )
+            total=$((total + confirmed))
+            echo "iter $i: confirmed=$confirmed total=$total stale_remaining=$stale"
+            # Stop when the queue is drained, or a run makes no progress (e.g. all
+            # remaining rows error individually) to avoid spinning.
+            [ "${stale:-0}" -eq 0 ] && { echo "queue drained"; break; }
+            [ "${confirmed:-0}" -eq 0 ] && { echo "no progress this iter; stopping"; break; }
+          done
+          echo "confirmed $total transfer(s) this run"


### PR DESCRIPTION
## The bug (cross-change interaction)
Rustchain#6900 bounded a single `/pending/confirm` call to a batch (default 100, max 500). But this scheduler called it **once with an empty body** — so post-#6900 it confirmed only **100 transfers/hour**, not the whole backlog. A backlog larger than the hourly inflow would never drain (the exact failure mode this scheduler exists to prevent).

A tri-brain review of #6900 (Codex + Grok + GPT-OSS) flagged it — neither #6900's green CI nor #13186's caught it, because no test exercises *scheduler + bounded-confirm together*, and the scheduler was written before the cap.

## The fix
Loop with `limit: 500`, repeating until the node reports `stale_pending_count == 0` (the observability field #6900 conveniently added) or a run makes no progress. Safety cap of 60 iterations (~30k transfers/run). Full past-void-window backlog delivered every run, any size.

Validated: `yaml.safe_load` parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)