### PR TITLE
Claim code review bounty for RustChain PR #7315

### DIFF
--- a/claims/code-review-bounty-73-deanventor-max-rustchain-pr7315.md
+++ b/claims/code-review-bounty-73-deanventor-max-rustchain-pr7315.md
@@ -1,0 +1,33 @@
+# Code Review Bounty #73 Claim - RustChain PR #7315
+
+Reviewer: @deanventor-max
+Wallet/miner ID: `deanventor-max`
+
+Reviewed PR: https://github.com/Scottcjn/Rustchain/pull/7315
+Review link: https://github.com/Scottcjn/Rustchain/pull/7315#pullrequestreview-4473434216
+Reviewed head: `53176ce6ae8b1fcfd10f505c42c3af026ccb78b6`
+
+## Review Type
+
+Thorough line-level review with changes requested.
+
+## Summary
+
+I reviewed the proposed canonical cross-platform hardware fingerprint module. The shared-file direction is reasonable, but the patch introduces two regressions that can reject genuine mining hardware.
+
+First, the cache benchmark replaces the existing randomized dependent pointer chase with predictable independent stride-64 accesses. Hardware prefetching and out-of-order execution can overlap those loads, while Python loop and modulo overhead dominate the timing. That flattens the measured L1/L2/L3 ratios and can incorrectly report `no_cache_hierarchy` on real machines.
+
+Second, the SIMD check no longer recognizes Linux AArch64's common `asimd` feature spelling and only uses `"arm" in arch` as its architecture fallback. Since `platform.machine()` commonly returns `aarch64`, valid ARM64 miners can now fall through to `no_simd_detected`.
+
+I requested preserving the dependent randomized cache benchmark and restoring explicit AArch64/ASIMD handling before merge.
+
+## Validation
+
+- Confirmed PR #7315 was open and had no prior human reviews before reviewing.
+- Inspected the complete patch for both platform modules and checksum updates.
+- Anchored two actionable comments to `miners/linux/fingerprint_checks.py` lines 93 and 194.
+- Compared both changed paths against the behavior intentionally removed by the patch.
+
+## Payout Boundary
+
+This file records a public review and bounty claim only. It is not a maintainer award, payout approval, wallet transfer, or payment receipt. Bounty #73 rate-limit, total-cap, first-substantive-review, and finite-pool terms still apply.


### PR DESCRIPTION
Claims Code Review Bounty #73 for the first substantive review of Scottcjn/Rustchain#7315. The review requests changes for a cache-timing measurement regression and broken Linux AArch64/ASIMD detection. This PR contains only the new claim record.