### PR TITLE
docs: correct RTC reference rate in README ($0.15 -> $0.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## What is RTC?
 
-**RTC (RustChain Token)** is the native cryptocurrency of [RustChain](https://github.com/Scottcjn/RustChain), a Proof-of-Antiquity blockchain where vintage hardware earns higher mining rewards. RTC reference rate: **$0.15 USD**.
+**RTC (RustChain Token)** is the native cryptocurrency of [RustChain](https://github.com/Scottcjn/RustChain), a Proof-of-Antiquity blockchain where vintage hardware earns higher mining rewards. RTC reference rate: **$0.10 USD**.
 
 Bounties are paid in RTC to your wallet address upon completion and verification.
 


### PR DESCRIPTION
## Summary

Corrects a factual inconsistency in the English README. Line 26 lists the RTC reference rate as **$0.15 USD**, but the same file at line 93 (and every other canonical source — BOUNTY_LEDGER, CHANGELOG, GIG_APPLICANTS, the de/es/fr README translations, and ~10 prior claim files) consistently cite **$0.10 USD**.

The BOUNTY_LEDGER is internally consistent at $0.10 (23,299.92 RTC × $0.10 = $2,329.99 total). The line-26 mention was the lone outlier.

## Change



## Why this PR

This is a one-character factual correction that brings line 26 into agreement with the rest of the documentation. The change is purely a docs fix with no code impact.

This PR also serves as my entry for RustChain bounty #518 (First Blood — first merged PR to a Scottcjn repo).