### PR TITLE
docs(contributing): add security reporting section [First Light]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,10 +182,22 @@ By participating in this project, you agree to maintain a respectful, inclusive,
 - **GitHub Issues**: For bugs and feature requests
 - **Discussions**: For questions and ideas
 
+## 🔒 Security Reporting
+
+If you discover a security vulnerability in RustChain, please report it responsibly:
+
+1. **Do not open a public issue** for security vulnerabilities
+2. **Email**: Report to the maintainers via [GitHub Security Advisories](https://github.com/Scottcjn/rustchain-bounties/security/advisories/new)
+3. **Include**: Steps to reproduce, potential impact, and suggested fix (if any)
+4. **Response**: Maintainers will acknowledge within 48 hours and work with you on a fix
+5. **Disclosure**: Coordinated disclosure will be arranged after a fix is developed
+
+Security bounties may qualify for the **Critical** tier (100-150 RTC) depending on severity.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the same license as the project (Apache 2.0).
 
 ---
 
-**Happy contributing! Every PR brings RustChain closer to its vision.** 🦀⛓️
+**Happy contributing! Every PR brings RustChain closer to its vision.**


### PR DESCRIPTION
## First Light Contribution - refs #12025

### What does this PR do?

Adds a dedicated **Security Reporting** section to CONTRIBUTING.md with responsible disclosure guidelines for the RustChain project.

### Why?

The existing CONTRIBUTING.md lacked guidance on how to report security vulnerabilities responsibly. This is a common gap in open-source projects and an important documentation improvement.

### Changes

Added security reporting section covering:
- Instruction to not open public issues for vulnerabilities
- Link to GitHub Security Advisories for private reporting
- Required information for reports (reproduction steps, impact, suggested fix)
- Response timeline expectations (48-hour acknowledgment)
- Coordinated disclosure process
- Reference to Critical bounty tier (100-150 RTC) for security bounties

### How to test?

1. Open CONTRIBUTING.md
2. Navigate to the new "Security Reporting" section
3. Verify all links are valid
4. Confirm the section follows the existing document style and formatting

### Related Issues

Refs #12025 (First Light bounty)

### Wallet
maojianian25-png