### PR TITLE
feat(rtc-reward): GitHub-handle wallet fallback (bot-guarded)

### DIFF
--- a/actions/rtc-reward/dist/index.js
+++ b/actions/rtc-reward/dist/index.js
@@ -124,13 +124,27 @@ async function run() {
   if (!wallet) {
     wallet = await findWalletInRepo(token, apiBase, owner, repo, pr.head.sha, walletPattern);
   }
+  let walletSource = 'pr-body-or-repo';
   if (!wallet) {
-    info(`No RTC wallet found in PR #${prNumber}. Skipping reward.`);
+    // Handle fallback: RustChain treats a contributor's GitHub handle as a valid
+    // wallet identifier (see rustchain-bounties/GIG_APPLICANTS.md), so a PR with
+    // no explicit RTC address still earns — the author can later bind that handle
+    // to an RTC address. Bots are excluded so automation cannot farm rewards.
+    const login = (pr.user && pr.user.login) || '';
+    const isBot = (pr.user && pr.user.type === 'Bot') || /\[bot\]$/i.test(login);
+    if (login && !isBot) {
+      wallet = login;
+      walletSource = 'github-handle-fallback';
+      info(`No RTC wallet in PR #${prNumber}; falling back to GitHub handle wallet: ${wallet}`);
+    }
+  }
+  if (!wallet) {
+    info(`No wallet and no eligible handle for PR #${prNumber} (bot author?). Skipping reward.`);
     setOutput('wallet-found', 'false');
     return;
   }
 
-  info(`Found wallet: ${wallet}`);
+  info(`Found wallet: ${wallet} (source: ${walletSource})`);
   info(`Awarding ${amount} RTC to @${pr.user.login} for PR #${prNumber}`);
 
   if (dryRun) {


### PR DESCRIPTION
## Pay the GitHub handle when no RTC address is given

Until now the reward action **skipped** any merged PR whose body (or repo wallet file) had no `RTC[0-9a-fA-F]{40}` address — so most contributors earned nothing even after the transfer pipeline was fixed.

This adds a fallback: when no explicit wallet is found, pay the author's **GitHub handle** as the wallet identifier. RustChain already treats a handle as a valid wallet (see `GIG_APPLICANTS.md` — "your GitHub handle works as a wallet identifier"); the contributor can later bind that handle to an RTC address.

**Bot guard:** accounts with `type: Bot` or a `[bot]` login are excluded, so `dependabot`/`github-actions` and other automation can't farm 5 RTC per merge.

Logs now show the wallet source (`pr-body-or-repo` vs `github-handle-fallback`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
