### PR TITLE
Add static-analysis Judge community gate (closes #14382)

### DIFF
--- a/integrations/static-analysis-judge/README.md
+++ b/integrations/static-analysis-judge/README.md
@@ -1,0 +1,89 @@
+# Static-Analysis Judge
+
+**Bounty:** [#14382](https://github.com/Scottcjn/rustchain-bounties/issues/14382) (75 RTC, multi-claim)
+
+A community implementation of the open `Judge` interface — an *alternative*
+gate to SophiaCore, suitable for code self-improvement requests where the
+gate needs a fast, deterministic, no-execution check.
+
+## Interface
+
+```python
+judge(request) -> (passed: bool, reasons: list[str])
+```
+
+The `StaticAnalysisJudge` class implements this contract and exposes
+`sign_verdict()` / `verify()` for Ed25519-signed envelopes that any SDK
+verifying signed Beacon-style envelopes can authenticate.
+
+## What it judges
+
+Given a request of the form `{"files": {"path.py": "<source>", ...}}`,
+the judge passes iff **every** file:
+
+1. Parses as valid Python (no `SyntaxError`).
+2. Contains no calls to `eval`, `exec`, `compile`, or `__import__`.
+3. Imports none of `os.system`, `subprocess`, `pickle`, `marshal`.
+4. Stays under the configured per-function and per-file line caps
+   (defaults: 200 / 2000).
+
+All rules run on the AST — **no submitted code is ever executed**.
+
+## Limits
+
+This is intentionally a narrow gate. It does **not**:
+
+- Run, import, or sandbox the submitted code.
+- Catch semantic bugs, races, or logic errors.
+- Replace a full linter, type checker, or security scanner.
+- Judge non-Python files (they are ignored).
+- Cover dynamic shell-outs via `os.popen`, `ctypes`, attribute-based
+  `getattr(__builtins__, 'eval')` tricks, etc. Adversarial code can
+  bypass static analysis; this judge is designed for honest
+  self-improvement requests, not adversarial review.
+
+For richer policy, compose this judge with a test-runner judge or a
+configurable policy judge.
+
+## Usage
+
+```python
+from judge import StaticAnalysisJudge
+
+j = StaticAnalysisJudge()
+passed, reasons = j.judge({"files": {"patch.py": open("patch.py").read()}})
+
+# Signed verdict envelope (Ed25519)
+envelope = j.sign_verdict({"files": {"patch.py": "..."}})
+assert StaticAnalysisJudge.verify(envelope)
+```
+
+## Plugging into the reference gate server
+
+Because the gate server consumes anything matching the open `Judge`
+interface, instantiation alone is enough:
+
+```python
+from judge import StaticAnalysisJudge
+gate_server.register_judge(StaticAnalysisJudge())
+```
+
+No reference-server code is modified.
+
+## Tests
+
+```bash
+pip install cryptography pytest
+pytest integrations/static-analysis-judge/test_judge.py -q
+```
+
+Twelve tests cover the interface contract, every rule, the signature
+roundtrip, and tamper detection.
+
+## RTC wallet
+
+Payout wallet: _to be added by maintainer of this fork on claim._
+
+## License
+
+MIT (SPDX-License-Identifier: MIT).

--- a/integrations/static-analysis-judge/judge.py
+++ b/integrations/static-analysis-judge/judge.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: MIT
+"""Static-analysis Judge — community gate for the open Judge interface.
+
+Implements the open ``Judge`` interface:
+
+    judge(request) -> (passed: bool, reasons: list[str])
+
+This is an *alternative* gate to SophiaCore. It runs purely on the
+Python source carried in ``request`` and produces a deterministic
+verdict based on AST-level static analysis. No code is executed.
+
+Each verdict is signed with the judge's own Ed25519 key so any SDK
+that verifies signed envelopes can confirm authorship.
+
+Bounty: Scottcjn/rustchain-bounties#14382 (75 RTC)
+"""
+
+from __future__ import annotations
+
+import ast
+import base64
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Tuple
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+
+# ─── Open Judge interface ───────────────────────────────────────────
+
+class Judge:
+    """Open Judge interface.
+
+    Any concrete judge must implement :meth:`judge` with the signature
+    ``judge(request) -> (passed, reasons)``. Implementations are free
+    to add extra methods (e.g. signing) so long as this contract holds.
+    """
+
+    judge_id: str = "judge.base"
+
+    def judge(self, request: Mapping[str, Any]) -> Tuple[bool, List[str]]:
+        raise NotImplementedError
+
+
+# ─── Static-analysis Judge ──────────────────────────────────────────
+
+# Default rules — chosen to be cheap, deterministic, and stable across
+# Python versions. They flag the cheap-and-obvious foot-guns we don't
+# want code self-improvements to introduce.
+
+DEFAULT_BANNED_CALLS = frozenset({"eval", "exec", "compile", "__import__"})
+DEFAULT_BANNED_MODULES = frozenset({"os.system", "subprocess", "pickle", "marshal"})
+DEFAULT_MAX_FUNCTION_LINES = 200
+DEFAULT_MAX_FILE_LINES = 2000
+
+
+@dataclass
+class StaticAnalysisJudge(Judge):
+    """A judge that runs AST-level static analysis on submitted code.
+
+    The judge passes a request iff every source file:
+
+    1. Parses as valid Python.
+    2. Contains no calls to ``eval``/``exec``/``compile``/``__import__``.
+    3. Imports no banned modules (e.g. ``subprocess``, ``pickle``).
+    4. Stays under the configured per-function and per-file line caps.
+
+    Configuration is intentionally limited — this is a *gate*, not a
+    full linter. For richer policy, compose multiple judges.
+    """
+
+    judge_id: str = "judge.static-analysis.v1"
+    banned_calls: frozenset = field(default_factory=lambda: DEFAULT_BANNED_CALLS)
+    banned_modules: frozenset = field(default_factory=lambda: DEFAULT_BANNED_MODULES)
+    max_function_lines: int = DEFAULT_MAX_FUNCTION_LINES
+    max_file_lines: int = DEFAULT_MAX_FILE_LINES
+    private_key: Ed25519PrivateKey = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.private_key is None:
+            self.private_key = Ed25519PrivateKey.generate()
+
+    # ── Interface ──────────────────────────────────────────────────
+
+    def judge(self, request: Mapping[str, Any]) -> Tuple[bool, List[str]]:
+        """Run the gate on ``request``.
+
+        ``request`` is expected to look like::
+
+            {
+                "files": {
+                    "path/to/file.py": "<source>",
+                    ...
+                }
+            }
+
+        Returns ``(passed, reasons)``. ``reasons`` is non-empty on
+        failure and may be empty on success.
+        """
+        files = self._extract_files(request)
+        if not files:
+            return False, ["no source files provided"]
+
+        reasons: List[str] = []
+        for path, source in files.items():
+            reasons.extend(self._check_file(path, source))
+
+        return (not reasons), reasons
+
+    # ── Signing ────────────────────────────────────────────────────
+
+    def public_key_bytes(self) -> bytes:
+        """Return the raw 32-byte Ed25519 public key."""
+        return self.private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+
+    def sign_verdict(self, request: Mapping[str, Any]) -> Dict[str, Any]:
+        """Return a signed verdict envelope.
+
+        The envelope is JSON-serialisable and contains the public key,
+        the verdict, and an Ed25519 signature over a canonical
+        encoding of ``(judge_id, passed, reasons, ts)``.
+        """
+        passed, reasons = self.judge(request)
+        verdict = {
+            "judge_id": self.judge_id,
+            "passed": passed,
+            "reasons": reasons,
+            "ts": int(time.time()),
+        }
+        message = _canonical(verdict)
+        signature = self.private_key.sign(message)
+        return {
+            "verdict": verdict,
+            "public_key": base64.b64encode(self.public_key_bytes()).decode("ascii"),
+            "signature": base64.b64encode(signature).decode("ascii"),
+        }
+
+    @staticmethod
+    def verify(envelope: Mapping[str, Any]) -> bool:
+        """Verify a signed verdict envelope. Returns True iff valid."""
+        try:
+            verdict = envelope["verdict"]
+            pk_bytes = base64.b64decode(envelope["public_key"])
+            sig = base64.b64decode(envelope["signature"])
+        except (KeyError, ValueError, TypeError):
+            return False
+        try:
+            pk = Ed25519PublicKey.from_public_bytes(pk_bytes)
+            pk.verify(sig, _canonical(verdict))
+            return True
+        except Exception:
+            return False
+
+    # ── Internals ──────────────────────────────────────────────────
+
+    @staticmethod
+    def _extract_files(request: Mapping[str, Any]) -> Dict[str, str]:
+        files = request.get("files") if isinstance(request, Mapping) else None
+        if not isinstance(files, Mapping):
+            return {}
+        return {str(k): str(v) for k, v in files.items() if v is not None}
+
+    def _check_file(self, path: str, source: str) -> List[str]:
+        reasons: List[str] = []
+        lines = source.count("\n") + 1
+        if lines > self.max_file_lines:
+            reasons.append(
+                f"{path}: file too large ({lines} > {self.max_file_lines} lines)"
+            )
+
+        try:
+            tree = ast.parse(source, filename=path)
+        except SyntaxError as exc:
+            reasons.append(f"{path}: syntax error at line {exc.lineno}: {exc.msg}")
+            return reasons
+
+        for node in ast.walk(tree):
+            reasons.extend(self._check_node(path, node))
+        return reasons
+
+    def _check_node(self, path: str, node: ast.AST) -> Iterable[str]:
+        # Banned bare calls: eval(...), exec(...), etc.
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id in self.banned_calls:
+                yield f"{path}:{node.lineno}: banned call to {node.func.id}()"
+
+        # Banned imports.
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in self.banned_modules:
+                    yield f"{path}:{node.lineno}: banned import '{alias.name}'"
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if mod in self.banned_modules:
+                yield f"{path}:{node.lineno}: banned import-from '{mod}'"
+
+        # Oversized functions.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            end = getattr(node, "end_lineno", node.lineno)
+            span = (end or node.lineno) - node.lineno + 1
+            if span > self.max_function_lines:
+                yield (
+                    f"{path}:{node.lineno}: function '{node.name}' too long "
+                    f"({span} > {self.max_function_lines} lines)"
+                )
+
+
+def _canonical(verdict: Mapping[str, Any]) -> bytes:
+    """Deterministic JSON encoding used for signing/verification."""
+    return json.dumps(verdict, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+__all__ = ["Judge", "StaticAnalysisJudge"]

--- a/integrations/static-analysis-judge/test_judge.py
+++ b/integrations/static-analysis-judge/test_judge.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the static-analysis Judge."""
+
+from __future__ import annotations
+
+import base64
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from judge import Judge, StaticAnalysisJudge  # noqa: E402
+
+
+def _req(**files: str) -> dict:
+    return {"files": files}
+
+
+def test_clean_code_passes():
+    j = StaticAnalysisJudge()
+    passed, reasons = j.judge(_req(**{"a.py": "def add(x, y):\n    return x + y\n"}))
+    assert passed is True
+    assert reasons == []
+
+
+def test_eval_call_fails():
+    j = StaticAnalysisJudge()
+    passed, reasons = j.judge(_req(**{"a.py": "x = eval('1+1')\n"}))
+    assert passed is False
+    assert any("eval" in r for r in reasons)
+
+
+def test_banned_import_fails():
+    j = StaticAnalysisJudge()
+    passed, reasons = j.judge(_req(**{"a.py": "import subprocess\n"}))
+    assert passed is False
+    assert any("subprocess" in r for r in reasons)
+
+
+def test_banned_import_from_fails():
+    j = StaticAnalysisJudge()
+    passed, reasons = j.judge(_req(**{"a.py": "from pickle import loads\n"}))
+    assert passed is False
+    assert any("pickle" in r for r in reasons)
+
+
+def test_syntax_error_fails():
+    j = StaticAnalysisJudge()
+    passed, reasons = j.judge(_req(**{"a.py": "def bad(:\n"}))
+    assert passed is False
+    assert any("syntax error" in r for r in reasons)
+
+
+def test_oversized_function_fails():
+    j = StaticAnalysisJudge(max_function_lines=3)
+    src = "def f():\n" + "    x = 1\n" * 10
+    passed, reasons = j.judge(_req(**{"a.py": src}))
+    assert passed is False
+    assert any("too long" in r for r in reasons)
+
+
+def test_oversized_file_fails():
+    j = StaticAnalysisJudge(max_file_lines=5)
+    src = "x = 1\n" * 20
+    passed, reasons = j.judge(_req(**{"a.py": src}))
+    assert passed is False
+    assert any("file too large" in r for r in reasons)
+
+
+def test_empty_request_fails():
+    j = StaticAnalysisJudge()
+    passed, reasons = j.judge({"files": {}})
+    assert passed is False
+    assert reasons
+
+
+def test_implements_judge_interface():
+    j = StaticAnalysisJudge()
+    assert isinstance(j, Judge)
+    # Contract: judge(request) -> (bool, list[str])
+    passed, reasons = j.judge(_req(**{"a.py": "x = 1\n"}))
+    assert isinstance(passed, bool)
+    assert isinstance(reasons, list)
+
+
+def test_sign_and_verify_roundtrip():
+    j = StaticAnalysisJudge()
+    env = j.sign_verdict(_req(**{"a.py": "x = 1\n"}))
+    assert env["verdict"]["passed"] is True
+    assert env["verdict"]["judge_id"] == "judge.static-analysis.v1"
+    assert StaticAnalysisJudge.verify(env) is True
+
+
+def test_signature_tamper_detected():
+    j = StaticAnalysisJudge()
+    env = j.sign_verdict(_req(**{"a.py": "x = 1\n"}))
+    # Tamper with the verdict body — verification must fail.
+    env["verdict"]["passed"] = False
+    assert StaticAnalysisJudge.verify(env) is False
+
+
+def test_signature_swap_detected():
+    j = StaticAnalysisJudge()
+    env = j.sign_verdict(_req(**{"a.py": "x = 1\n"}))
+    # Replace signature with garbage of the right length.
+    env["signature"] = base64.b64encode(b"\x00" * 64).decode("ascii")
+    assert StaticAnalysisJudge.verify(env) is False
+
+
+def test_public_key_is_32_bytes():
+    j = StaticAnalysisJudge()
+    assert len(j.public_key_bytes()) == 32


### PR DESCRIPTION
Closes #14382 — community gate on the open `Judge` interface (75 RTC, multi-claim).

## What

A static-analysis judge under `integrations/static-analysis-judge/`. Implements `judge(request) -> (passed, reasons)`, signs verdicts with its own Ed25519 key, and plugs into the reference gate server unmodified.

## Rules (AST-only, no code execution)

- Banned calls: `eval`, `exec`, `compile`, `__import__`
- Banned imports: `subprocess`, `pickle`, `marshal`, `os.system`
- Syntax errors
- Oversized files / functions (configurable caps)

## Acceptance

- [x] Implements `Judge`, plugs into a reference gate server unmodified (interface-only)
- [x] Signs verdicts with its own Ed25519 key; SDK verification passes (`StaticAnalysisJudge.verify`)
- [x] Tests (13 passing) + short README on what it judges and its limits
- [x] SPDX headers on new code files
- [x] BCOS-L1

## Verification

```
$ pytest integrations/static-analysis-judge/test_judge.py -q
13 passed in 0.40s
```

## Maintainer packet

1. Issue: #14382
2. PR: this one
3. Last commit: 802b899
4. Scope: one new community judge under `integrations/static-analysis-judge/`; no other files touched.
5. Verification: pytest → 13 passed.

RTC wallet field intentionally left as placeholder in README.

*This PR was created with the assistance of claude-sonnet-4-5 by Anthropic. Happy to make any adjustments!*