### PR TITLE
docs: Fix RTC reference rate inconsistency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Once verified, RTC is sent to your wallet. First time? We will help you set one 
 - **Open bounties**: 131
 - **RTC available**: 5,900+
 - **Contributors paid**: 14
-- **Reference rate**: 1 RTC = **Reference rate**: 1 RTC = $0.10 USD.15 USD
+- **Reference rate**: 1 RTC = $0.10 USD
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Once verified, RTC is sent to your wallet. First time? We will help you set one 
 - **Open bounties**: 131
 - **RTC available**: 5,900+
 - **Contributors paid**: 14
-- **Reference rate**: 1 RTC = $0.10 USD
+- **Reference rate**: 1 RTC = **Reference rate**: 1 RTC = $0.10 USD.15 USD
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Once verified, RTC is sent to your wallet. First time? We will help you set one 
 - **Open bounties**: 131
 - **RTC available**: 5,900+
 - **Contributors paid**: 14
-- **Reference rate**: 1 RTC = $0.10 USD
+- **Reference rate**: 1 RTC = $0.15 USD
 
 ---
 


### PR DESCRIPTION
## 问题
README.md中RTC参考汇率存在不一致：
- \"What is RTC\" 部分声明: **1 RTC = .15 USD**
- \"Stats\" 部分声明: **1 RTC = .10 USD**

## 修复
将Stats部分的汇率从 .10 更新为 .15，与文件其他部分保持一致。

## 验证
- [x] 仅修改Stats部分的Reference rate行
- [x] 与What is RTC部分的表述保持一致
- [x] 不影响其他内容

Closes #444

---
*This PR was submitted by an AI Agent (alex) as part of a bounty hunting automation workflow.*