### PR TITLE
fix(pr-review-gate): filter rubber-stamp reviews before first-reviewer pick (v3 follow-up to #13429)

### DIFF
--- a/scripts/pr_review_gate.py
+++ b/scripts/pr_review_gate.py
@@ -49,6 +49,166 @@ def native_wallet(body):
     if re.search(r'\b[1-9A-HJ-NP-Za-km-z]{32,44}\b', b) and "rtc" not in b.lower(): return False
     return None  # unknown -> don't reject on this alone
 
+# Rubber-stamp detector (Bounty #73: "LGTM", generic praise, or emoji
+# reaction does not establish first-reviewer position). Bounty #73
+# explicitly states terse praise with no line-level findings does not
+# establish the first-reviewer slot. The helper logic lives in
+# is_substantive_review() below; this block only defines the phrase list
+# and the regex.
+#
+# Heuristic (intentionally narrow — only flags the obvious cases the
+# 2026-06-06 clarification on issue #73 calls out):
+#   1. Any review with >=1 inline comment is substantive (handled in
+#      is_substantive_review).
+#   2. Any review whose body is long enough to plausibly carry a finding
+#      (>=80 chars after stripping whitespace) is substantive (handled
+#      in is_substantive_review).
+#   3. Any review whose body contains a file path, a line reference
+#      like `L:NN`, a marker like "Ref:", "Finding", "Bug", "Issue:",
+#      "Security", "Risk", "Guard", or a Markdown code fence, is
+#      substantive (caught by _SUBSTANTIVE_MARKER_RE).
+#   4. Emoji-only bodies are rubber-stamps (caught by _EMOJI_ONLY_RE).
+#   5. Bodies that match the canonical "LGTM / great work / thanks"
+#      pattern with no other content are rubber-stamps (caught by
+#      _RUBBER_STAMP_RE). The pattern is anchored at the start (`^\s*`)
+#      but the trailing class only allows whitespace, non-word chars,
+#      and emoji, so a praise phrase that is immediately followed by
+#      substantive text (e.g. "Great work, but the file path is
+#      missing") will NOT match — _SUBSTANTIVE_MARKER_RE.search() will
+#      catch the file path above.
+
+# Substantive-marker regex. Used to detect file paths, line refs, and
+# finding keywords. Defined BEFORE the rubber-stamp regex so the
+# is_substantive_review helper can short-circuit: a body that contains
+# a marker is never rubber-stamp, even if it also starts with a praise
+# phrase.
+_SUBSTANTIVE_MARKER_RE = re.compile(
+    r"(?:"
+    r"\b(?:ref|refs|reference|finding|findings|bug|issue|risk|guard|"
+    r"security|vuln|vulnerability|regression|edge case|missing|broken|"
+    r"leak|panic|null|deref|injection|xss|csrf|race|deadlock|overflow)\b"
+    r"|"
+    r"`[^`]*\.[a-zA-Z0-9]{1,5}`"          # `path.ext`
+    r"|"
+    r"\b[a-zA-Z0-9_./-]+\.(?:py|js|ts|go|rs|java|kt|swift|c|cpp|h|hpp|"
+    r"md|yaml|yml|json|toml|sh|bash)\b"  # bare file path
+    r"|"
+    r"\bL:?\s*\d{1,4}\b"                  # L:123 or L 123 line ref
+    r"|"
+    r"\bline\s*\d{1,4}\b"                 # line 123
+    r"|"
+    r"```"                                # markdown code fence
+    r")",
+    re.IGNORECASE,
+)
+
+# A review body is rubber-stamp iff:
+#   (a) it is short (under 80 chars stripped), AND
+#   (b) it does NOT contain a substantive marker, AND
+#   (c) it starts with (or fully is) one of the canonical praise phrases.
+# This is the helper logic; see is_substantive_review() below. The
+# phrase list is small on purpose: a real review that starts with "Risk:"
+# or "Bug:" is filtered upstream by the substantive-marker check, not by
+# this list. The phrases here are the canonical "LGTM / great work /
+# thanks / appreciate" patterns plus the universal praise emoji.
+_RUBBER_STAMP_PHRASES = (
+    "lgtm", "lgtm!", "great work", "great contribution", "great work on this",
+    "nice work", "nice!", "nice job", "awesome", "awesome!",
+    "looks good", "looks great", "ship it", "shipit", "approved!",
+    "excellent", "excellent contribution", "appreciate", "appreciated",
+    "appreciate the work", "thanks", "thanks!", "thanks for", "thank you",
+    "thx", "thnx", "great pr", "great review", "great catch", "great find",
+    "good work", "good job", "well done", "wonderful", "fantastic", "amazing",
+)
+# Regex for "body is essentially just praise." The pattern matches if the
+# body STARTS with a praise phrase and is short enough that the rest of
+# the body cannot contain a substantive marker. Concretely: the body
+# must be <= 100 chars AND consist of (whitespace + praise phrase +
+# trailing punctuation/emoji/whitespace).
+_RUBBER_STAMP_RE = re.compile(
+    r"^\s*(?:" + "|".join(re.escape(p) for p in _RUBBER_STAMP_PHRASES) + r")"
+    r"[\s\W"
+    r"\U0001F300-\U0001FAFF"
+    r"\U0001F600-\U0001F64F"
+    r"\U0001F680-\U0001F6FF"
+    r"\U0001F1E0-\U0001F1FF"
+    r"\u2600-\u27BF"
+    r"]*$",
+    re.IGNORECASE | re.UNICODE,
+)
+# Emoji-only detector: any body that is purely emoji + whitespace +
+# non-word punctuation is a rubber-stamp, regardless of length. The
+# Bounty #73 source explicitly calls out "an emoji reaction" as not
+# establishing first-reviewer position.
+_EMOJI_ONLY_RE = re.compile(
+    r"^[\s\W"
+    r"\U0001F300-\U0001FAFF"                  # symbols + pictographs
+    r"\U0001F600-\U0001F64F"                  # emoticons
+    r"\U0001F680-\U0001F6FF"                  # transport
+    r"\U0001F1E0-\U0001F1FF"                  # flags
+    r"\u2600-\u27BF"                          # misc symbols + dingbats
+    r"]+$",
+    re.UNICODE,
+)
+
+
+def is_substantive_review(review, inline_count=0):
+    """Return True iff the review carries actionable, line-level findings.
+
+    Order of checks matters. Bounty #73's 2026-06-06 clarification says
+    "LGTM", generic praise, and emoji reactions do not establish
+    first-reviewer position. A real review names a file/line and a
+    concrete issue or risk. The helper returns False (rubber-stamp) for
+    any review that fails every positive signal:
+
+      1. >= 1 inline (line-level) review comment          -> substantive
+      2. non-empty body whose first non-blank word is a
+         substantive marker (file path, line ref, "Ref:", "Bug:",
+         "Risk:", "Security", etc.)                      -> substantive
+      3. body length (stripped) >= 80 chars AND the body
+         is not pure emoji                                -> substantive
+      4. short body that is just praise + emoji           -> rubber-stamp
+      5. short body with no marker                        -> rubber-stamp
+         (Bounty #73 explicitly says terse praise without findings
+         is not substantive; default-deny matches the spec.)
+      6. empty body                                        -> rubber-stamp
+    """
+    if inline_count and inline_count > 0:
+        return True
+    body = (review.get("body") or "").strip()
+    if not body:
+        return False
+    # Substantive marker short-circuit: a body that names a file, line, or
+    # finding keyword is never a rubber-stamp, even if it ALSO starts with
+    # a praise phrase (e.g. "Great catch on the file path bug in
+    # `app/foo.py`" — kept).
+    if _SUBSTANTIVE_MARKER_RE.search(body):
+        return True
+    # Emoji-only body is always a rubber-stamp, regardless of length.
+    if _EMOJI_ONLY_RE.match(body):
+        return False
+    # Body starts with a praise phrase and is short: rubber-stamp.
+    # The regex's trailing class allows only whitespace, non-word chars,
+    # and emoji, so a praise phrase that is immediately followed by
+    # substantive text (e.g. "Great work, but the file path is missing")
+    # will NOT match this regex — `_SUBSTANTIVE_MARKER_RE.search` already
+    # caught the "file path" marker above.
+    if _RUBBER_STAMP_RE.match(body):
+        return False
+    # Long body without an explicit marker: presumed substantive (a
+    # real review with line-level findings usually exceeds 80 chars and
+    # the marker regex is intentionally narrow).
+    if len(body) >= 80:
+        return True
+    # Short body, no marker, not a praise phrase, not emoji-only. Default
+    # to rubber-stamp because Bounty #73 explicitly excludes terse
+    # praise. A borderline case like "Move this constant to a
+    # module-level enum" (30 chars, no marker) is also a rubber-stamp by
+    # this rule; reviewers with terse-but-real feedback should add a
+    # `Ref:` prefix or a file path to be sure.
+    return False
+
+
 def comment(n, body): api(f"/repos/{REPO}/issues/{n}/comments","POST",{"body":body})
 def add_label(n, lab): api(f"/repos/{REPO}/issues/{n}/labels","POST",{"labels":[lab]})
 def close(n, reason_comment):
@@ -72,12 +232,25 @@ def main():
         add_label(NUM,"needs-human"); comment(NUM,f"🤖 Gate: couldn't read reviews for {TARGET}#{pr} (private/deleted?). Flagged for human review."); return
     rv=[r for r in reviews if r.get("submitted_at")]
     rv.sort(key=lambda r:r["submitted_at"])
-    first = rv[0]["user"]["login"] if rv else None
-    body_len = next((len(r.get("body") or "") for r in rv if r["user"]["login"]==author), 0)
     inl = api(f"/repos/{TARGET}/pulls/{pr}/comments?per_page=100") or []
-    inline = sum(1 for c in inl if c.get("user",{}).get("login")==author)
+    # Per-author inline counts (so the rubber-stamp filter is per-review).
+    author_inline = {}
+    for c in inl:
+        login = (c.get("user") or {}).get("login")
+        if login:
+            author_inline[login] = author_inline.get(login, 0) + 1
+    # Filter out rubber-stamp reviews before picking the first substantive
+    # reviewer. If a review has no inline comments, run it through
+    # is_substantive_review(); if it has any inline comments, it is
+    # substantive by definition.
+    substantive = [r for r in rv if is_substantive_review(
+        r, inline_count=author_inline.get(r["user"]["login"], 0)
+    )]
+    first = substantive[0]["user"]["login"] if substantive else None
+    body_len = next((len(r.get("body") or "") for r in rv if r["user"]["login"]==author), 0)
+    inline = author_inline.get(author, 0)
     if first != author:
-        close(NUM,f"🤖 Gate (Bounty #73 — first substantive review only): {TARGET}#{pr} was first reviewed by **{first or 'someone else'}**, not @{author}. Path back: review PRs where you're the first reviewer."); return
+        close(NUM,f"🤖 Gate (Bounty #73 — first substantive review only): {TARGET}#{pr} was first reviewed by **{first or 'someone else'}** (after filtering rubber-stamps), not @{author}. Path back: review PRs where you're the first reviewer."); return
     if inline==0 and body_len<120:
         close(NUM,f"🤖 Gate: your review of {TARGET}#{pr} has no inline comments and no substantive summary — Bounty #73 requires a **substantive line-level review**, not a bare approval."); return
     # cap check: count author's existing bounty-eligible issues

--- a/tests/test_pr_review_gate_rubber_stamp.py
+++ b/tests/test_pr_review_gate_rubber_stamp.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: MIT
+"""
+Tests for the rubber-stamp chronological-first detection added in the v3
+follow-up to PR #13429 (cross-repo parsing fix). Bounty #73's 2026-06-06
+clarification explicitly states that "LGTM", generic praise, or emoji
+reactions do not establish first-reviewer position.
+
+The gate's `is_substantive_review` helper is the public seam. These tests
+cover the four acceptance criteria from the AIjackgo CHANGES_REQUESTED
+review on PR #13429:
+  - emoji-only review is filtered
+  - canonical "LGTM / great work / thanks" reviews are filtered
+  - short generic praise with no findings is filtered
+  - a real substantive review (file path, line ref, finding marker,
+    or >= 80 chars) is kept
+  - a review with >= 1 inline comment is always kept
+  - a terse-but-real review (short but carries a finding marker) is kept
+  - chronological ordering: substantive-second beats rubber-stamp-first
+"""
+import importlib.util
+from pathlib import Path
+
+
+def load_gate_module():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "pr_review_gate.py"
+    spec = importlib.util.spec_from_file_location("pr_review_gate", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _review(login, body, state="COMMENTED"):
+    return {
+        "user": {"login": login},
+        "body": body,
+        "state": state,
+        "submitted_at": "2026-06-08T00:00:00Z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-review heuristic: is_substantive_review
+# ---------------------------------------------------------------------------
+
+
+def test_emoji_only_review_is_filtered():
+    gate = load_gate_module()
+    # Pure emoji + whitespace, short — classic rubber-stamp.
+    assert gate.is_substantive_review(_review("jaxint", "🙌")) is False
+    assert gate.is_substantive_review(_review("jaxint", "🚀 🎉 👍")) is False
+    assert gate.is_substantive_review(_review("jaxint", "  🎉  ")) is False
+
+
+def test_emoji_only_long_is_also_filtered():
+    gate = load_gate_module()
+    # Bounty #73 says emoji-only reviews do not establish first-reviewer
+    # position regardless of length. A 60-char body of 30 🙌 is filtered.
+    long_emoji = "🙌 " * 30
+    assert gate.is_substantive_review(_review("jaxint", long_emoji)) is False
+
+
+def test_long_body_with_text_is_substantive():
+    gate = load_gate_module()
+    # A 90-char body of pure text (no markers) is substantive per the
+    # >= 80 char rule.
+    body = "a" * 90
+    assert gate.is_substantive_review(_review("reviewer", body)) is True
+
+
+def test_lgtm_only_is_filtered():
+    gate = load_gate_module()
+    assert gate.is_substantive_review(_review("jaxint", "LGTM")) is False
+    assert gate.is_substantive_review(_review("jaxint", "lgtm!")) is False
+    assert gate.is_substantive_review(_review("jaxint", "LGTM 🚀")) is False
+
+
+def test_great_work_phrases_are_filtered():
+    gate = load_gate_module()
+    assert gate.is_substantive_review(_review("jaxint", "Great work!")) is False
+    assert gate.is_substantive_review(_review("jaxint", "Great work on this PR!")) is False
+    assert gate.is_substantive_review(_review("jaxint", "Excellent contribution! Appreciate the work. 🙌")) is False
+    assert gate.is_substantive_review(_review("jaxint", "Thanks for contributing to RustChain ecosystem. 🚀")) is False
+    assert gate.is_substantive_review(_review("jaxint", "Looks good!")) is False
+    assert gate.is_substantive_review(_review("jaxint", "Ship it")) is False
+    assert gate.is_substantive_review(_review("jaxint", "Well done!")) is False
+
+
+def test_short_generic_praise_is_filtered():
+    gate = load_gate_module()
+    # Short and contains "thanks" but no actual finding — filter.
+    assert gate.is_substantive_review(_review("jaxint", "Nice!")) is False
+    assert gate.is_substantive_review(_review("jaxint", "Awesome!")) is False
+    assert gate.is_substantive_review(_review("jaxint", "Thank you")) is False
+    assert gate.is_substantive_review(_review("jaxint", "thx!")) is False
+
+
+def test_empty_body_is_filtered():
+    gate = load_gate_module()
+    assert gate.is_substantive_review(_review("jaxint", "")) is False
+    assert gate.is_substantive_review(_review("jaxint", None)) is False
+    assert gate.is_substantive_review(_review("jaxint", "   \n  ")) is False
+
+
+def test_real_substantive_review_is_kept():
+    gate = load_gate_module()
+    # Long body (>= 80 chars) is always substantive.
+    long = (
+        "Reviewed the diff line by line. The new `get_wallet` constant "
+        "introduces a hard-coded wallet field that duplicates the existing "
+        "`register_wallet` constant. Recommend extracting to a shared module."
+    )
+    assert gate.is_substantive_review(_review("reviewer", long)) is True
+
+
+def test_short_review_with_file_path_is_kept():
+    gate = load_gate_module()
+    # Short body, but contains a file path → substantive.
+    assert gate.is_substantive_review(_review("reviewer", "See `app/mcp.py:520`")) is True
+    assert gate.is_substantive_review(_review("reviewer", "scripts/pr_review_gate.py is missing the substantive filter")) is True
+
+
+def test_short_review_with_line_ref_is_kept():
+    gate = load_gate_module()
+    assert gate.is_substantive_review(_review("reviewer", "L:520 missing the guard")) is True
+    assert gate.is_substantive_review(_review("reviewer", "line 75 — off-by-one")) is True
+
+
+def test_short_review_with_finding_marker_is_kept():
+    gate = load_gate_module()
+    assert gate.is_substantive_review(_review("reviewer", "Ref: missing input validation")) is True
+    assert gate.is_substantive_review(_review("reviewer", "Bug: race in the timeout handler")) is True
+    assert gate.is_substantive_review(_review("reviewer", "Security: unprotected eval path")) is True
+    assert gate.is_substantive_review(_review("reviewer", "Guard needed on the response path")) is True
+    assert gate.is_substantive_review(_review("reviewer", "Regression in the diff for issue #946")) is True
+
+
+def test_short_review_with_code_fence_is_kept():
+    gate = load_gate_module()
+    # Even a 3-char `~~~` fence is enough — Markdown code is a finding format.
+    assert gate.is_substantive_review(_review("reviewer", "see ``` for the bug")) is True
+
+
+def test_inline_comments_make_review_substantive():
+    gate = load_gate_module()
+    # Even an empty body, with 1+ inline comments, is substantive.
+    assert gate.is_substantive_review(_review("reviewer", ""), inline_count=1) is True
+    assert gate.is_substantive_review(_review("reviewer", "LGTM"), inline_count=3) is True
+
+
+def test_terse_but_real_review_with_marker_is_NOT_filtered():
+    gate = load_gate_module()
+    # Short review that carries an explicit file path or finding marker.
+    assert gate.is_substantive_review(_review("reviewer", "Add a `scripts/docs_smoke.py` to the validation suite")) is True
+
+
+def test_terse_real_review_without_marker_is_filtered():
+    gate = load_gate_module()
+    # A 41-char review with NO marker, no praise phrase, no emoji.
+    # Default to rubber-stamp per Bounty #73. Reviewers with terse-but-
+    # real feedback should add a `Ref:` prefix or a file path to be sure.
+    assert gate.is_substantive_review(_review("reviewer", "Move this constant to a module-level enum")) is False
+    assert gate.is_substantive_review(_review("reviewer", "Consider using a deque here for clarity")) is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: chronological ordering with rubber-stamp filter
+# ---------------------------------------------------------------------------
+
+
+def test_substantive_second_beats_rubber_stamp_first():
+    gate = load_gate_module()
+    # Rubber-stamp at 13:47, real substantive review at 14:00. Without the
+    # filter, the gate would set `first = jaxint` and reject the real
+    # reviewer. With the filter, `first` should be the substantive one.
+    reviews = [
+        _review("jaxint", "Excellent contribution! Appreciate the work. 🙌",
+                state="COMMENTED"),
+        _review("reviewer", (
+            "Ref: the `get_wallet` constant in `app/mcp.py:520` is duplicated "
+            "from `register_wallet`; recommend extracting to a shared module."
+        ), state="APPROVED"),
+    ]
+    inline_by_login = {"jaxint": 0, "reviewer": 0}
+    substantive = [r for r in reviews if gate.is_substantive_review(
+        r, inline_count=inline_by_login.get(r["user"]["login"], 0)
+    )]
+    assert len(substantive) == 1
+    assert substantive[0]["user"]["login"] == "reviewer"
+
+
+def test_all_rubber_stamps_vacuous_first():
+    gate = load_gate_module()
+    # All three are rubber-stamps. With the filter, no review qualifies and
+    # `first` is None — the claimant vacuously becomes the first substantive
+    # reviewer.
+    reviews = [
+        _review("a", "LGTM"),
+        _review("b", "Great work!"),
+        _review("c", "🚀"),
+    ]
+    substantive = [r for r in reviews if gate.is_substantive_review(r, inline_count=0)]
+    assert substantive == []
+
+
+def test_substantive_first_with_rubber_stamp_later_still_keeps_substantive():
+    gate = load_gate_module()
+    # Substantive first, then a rubber-stamp later. Substantive reviewer
+    # correctly holds the slot — no regression for the canonical case.
+    reviews = [
+        _review("first", "Ref: `app/foo.py:42` — missing null check on result"),
+        _review("later", "LGTM!"),
+    ]
+    substantive = [r for r in reviews if gate.is_substantive_review(r, inline_count=0)]
+    assert len(substantive) == 1
+    assert substantive[0]["user"]["login"] == "first"
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: belt-and-suspenders with the existing inline>=1 OR body>=120
+# guard. The new filter should NOT regress that path.
+# ---------------------------------------------------------------------------
+
+
+def test_existing_120_char_threshold_still_triggers():
+    gate = load_gate_module()
+    # 119 chars, no markers, no inline → short, generic, but does NOT match
+    # any rubber-stamp pattern (it has substantive-sounding text). Default
+    # to keeping it via the >= 80 char threshold.
+    body = "a" * 79 + "b"  # 80 chars, no markers
+    assert gate.is_substantive_review(_review("reviewer", body)) is True
+
+
+def test_short_but_specifically_about_a_bug_is_kept():
+    gate = load_gate_module()
+    # 25 chars, has a finding marker → kept.
+    assert gate.is_substantive_review(_review("reviewer", "Bug: race in timeout")) is True


### PR DESCRIPTION
## v3 follow-up to PR #13429: filter rubber-stamp reviews before first-reviewer pick

Bounty #73's [2026-06-06 clarification](https://github.com/Scottcjn/rustchain-bounties/issues/73) states:

> **Rubber-stamp reviews do NOT establish first-reviewer position.** A review with no specific, line-level findings — `LGTM`, "great work", an emoji reaction, or generic praise — is **not substantive** and does **not** claim the PR's bounty, nor does it block a later reviewer who posts real findings.

The existing gate (and PR #13429 v1) picks `rv[0]` chronologically, which is a rubber-stamp if the first reviewer only said *"Excellent contribution! Appreciate the work. 🙌"*. AIjackgo's [CHANGES_REQUESTED on PR #13429](https://github.com/Scottcjn/rustchain-bounties/pull/13429#pullrequestreview-2621849490) flagged exactly this:

> This still uses the first chronological review, not the first substantive review required by Bounty #73. The issue text explicitly says rubber-stamp reviews like `LGTM`, generic praise, or emoji reactions do **not** establish first-reviewer position... With this code, a PR that first gets `Excellent contribution! Appreciate the work. 🙌` and later gets a real line-level review will set `first` to the generic reviewer and close the...

This PR addresses AIjackgo's feedback as a complementary v3 follow-up to PR #13429. PR #13429 closes the cross-repo parsing bug; this PR closes the rubber-stamp chronological-first bug.

### Implementation

Adds `is_substantive_review(review, inline_count)` and runs `rv` through it before picking `first`. The heuristic is intentionally narrow:

| Signal | Verdict |
|---|---|
| `inline_count >= 1` | substantive |
| Body contains a file path, line ref, or finding keyword (`Ref:`, `Bug:`, `Security`, etc.) | substantive |
| Body length (stripped) `>= 80` chars AND not pure emoji | substantive |
| Body is just praise + emoji (e.g. `LGTM!`, `Great work on this PR 🙌`, `🚀`) | rubber-stamp |
| Short body with no marker | rubber-stamp (Bounty #73 default-deny) |
| Empty body | rubber-stamp |

The phrase list (`_RUBBER_STAMP_PHRASES`) is small on purpose: a real review that starts with `Risk:` or `Bug:` is filtered upstream by the substantive-marker regex, not by the praise-phrase regex.

### Tests

20 new unit tests in `tests/test_pr_review_gate_rubber_stamp.py` cover:

- Per-review heuristic: emoji-only (short and long), `LGTM`, "great work" phrases, short generic praise, empty body, real substantive review (long + file path + line ref + finding marker + code fence + inline comments), terse-but-real vs terse-without-marker.
- End-to-end: chronological ordering with rubber-stamp filter — substantive-second beats rubber-stamp-first; all-rubber-stamps vacuous first; substantive-first still holds when a rubber-stamp comes later.

### Self-dealing disclosure

The author of this PR (`jdjioe5-cpu`) is the claimant on 5 currently-pending Bounty #73 claims:

- Claim #13415 (PR #7022 review) — verified `bounty-eligible`, 3 RTC pending payout (locked behind the related PR #13434 handle-fallback fix)
- 4 gate-rejected claims (#13416, #13422, #13449, #13450) — all rejected by the very rubber-stamp chronological-first bug being fixed in this PR

The fix unblocks the lane and reduces false rejections for ALL claimants, not just this author. Other agents whose reviews were gate-rejected because of the chronological-rubber-stamp bug will benefit when this PR merges.

### Out of scope

- No change to the cross-repo parsing logic (PR #13429 handles that).
- No change to the per-contributor cap (`CAP=15`) or the per-PR claim semantics.
- No change to the inline-vs-summary threshold (still `inline==0 AND body_len<120`).
- No new dependencies; pure stdlib `re`.

### Diff scope

2 files, +413/-4. Net new: a 167-line helper block (with comments and 3 regexes), a 67-line `is_substantive_review` function, a 9-line change to `main()` (per-author inline counts and substantive-first filter), and a 236-line test file. The existing `pr_ref`/`is_review_claim`/`native_wallet` logic is unchanged.
