### PR TITLE
fix(rtc-reward): call real /wallet/transfer contract so rewards actually send

### DIFF
--- a/actions/rtc-reward/dist/index.js
+++ b/actions/rtc-reward/dist/index.js
@@ -189,10 +189,20 @@ async function findWalletInRepo(token, apiBase, owner, repo, ref, pattern) {
 }
 
 async function sendRTC(nodeUrl, from, to, amount, adminKey, memo) {
-  const payload = { from, to, amount, admin_key: adminKey, memo };
-  const resp = await fetch(`${nodeUrl.replace(/\/$/, '')}/api/v1/transfer`, {
+  // RustChain node contract: POST /wallet/transfer with {from_miner,to_miner,
+  // amount_rtc}, admin auth via the X-Admin-Key header (NOT the body). The old
+  // /api/v1/transfer path 404s and body admin_key is ignored, so every reward
+  // silently failed. idempotency_key (the PR URL) prevents double-pay on re-run.
+  const payload = {
+    from_miner: from,
+    to_miner: to,
+    amount_rtc: amount,
+    memo,
+    idempotency_key: memo,
+  };
+  const resp = await fetch(`${nodeUrl.replace(/\/$/, '')}/wallet/transfer`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'X-Admin-Key': adminKey },
     body: JSON.stringify(payload),
   });
   if (!resp.ok) {


### PR DESCRIPTION
## Make merge rewards actually send RTC

The `rtc-reward` action never successfully paid anyone. Three compounding failures in `dist/index.js`:

1. **Wrong endpoint** — it POSTed to `/api/v1/transfer`, which returns **404**. The node exposes `/wallet/transfer`.
2. **Wrong contract** — it sent `{from, to, amount, admin_key}` with the admin key in the **body**. The node expects `{from_miner, to_miner, amount_rtc}` with auth in the **`X-Admin-Key` header**.
3. (In the consuming workflow) the node-url pointed at the bare IP `https://50.28.86.131`, whose TLS cert doesn't validate from a runner (`HTTP 000`). Companion PR repoints it to `https://rustchain.org` (valid cert).

### Fix
`sendRTC` now uses the real `/wallet/transfer` contract + header auth, and sends an `idempotency_key` (the PR URL) so a re-run can't double-pay.

Verified the exact target contract end-to-end against `https://rustchain.org/wallet/transfer` → `{"ok": true, "pending_id": ...}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
