### PR TITLE
feat: RTC Reward GitHub Action — bounty claim #2864

### DIFF
--- a/submissions/2864-rtc-reward-action.md
+++ b/submissions/2864-rtc-reward-action.md
@@ -1,0 +1,18 @@
+# Submission: RTC Reward GitHub Action (Issue #2864)
+
+**Bounty:** 13 RTC  
+**Issue:** #2864  
+**Submitted by:** XananasX7  
+
+## Deliverable
+
+Published GitHub Action: https://github.com/XananasX7/rtc-reward-action
+
+### Features
+- Triggers on PR merge
+- Configurable RTC amount per merge
+- Reads contributor wallet from PR body or `.rtc-wallet` file
+- Posts confirmation comment on PR
+- Supports dry-run mode
+- GitHub Marketplace ready (action.yml with branding)
+- Inputs: node-url, amount, wallet-from, admin-key


### PR DESCRIPTION
/claim #2864

## Summary

This PR claims the **13 RTC** bounty for issue [#2864](https://github.com/Scottcjn/rustchain-bounties/issues/2864): *Create a GitHub Action That Awards RTC for Merged Pull Requests*.

I have built and published a reusable GitHub Action at **[XananasX7/rtc-reward-action](https://github.com/XananasX7/rtc-reward-action)** that automatically awards RTC tokens when a pull request is merged.

---

## Deliverable

**Action repository:** https://github.com/XananasX7/rtc-reward-action  
**Tag:** `v1.0.0` / `v1`

### Files

| File | Purpose |
|------|---------|
| `action.yml` | Action metadata with inputs/outputs and Marketplace branding |
| `index.js` | Main logic: wallet resolution, RTC transfer, PR comment |
| `dist/index.js` | Bundled entry point for runners (no install step needed) |
| `package.json` | Dependencies: @actions/core, @actions/github, node-fetch |
| `README.md` | Full usage documentation with examples |
| `.github/workflows/test.yml` | CI: runs action in dry-run mode on PR merge |
| `LICENSE` | MIT |

---

## Requirements met

- ✅ **Triggers on PR merge** — `pull_request: [closed]` + `merged == true` guard
- ✅ **Configurable RTC amount** — `amount` input (default `10`, can be set to any value)
- ✅ **Reads wallet from PR body** — regex matches `RTC wallet: <addr>` and HTML comment `<!-- rtc-wallet: <addr> -->`
- ✅ **Falls back to `.rtc-wallet` file** — reads first non-comment line from the committed file
- ✅ **Posts confirmation comment** — formatted table showing amount, recipient wallet, node URL, and tx hash
- ✅ **Dry-run mode** — `dry-run: true` simulates everything without submitting to chain; comment is still posted (marked as dry-run)
- ✅ **GitHub Marketplace ready** — `action.yml` with `branding.icon: award`, `branding.color: orange`
- ✅ **Inputs: node-url, amount, wallet-from, admin-key** — all defined and documented

---

## Usage

```yaml
name: Reward Contributors
on:
  pull_request:
    types: [closed]
jobs:
  reward:
    runs-on: ubuntu-latest
    if: github.event.pull_request.merged == true
    steps:
      - uses: actions/checkout@v4
      - uses: XananasX7/rtc-reward-action@v1
        with:
          wallet-from: ${{ secrets.TREASURY_WALLET }}
          admin-key: ${{ secrets.ADMIN_PRIVATE_KEY }}
          amount: "13"
          node-url: "https://rustchain.org"
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Action repo: https://github.com/XananasX7/rtc-reward-action

---

**RTC wallet: xananax7**