### PR TITLE
chore(deps): consolidate bridge/requirements.txt dependabot bumps

### DIFF
--- a/bridge/requirements.txt
+++ b/bridge/requirements.txt
@@ -1,10 +1,10 @@
 # All dependencies pinned to specific versions for supply-chain security
-flask==2.3.3
-requests==2.31.0
+flask==3.1.3
+requests==2.34.2
 
 # Test dependencies
-pytest==7.4.3
-pytest-cov==4.1.0
-flake8==6.1.0
-mypy==1.7.1
-black==23.12.1
+pytest==9.0.3
+pytest-cov==7.1.0
+flake8==7.3.0
+mypy==2.1.0
+black==26.5.1


### PR DESCRIPTION
Applies the 7 stale dependabot bumps that all touched `bridge/requirements.txt` (mutually conflicting, all BEHIND) in one commit: flask 3.1.3, requests 2.34.2, pytest 9.0.3, pytest-cov 7.1.0, flake8 7.3.0, mypy 2.1.0, black 26.5.1. Supersedes #12220 #12221 #12223 #12224 #12226 #12227 #12228.