### PR TITLE
docs: add proof template for bounty #2866 - Post RustChain to tech commu

### DIFF
--- a/bounty-2866-post-proof.md
+++ b/bounty-2866-post-proof.md
@@ -1,0 +1,37 @@
+# Bounty #2866 — Post RustChain to Hacker News, Reddit, or Lobsters (With Proof)
+
+**Reward: 5 RTC (~$0.50 USD)**
+**Multi-claim: first 20 unique posts**
+
+## Goal
+
+Create a genuine post about RustChain on one of the eligible tech communities listed below. Share the link in this issue to claim your reward.
+
+## Eligible Platforms
+
+| Platform | Section / Subreddit |
+|----------|---------------------|
+| Reddit   | r/cryptocurrency, r/altcoin, r/depin, r/selfhosted, r/vintagecomputing, r/retrobattlestations, r/homelab |
+| Hacker News | Show HN or a comment thread |
+| Lobsters | via invite (share your post) |
+
+## How to Submit Proof
+
+1. **Post your content** on any of the above platforms. Make sure it's genuine, not spam, and includes a link to RustChain (https://github.com/Scottcjn/RustChain or https://rustchain.org).
+2. **Comment on this issue** with the direct URL to your post.
+3. **Include your RTC wallet address** (if you don't have one, comment and we'll help you set it up).
+4. Wait for verification. Once approved, you'll receive 5 RTC.
+
+## Tips for a Good Post
+
+- Explain what RustChain is: a Proof-of-Antiquity blockchain that rewards vintage hardware.
+- Share what excites you: retro mining, unique consensus, open source.
+- Engage with the community — answer questions, join discussions.
+- Avoid spamming the same text across multiple platforms.
+
+## Security Reminder
+
+Only @Scottcjn (or clearly labeled project automation on his behalf) will authorize payouts. Anyone else claiming to send RTC is a scam. See [SECURITY.md](SECURITY.md#payment-authority-impersonation) for details.
+
+---
+*Part of the [RustChain Bounties](https://github.com/Scottcjn/rustchain-bounties) program.*


### PR DESCRIPTION
创建 bounty-2866 的证明提交模板，指导参与者如何在 Hacker News、Reddit 或 Lobsters 上发布关于 RustChain 的内容并提交证明以获取 5 RTC 奖励。