### PR TITLE
feat: add OpenAI Agents SDK RustChain tools

### DIFF
--- a/README_OPENAI_AGENTS.md
+++ b/README_OPENAI_AGENTS.md
@@ -1,0 +1,47 @@
+# RustChain tools for the OpenAI Agents SDK
+
+This integration exposes four native function tools:
+
+- `check_balance(wallet_id)`
+- `list_bounties(limit)`
+- `get_node_health()`
+- `get_current_epoch()`
+
+Use Python 3.10 or newer, then install the SDK and the repository's HTTP
+dependency:
+
+```bash
+python -m pip install "openai-agents>=0.7,<0.8" requests
+```
+
+Create and run an agent:
+
+```python
+from agents import Runner
+
+from openai_agents_rustchain_tool import create_rustchain_agent
+
+agent = create_rustchain_agent()
+result = Runner.run_sync(agent, "List five open RustChain bounties.")
+print(result.final_output)
+```
+
+`Runner` requires the normal OpenAI Agents SDK authentication. The underlying
+tools only call public RustChain and GitHub endpoints, and can also be attached
+to an existing agent:
+
+```python
+from agents import Agent
+
+from openai_agents_rustchain_tool import RUSTCHAIN_TOOLS
+
+agent = Agent(
+    name="Bounty helper",
+    instructions="Help contributors inspect public RustChain information.",
+    tools=RUSTCHAIN_TOOLS,
+)
+```
+
+HTTP failures, invalid JSON, and invalid arguments are returned as structured
+`{"ok": false, "error": "..."}` results so an agent can explain the problem
+instead of crashing.

--- a/openai_agents_rustchain_tool.py
+++ b/openai_agents_rustchain_tool.py
@@ -1,0 +1,151 @@
+"""OpenAI Agents SDK tools for public RustChain data."""
+
+from typing import Any, Dict, List, Optional, Sequence
+
+import requests
+from agents import Agent, FunctionTool, function_tool
+
+
+DEFAULT_NODE_URL = "https://rustchain.org"
+DEFAULT_BOUNTIES_URL = (
+    "https://api.github.com/repos/Scottcjn/rustchain-bounties/issues"
+)
+
+
+class RustChainClient:
+    """Small HTTP client used by the agent tools."""
+
+    def __init__(
+        self,
+        node_url: str = DEFAULT_NODE_URL,
+        bounties_url: str = DEFAULT_BOUNTIES_URL,
+        timeout: float = 10.0,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.node_url = node_url.rstrip("/")
+        self.bounties_url = bounties_url
+        self.timeout = timeout
+        self.session = session or requests.Session()
+        self.session.headers.update(
+            {
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "rustchain-openai-agents-tool",
+            }
+        )
+
+    def _get_json(
+        self, url: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        try:
+            response = self.session.get(
+                url,
+                params=params,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return {"ok": True, "data": response.json()}
+        except requests.RequestException as exc:
+            return {"ok": False, "error": f"RustChain request failed: {exc}"}
+        except ValueError as exc:
+            return {"ok": False, "error": f"RustChain returned invalid JSON: {exc}"}
+
+    def check_balance(self, wallet_id: str) -> Dict[str, Any]:
+        """Return the RTC balance payload for a wallet or miner handle."""
+        wallet_id = wallet_id.strip()
+        if not wallet_id:
+            return {"ok": False, "error": "wallet_id must not be empty"}
+
+        result = self._get_json(
+            f"{self.node_url}/wallet/balance",
+            params={"miner_id": wallet_id},
+        )
+        if result["ok"]:
+            result["wallet_id"] = wallet_id
+        return result
+
+    def list_bounties(self, limit: int = 10) -> Dict[str, Any]:
+        """Return open RustChain bounty issues from the project repository."""
+        if not 1 <= limit <= 100:
+            return {"ok": False, "error": "limit must be between 1 and 100"}
+
+        result = self._get_json(
+            self.bounties_url,
+            params={"state": "open", "labels": "bounty", "per_page": limit},
+        )
+        if not result["ok"]:
+            return result
+
+        payload = result["data"]
+        if not isinstance(payload, list):
+            return {"ok": False, "error": "Bounty API returned an unexpected payload"}
+
+        bounties = [item for item in payload if "pull_request" not in item][:limit]
+        return {"ok": True, "count": len(bounties), "bounties": bounties}
+
+    def get_node_health(self) -> Dict[str, Any]:
+        """Return the RustChain node health payload."""
+        return self._get_json(f"{self.node_url}/health")
+
+    def get_current_epoch(self) -> Dict[str, Any]:
+        """Return the current RustChain epoch payload."""
+        return self._get_json(f"{self.node_url}/epoch")
+
+
+def create_rustchain_tools(
+    client: Optional[RustChainClient] = None,
+) -> Sequence[FunctionTool]:
+    """Create four OpenAI Agents SDK tools backed by a RustChain client."""
+    rustchain = client or RustChainClient()
+
+    @function_tool
+    def check_balance(wallet_id: str) -> Dict[str, Any]:
+        """Check the RTC balance for a RustChain wallet or miner handle.
+
+        Args:
+            wallet_id: RustChain wallet identifier or registered miner handle.
+        """
+        return rustchain.check_balance(wallet_id)
+
+    @function_tool
+    def list_bounties(limit: int = 10) -> Dict[str, Any]:
+        """List open RustChain bounty issues.
+
+        Args:
+            limit: Maximum number of bounties to return, from 1 through 100.
+        """
+        return rustchain.list_bounties(limit)
+
+    @function_tool
+    def get_node_health() -> Dict[str, Any]:
+        """Get the current health payload from the public RustChain node."""
+        return rustchain.get_node_health()
+
+    @function_tool
+    def get_current_epoch() -> Dict[str, Any]:
+        """Get the current epoch payload from the public RustChain node."""
+        return rustchain.get_current_epoch()
+
+    return (
+        check_balance,
+        list_bounties,
+        get_node_health,
+        get_current_epoch,
+    )
+
+
+def create_rustchain_agent(
+    client: Optional[RustChainClient] = None,
+) -> Agent:
+    """Create an agent that can inspect public RustChain state and bounties."""
+    return Agent(
+        name="RustChain assistant",
+        instructions=(
+            "Use the RustChain tools to answer questions about wallet balances, "
+            "open bounties, node health, and the current epoch. Report tool "
+            "errors clearly and do not invent unavailable blockchain data."
+        ),
+        tools=list(create_rustchain_tools(client)),
+    )
+
+
+RUSTCHAIN_TOOLS: List[FunctionTool] = list(create_rustchain_tools())

--- a/requirements-openai-agents.txt
+++ b/requirements-openai-agents.txt
@@ -1,0 +1,2 @@
+# The OpenAI Agents SDK requires Python 3.10 or newer.
+openai-agents>=0.7,<0.8

--- a/tests/test_openai_agents_rustchain_tool.py
+++ b/tests/test_openai_agents_rustchain_tool.py
@@ -1,0 +1,122 @@
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from openai_agents_rustchain_tool import (
+    RustChainClient,
+    create_rustchain_agent,
+    create_rustchain_tools,
+)
+
+
+def make_client(payload, *, status_error=None):
+    response = Mock()
+    response.json.return_value = payload
+    if status_error is not None:
+        response.raise_for_status.side_effect = status_error
+
+    session = Mock()
+    session.headers = {}
+    session.get.return_value = response
+    return RustChainClient(session=session), session
+
+
+def test_check_balance_uses_documented_wallet_endpoint():
+    client, session = make_client({"balance": 42})
+
+    result = client.check_balance("alice")
+
+    assert result == {
+        "ok": True,
+        "data": {"balance": 42},
+        "wallet_id": "alice",
+    }
+    session.get.assert_called_once_with(
+        "https://rustchain.org/wallet/balance",
+        params={"miner_id": "alice"},
+        timeout=10.0,
+    )
+
+
+def test_check_balance_rejects_empty_wallet_without_request():
+    client, session = make_client({})
+
+    assert client.check_balance("  ") == {
+        "ok": False,
+        "error": "wallet_id must not be empty",
+    }
+    session.get.assert_not_called()
+
+
+def test_list_bounties_uses_github_api_and_excludes_pull_requests():
+    client, session = make_client(
+        [
+            {"number": 1, "title": "A bounty"},
+            {"number": 2, "pull_request": {"url": "example"}},
+        ]
+    )
+
+    result = client.list_bounties(5)
+
+    assert result == {
+        "ok": True,
+        "count": 1,
+        "bounties": [{"number": 1, "title": "A bounty"}],
+    }
+    session.get.assert_called_once_with(
+        "https://api.github.com/repos/Scottcjn/rustchain-bounties/issues",
+        params={
+            "state": "open",
+            "labels": "bounty",
+            "per_page": 5,
+        },
+        timeout=10.0,
+    )
+
+
+@pytest.mark.parametrize("limit", [0, 101])
+def test_list_bounties_rejects_invalid_limit(limit):
+    client, session = make_client([])
+
+    assert client.list_bounties(limit) == {
+        "ok": False,
+        "error": "limit must be between 1 and 100",
+    }
+    session.get.assert_not_called()
+
+
+def test_node_errors_are_returned_without_raising():
+    error = requests.HTTPError("503 Server Error")
+    client, _ = make_client({}, status_error=error)
+
+    assert client.get_node_health() == {
+        "ok": False,
+        "error": "RustChain request failed: 503 Server Error",
+    }
+
+
+def test_invalid_json_is_returned_without_raising():
+    client, session = make_client({})
+    session.get.return_value.json.side_effect = ValueError("bad JSON")
+
+    assert client.get_current_epoch() == {
+        "ok": False,
+        "error": "RustChain returned invalid JSON: bad JSON",
+    }
+
+
+def test_creates_expected_native_tools_and_agent():
+    client, _ = make_client({})
+
+    tools = create_rustchain_tools(client)
+    agent = create_rustchain_agent(client)
+
+    expected_names = {
+        "check_balance",
+        "list_bounties",
+        "get_node_health",
+        "get_current_epoch",
+    }
+    assert {tool.name for tool in tools} == expected_names
+    assert {tool.name for tool in agent.tools} == expected_names


### PR DESCRIPTION
## Summary
- add native OpenAI Agents SDK function tools for wallet balance, bounty listing, node health, and epoch queries
- use the documented RustChain wallet endpoint and GitHub issue API with shared timeout/error handling
- add an agent factory, usage documentation, and mocked HTTP tests

Closes #13952 for the OpenAI Agents SDK framework slot.

## Validation
- `python -m pytest -q tests/test_openai_agents_rustchain_tool.py` (8 passed)
- `ruff check openai_agents_rustchain_tool.py tests/test_openai_agents_rustchain_tool.py`
- `python -m compileall -q openai_agents_rustchain_tool.py tests/test_openai_agents_rustchain_tool.py`
- `git diff --check`
- full repository suite: 471 passed, 1 skipped, 16 unrelated failures caused by `ai_agent.py` making a live GitHub request with invalid placeholder credentials and an existing YAML parser expectation

## Notes
- requires Python 3.10 or newer, matching the current OpenAI Agents SDK
- no API key is needed for the public RustChain tools themselves; running an OpenAI agent uses the SDK’s normal authentication

This contribution was developed with AI assistance and manually reviewed and tested.