### PR TITLE
Fix PR review gate cross-repo parsing

### DIFF
--- a/scripts/pr_review_gate.py
+++ b/scripts/pr_review_gate.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 """
-PR-Review Bounty Gate — on-arrival adjudication of Bounty #73 code-review claims.
+PR-Review Bounty Gate - on-arrival adjudication of Bounty #73 code-review claims.
 
 Runs per newly-opened/edited issue. For a code-review claim it verifies, against
-the (public) Rustchain repo, that the claimant was the FIRST substantive reviewer
-of the referenced PR, within the per-contributor cap. Conservative:
+the eligible public target repo, that the claimant was the FIRST substantive
+reviewer of the referenced PR, within the per-contributor cap. Conservative:
   - clear NOT-FIRST / rubber-stamp / over-cap  -> close (not planned) + comment
   - eligible                                   -> label 'bounty-eligible' + comment
   - ambiguous / no PR ref / non-native wallet  -> label 'needs-human' (no close)
 Idempotent: skips issues already labeled/closed by the gate.
 
 Env: GITHUB_TOKEN (repo + public read), GH_REPO (owner/name), ISSUE_NUMBER,
-     TARGET_REPO (default Scottcjn/Rustchain), CAP (default 15), RATE_RTC (3).
+     TARGET_REPO (fallback default Scottcjn/Rustchain), CAP (default 15),
+     RATE_RTC (3).
 """
 import os, re, json, sys, urllib.request, urllib.error
 
@@ -22,6 +23,12 @@ TARGET=os.environ.get("TARGET_REPO","Scottcjn/Rustchain")
 NUM=os.environ.get("ISSUE_NUMBER","")
 CAP=int(os.environ.get("CAP","15")); RATE=os.environ.get("RATE_RTC","3")
 API="https://api.github.com"
+ELIGIBLE_TARGETS={
+    "scottcjn/rustchain",
+    "scottcjn/bottube",
+    "scottcjn/rustchain-bounties",
+    "scottcjn/ram-coffers",
+}
 def api(path, method="GET", data=None):
     req=urllib.request.Request(f"{API}{path}", method=method,
         headers={"Authorization":f"Bearer {TOKEN}","Accept":"application/vnd.github+json",
@@ -37,11 +44,17 @@ def api(path, method="GET", data=None):
 def is_review_claim(title):
     t=title.lower()
     return ("review" in t) and ("pr " in t or "code review" in t or "#73" in t or "pr#" in t or "pr #" in t)
-def pr_ref(title, body):
-    for s in (title, body or ""):
+def pr_ref(title, body, fallback_repo=TARGET):
+    sources=(title, body or "")
+    for s in sources:
+        m=re.search(r'github\.com/([^/\s]+)/([^/\s]+)/pull/(\d{1,6})', s, re.I)
+        if m: return f"{m.group(1)}/{m.group(2)}", m.group(3)
+        m=re.search(r'\b([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)#(\d{1,6})\b', s)
+        if m: return f"{m.group(1)}/{m.group(2)}", m.group(3)
+    for s in sources:
         m=re.search(r'(?:PR\s*#?|pull/|#)(\d{3,6})', s)
-        if m: return m.group(1)
-    return None
+        if m: return fallback_repo, m.group(1)
+    return None, None
 def native_wallet(body):
     b=body or ""
     if re.search(r'\bRTC[0-9a-fA-F]{40}\b', b) or re.search(r'(?i)miner[_\-]?id', b): return True
@@ -58,34 +71,35 @@ def main():
     iss=api(f"/repos/{REPO}/issues/{NUM}")
     if not iss or iss.get("state")!="open": return
     labels={l["name"] for l in iss.get("labels",[])}
-    if {"bounty-eligible","needs-human","gate-processed"} & labels: return  # idempotent
+    if {"bounty-eligible","needs-human","gate-processed"} & labels: return
     title=iss.get("title",""); body=iss.get("body") or ""; author=iss["user"]["login"]
-    if not is_review_claim(title): return  # not our claim type; leave for other workflows
+    if not is_review_claim(title): return
     add_label(NUM,"gate-processed")
-    pr=pr_ref(title,body)
+    target, pr=pr_ref(title,body)
+    if target and target.lower() not in ELIGIBLE_TARGETS:
+        add_label(NUM,"needs-human"); comment(NUM,f"Gate: {target}#{pr} is not in the configured Bounty #73 eligible repository list. Flagged for human review."); return
     if not pr:
-        add_label(NUM,"needs-human"); comment(NUM,"🤖 Gate: couldn't find a single PR reference. Per **Bounty #73**, file one claim per PR with `PR #<number>`. Flagged for human review."); return
+        add_label(NUM,"needs-human"); comment(NUM,"Gate: couldn't find a single PR reference. Per Bounty #73, file one claim per PR with `PR #<number>`. Flagged for human review."); return
     if native_wallet(body) is False:
-        close(NUM,"🤖 Gate: payout must be a **native RTC wallet** (`RTC…`) — RTC has no off-ramp, no Solana/ETH bridge. Reopen with a native wallet."); return
-    reviews=api(f"/repos/{TARGET}/pulls/{pr}/reviews")
+        close(NUM,"Gate: payout must be a native RTC wallet (`RTC...`). RTC has no off-ramp, no Solana/ETH bridge. Reopen with a native wallet."); return
+    reviews=api(f"/repos/{target}/pulls/{pr}/reviews")
     if reviews is None:
-        add_label(NUM,"needs-human"); comment(NUM,f"🤖 Gate: couldn't read reviews for {TARGET}#{pr} (private/deleted?). Flagged for human review."); return
+        add_label(NUM,"needs-human"); comment(NUM,f"Gate: couldn't read reviews for {target}#{pr} (private/deleted?). Flagged for human review."); return
     rv=[r for r in reviews if r.get("submitted_at")]
     rv.sort(key=lambda r:r["submitted_at"])
     first = rv[0]["user"]["login"] if rv else None
     body_len = next((len(r.get("body") or "") for r in rv if r["user"]["login"]==author), 0)
-    inl = api(f"/repos/{TARGET}/pulls/{pr}/comments?per_page=100") or []
+    inl = api(f"/repos/{target}/pulls/{pr}/comments?per_page=100") or []
     inline = sum(1 for c in inl if c.get("user",{}).get("login")==author)
     if first != author:
-        close(NUM,f"🤖 Gate (Bounty #73 — first substantive review only): {TARGET}#{pr} was first reviewed by **{first or 'someone else'}**, not @{author}. Path back: review PRs where you're the first reviewer."); return
+        close(NUM,f"Gate (Bounty #73 - first substantive review only): {target}#{pr} was first reviewed by **{first or 'someone else'}**, not @{author}. Path back: review PRs where you're the first reviewer."); return
     if inline==0 and body_len<120:
-        close(NUM,f"🤖 Gate: your review of {TARGET}#{pr} has no inline comments and no substantive summary — Bounty #73 requires a **substantive line-level review**, not a bare approval."); return
-    # cap check: count author's existing bounty-eligible issues
+        close(NUM,f"Gate: your review of {target}#{pr} has no inline comments and no substantive summary - Bounty #73 requires a substantive line-level review, not a bare approval."); return
     elig=api(f"/search/issues?q=repo:{REPO}+label:bounty-eligible+author:{author}+type:issue") or {}
     if elig.get("total_count",0)>=CAP:
-        close(NUM,f"🤖 Gate: @{author} has reached the **{CAP} eligible reviews/contributor** cap (Bounty #73). Quality over volume — thanks!"); return
+        close(NUM,f"Gate: @{author} has reached the {CAP} eligible reviews/contributor cap (Bounty #73). Quality over volume - thanks!"); return
     add_label(NUM,"bounty-eligible")
-    comment(NUM,f"✅ 🤖 Gate: **verified eligible** — @{author} is the first substantive reviewer of {TARGET}#{pr}. **{RATE} RTC** pending payout (native `RTC…` wallet if not on file).")
+    comment(NUM,f"Gate: verified eligible - @{author} is the first substantive reviewer of {target}#{pr}. {RATE} RTC pending payout (native `RTC...` wallet if not on file).")
 
 if __name__=="__main__":
     try: main()

--- a/tests/test_pr_review_gate.py
+++ b/tests/test_pr_review_gate.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+from pathlib import Path
+
+
+def load_gate_module():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "pr_review_gate.py"
+    spec = importlib.util.spec_from_file_location("pr_review_gate", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pr_ref_uses_full_github_pull_url_repo():
+    gate = load_gate_module()
+    body = "Reviewed pull request: https://github.com/Scottcjn/bottube/pull/1327"
+
+    assert gate.pr_ref("[CLAIM] Code review bounty #73", body) == (
+        "Scottcjn/bottube",
+        "1327",
+    )
+
+
+def test_pr_ref_prefers_explicit_repo_over_title_bare_pr():
+    gate = load_gate_module()
+    title = "[CLAIM] Code review bounty #73 for PR #1327"
+    body = "Reviewed pull request: https://github.com/Scottcjn/bottube/pull/1327"
+
+    assert gate.pr_ref(title, body) == ("Scottcjn/bottube", "1327")
+
+
+def test_pr_ref_uses_owner_repo_shorthand():
+    gate = load_gate_module()
+
+    assert gate.pr_ref("Bounty #73 review for Scottcjn/ram-coffers#663", "") == (
+        "Scottcjn/ram-coffers",
+        "663",
+    )
+
+
+def test_pr_ref_falls_back_for_bare_pr_number():
+    gate = load_gate_module()
+
+    assert gate.pr_ref("Code review PR #7022", "", "Scottcjn/Rustchain") == (
+        "Scottcjn/Rustchain",
+        "7022",
+    )


### PR DESCRIPTION
## Summary
- Parse full GitHub pull URLs and owner/repo#PR shorthand in Bounty #73 review claims.
- Prefer explicit repository references over bare PR numbers, so a title like `PR #1327` does not override a BoTTube URL in the body.
- Use the parsed target repo when reading reviews/comments and when reporting gate decisions.
- Add focused parser regression tests.

## Context
Claims #13420 and #13421 referenced the BoTTube review at https://github.com/Scottcjn/bottube/pull/1327#pullrequestreview-4447051842, but the gate evaluated `Scottcjn/Rustchain#1327` because bare PR references fell back to `TARGET_REPO`.

## Validation
- `python -m pytest tests\test_pr_review_gate.py -q` -> 4 passed
- `python -m py_compile scripts\pr_review_gate.py tests\test_pr_review_gate.py`
- `git diff --check -- scripts\pr_review_gate.py tests\test_pr_review_gate.py`