### PR TITLE
Add @elyan/staking JS/TS SDK (#14381)

### DIFF
--- a/packages/elyan-staking-js/.gitignore
+++ b/packages/elyan-staking-js/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/packages/elyan-staking-js/README.md
+++ b/packages/elyan-staking-js/README.md
@@ -1,0 +1,86 @@
+<!-- SPDX-License-Identifier: MIT -->
+# @elyan/staking
+
+Typed JS/TS client for the Elyan staking gate. Implements the open contract:
+`stake()` / `submit()` / `poll()` / `verify()`. Verifies the gate's Ed25519
+signed verdict and the on-chain attestation. Fail-safe: any verification
+failure throws — the caller never sees an untrusted payload.
+
+Closes #14381.
+
+## Install
+
+```bash
+npm install @elyan/staking
+```
+
+Node 18+ required (uses global `fetch` and `node:crypto` Ed25519). No third-party
+runtime dependencies.
+
+## Quick start
+
+```ts
+import { StakingClient } from "@elyan/staking";
+
+const client = new StakingClient({
+  gateUrl: "https://gate.elyan.example",
+  apiKey: process.env.ELYAN_API_KEY!,
+  // Gate's Ed25519 public key, 32 bytes hex.
+  gatePublicKey: process.env.ELYAN_GATE_PUBKEY!,
+});
+
+const result = await client.stake({
+  agentId: "agent-42",
+  amount: "10",
+  purpose: "self-improvement-cycle",
+});
+
+console.log("verified payload:", result.payload);
+console.log("attestation tx:", result.attestationTxHash);
+```
+
+`stake()` is `submit()` → poll-until-ready → `verify()`. Call the individual
+methods if you need finer control.
+
+## Canonical JSON
+
+Requests and verdict payloads are serialized with sorted keys and no extra
+whitespace (matching Python's `json.dumps(sort_keys=True, separators=(",",":"))`)
+so signatures match byte-for-byte with the Python reference SDK.
+
+## Errors
+
+| Error | When |
+|---|---|
+| `UnauthorizedError` | gate returned 401/403 (bad API key) |
+| `SignatureError` | Ed25519 signature does not verify against `gatePublicKey` |
+| `AttestationError` | on-chain attestation check failed |
+| `GateUnavailableError` | network error, 5xx, or poll timeout |
+| `StakingError` | base class for all of the above |
+
+## Custom attestation verification
+
+Replace the default verifier (which only requires a non-empty `txHash`) with
+chain-aware logic — e.g. fetch the transaction from an RPC endpoint and confirm
+it commits the verdict hash.
+
+```ts
+const client = new StakingClient({
+  gateUrl, apiKey, gatePublicKey,
+  attestationVerifier: {
+    async verify(verdict) {
+      // ...look up verdict.attestation.txHash on chain and compare digest...
+      return true;
+    },
+  },
+});
+```
+
+## Tests
+
+```bash
+npm test
+```
+
+Covers: happy path, bad API key, forged/mismatched pubkey, tampered payload,
+gate-down, gate-5xx, failed attestation.

--- a/packages/elyan-staking-js/package.json
+++ b/packages/elyan-staking-js/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@elyan/staking",
+  "version": "0.1.0",
+  "description": "JS/TS client for the Elyan staking gate (open interface).",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist", "src", "README.md"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test --import tsx test/*.test.ts"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0",
+    "@types/node": "^20.11.0"
+  }
+}

--- a/packages/elyan-staking-js/src/canonical.ts
+++ b/packages/elyan-staking-js/src/canonical.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// Canonical JSON serialization: sorted keys, no extra whitespace.
+// Mirrors Python's `json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)`
+// so signatures match byte-for-byte across language implementations.
+
+export function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map(canonicalize).join(",") + "]";
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  const parts = keys.map(
+    (k) => JSON.stringify(k) + ":" + canonicalize(obj[k]),
+  );
+  return "{" + parts.join(",") + "}";
+}
+
+export function canonicalBytes(value: unknown): Uint8Array {
+  return new TextEncoder().encode(canonicalize(value));
+}

--- a/packages/elyan-staking-js/src/client.ts
+++ b/packages/elyan-staking-js/src/client.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+import { canonicalize } from "./canonical.js";
+import { verifyEd25519, hexToBytes } from "./verify.js";
+import {
+  AttestationError,
+  GateUnavailableError,
+  SignatureError,
+  StakingError,
+  UnauthorizedError,
+} from "./errors.js";
+
+export interface StakingClientOptions {
+  /** Base URL of the staking gate, e.g. "https://gate.elyan.example". */
+  gateUrl: string;
+  /** Bearer API key issued by the gate. */
+  apiKey: string;
+  /** Gate's Ed25519 public key (hex, 32 bytes / 64 hex chars). */
+  gatePublicKey: string;
+  /** Optional fetch override (defaults to global fetch). */
+  fetchImpl?: typeof fetch;
+  /** Optional on-chain attestation verifier; defaults to a no-op that requires a non-empty txHash. */
+  attestationVerifier?: AttestationVerifier;
+  /** Request timeout in ms (default 15000). */
+  timeoutMs?: number;
+}
+
+export interface StakeRequest {
+  agentId: string;
+  amount: string | number;
+  purpose: string;
+  nonce?: string;
+  [k: string]: unknown;
+}
+
+export interface SubmitResponse {
+  jobId: string;
+  acceptedAt: string;
+}
+
+export type JobStatus = "pending" | "ready" | "rejected";
+
+export interface PollResponse {
+  jobId: string;
+  status: JobStatus;
+  verdict?: SignedVerdict;
+}
+
+export interface SignedVerdict {
+  /** The verdict payload — canonicalized and signed by the gate. */
+  payload: Record<string, unknown>;
+  /** Ed25519 signature over canonical(payload), hex-encoded (128 chars). */
+  signature: string;
+  /** On-chain attestation tx hash (chain-specific). */
+  attestation: { txHash: string; chain?: string };
+}
+
+export interface VerifiedVerdict {
+  payload: Record<string, unknown>;
+  attestationTxHash: string;
+}
+
+export interface AttestationVerifier {
+  verify(verdict: SignedVerdict): Promise<boolean>;
+}
+
+const defaultAttestationVerifier: AttestationVerifier = {
+  async verify(v) {
+    return typeof v.attestation?.txHash === "string" && v.attestation.txHash.length > 0;
+  },
+};
+
+export class StakingClient {
+  private readonly gateUrl: string;
+  private readonly apiKey: string;
+  private readonly gatePubKey: Uint8Array;
+  private readonly fetchImpl: typeof fetch;
+  private readonly attestation: AttestationVerifier;
+  private readonly timeoutMs: number;
+
+  constructor(opts: StakingClientOptions) {
+    if (!opts.gateUrl) throw new StakingError("gateUrl required");
+    if (!opts.apiKey) throw new StakingError("apiKey required");
+    if (!opts.gatePublicKey) throw new StakingError("gatePublicKey required");
+    this.gateUrl = opts.gateUrl.replace(/\/+$/, "");
+    this.apiKey = opts.apiKey;
+    this.gatePubKey = hexToBytes(opts.gatePublicKey);
+    if (this.gatePubKey.length !== 32) {
+      throw new StakingError("gatePublicKey must be 32 bytes (64 hex chars)");
+    }
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+    this.attestation = opts.attestationVerifier ?? defaultAttestationVerifier;
+    this.timeoutMs = opts.timeoutMs ?? 15000;
+  }
+
+  /** High-level helper: submit → poll → verify. */
+  async stake(req: StakeRequest): Promise<VerifiedVerdict> {
+    const { jobId } = await this.submit(req);
+    let polled: PollResponse;
+    // Bounded poll loop.
+    const deadline = Date.now() + this.timeoutMs;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      polled = await this.poll(jobId);
+      if (polled.status !== "pending") break;
+      if (Date.now() > deadline) {
+        throw new GateUnavailableError("timed out waiting for verdict");
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    if (polled.status === "rejected" || !polled.verdict) {
+      throw new StakingError("stake rejected by gate");
+    }
+    return this.verify(polled.verdict);
+  }
+
+  /** POST /v1/stake — submit a stake request, get a jobId. */
+  async submit(req: StakeRequest): Promise<SubmitResponse> {
+    const body = canonicalize(req);
+    const res = await this.call("/v1/stake", "POST", body);
+    const json = (await res.json()) as SubmitResponse;
+    if (!json?.jobId) throw new StakingError("malformed submit response");
+    return json;
+  }
+
+  /** GET /v1/stake/:jobId — poll for verdict. */
+  async poll(jobId: string): Promise<PollResponse> {
+    const res = await this.call(`/v1/stake/${encodeURIComponent(jobId)}`, "GET");
+    const json = (await res.json()) as PollResponse;
+    if (!json?.jobId || !json?.status) {
+      throw new StakingError("malformed poll response");
+    }
+    return json;
+  }
+
+  /**
+   * Verify a signed verdict fail-safe: checks Ed25519 signature first, then on-chain
+   * attestation. Throws on any failure; returns the trusted payload on success.
+   */
+  async verify(verdict: SignedVerdict): Promise<VerifiedVerdict> {
+    if (!verdict?.signature || !verdict?.payload) {
+      throw new SignatureError("verdict missing signature or payload");
+    }
+    let sigBytes: Uint8Array;
+    try {
+      sigBytes = hexToBytes(verdict.signature);
+    } catch {
+      throw new SignatureError("verdict signature is not valid hex");
+    }
+    const ok = verifyEd25519(verdict.payload, sigBytes, this.gatePubKey);
+    if (!ok) throw new SignatureError();
+
+    const attOk = await this.attestation.verify(verdict);
+    if (!attOk) throw new AttestationError();
+
+    return {
+      payload: verdict.payload,
+      attestationTxHash: verdict.attestation.txHash,
+    };
+  }
+
+  private async call(path: string, method: "GET" | "POST", body?: string): Promise<Response> {
+    const url = this.gateUrl + path;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, {
+        method,
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      throw new GateUnavailableError(`gate request failed: ${(err as Error).message}`);
+    } finally {
+      clearTimeout(timer);
+    }
+    if (res.status === 401 || res.status === 403) {
+      throw new UnauthorizedError();
+    }
+    if (res.status >= 500 || res.status === 0) {
+      throw new GateUnavailableError(`gate returned ${res.status}`);
+    }
+    if (!res.ok) {
+      throw new StakingError(`gate error ${res.status}`);
+    }
+    return res;
+  }
+}

--- a/packages/elyan-staking-js/src/errors.ts
+++ b/packages/elyan-staking-js/src/errors.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+
+export class StakingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StakingError";
+  }
+}
+
+export class UnauthorizedError extends StakingError {
+  constructor(message = "unauthorized: bad API key") {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}
+
+export class SignatureError extends StakingError {
+  constructor(message = "verdict signature verification failed") {
+    super(message);
+    this.name = "SignatureError";
+  }
+}
+
+export class AttestationError extends StakingError {
+  constructor(message = "on-chain attestation verification failed") {
+    super(message);
+    this.name = "AttestationError";
+  }
+}
+
+export class GateUnavailableError extends StakingError {
+  constructor(message = "staking gate unavailable") {
+    super(message);
+    this.name = "GateUnavailableError";
+  }
+}

--- a/packages/elyan-staking-js/src/index.ts
+++ b/packages/elyan-staking-js/src/index.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+export { StakingClient } from "./client.js";
+export type {
+  StakingClientOptions,
+  StakeRequest,
+  SubmitResponse,
+  PollResponse,
+  SignedVerdict,
+  VerifiedVerdict,
+  AttestationVerifier,
+  JobStatus,
+} from "./client.js";
+export { canonicalize, canonicalBytes } from "./canonical.js";
+export { verifyEd25519, hexToBytes, bytesToHex } from "./verify.js";
+export {
+  StakingError,
+  UnauthorizedError,
+  SignatureError,
+  AttestationError,
+  GateUnavailableError,
+} from "./errors.js";

--- a/packages/elyan-staking-js/src/verify.ts
+++ b/packages/elyan-staking-js/src/verify.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+import { createPublicKey, verify as nodeVerify } from "node:crypto";
+import { canonicalBytes } from "./canonical.js";
+
+/**
+ * Verify an Ed25519 signature over a canonical-JSON message.
+ *
+ * @param message  The original verdict object (will be canonicalized).
+ * @param signature Raw 64-byte Ed25519 signature.
+ * @param publicKey Raw 32-byte Ed25519 public key.
+ * @returns true iff signature is valid; false otherwise. Never throws on bad input.
+ */
+export function verifyEd25519(
+  message: unknown,
+  signature: Uint8Array,
+  publicKey: Uint8Array,
+): boolean {
+  try {
+    if (publicKey.length !== 32) return false;
+    if (signature.length !== 64) return false;
+    // Wrap the raw 32-byte key in a SubjectPublicKeyInfo DER for Node's KeyObject.
+    const spki = new Uint8Array([
+      0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+      ...publicKey,
+    ]);
+    const key = createPublicKey({
+      key: Buffer.from(spki),
+      format: "der",
+      type: "spki",
+    });
+    return nodeVerify(null, canonicalBytes(message), key, signature);
+  } catch {
+    return false;
+  }
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) throw new Error("invalid hex length");
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/packages/elyan-staking-js/test/canonical.test.ts
+++ b/packages/elyan-staking-js/test/canonical.test.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { canonicalize } from "../src/canonical.js";
+
+test("sorts keys lexicographically", () => {
+  assert.equal(canonicalize({ b: 1, a: 2 }), '{"a":2,"b":1}');
+});
+
+test("recurses into nested objects and arrays", () => {
+  const out = canonicalize({ z: [{ b: 1, a: 2 }], a: null });
+  assert.equal(out, '{"a":null,"z":[{"a":2,"b":1}]}');
+});
+
+test("matches Python json.dumps(sort_keys=True, separators=(',',':')) on sample", () => {
+  // python: json.dumps({"agentId":"x","amount":10,"purpose":"train"}, sort_keys=True, separators=(",",":"))
+  assert.equal(
+    canonicalize({ purpose: "train", agentId: "x", amount: 10 }),
+    '{"agentId":"x","amount":10,"purpose":"train"}',
+  );
+});

--- a/packages/elyan-staking-js/test/client.test.ts
+++ b/packages/elyan-staking-js/test/client.test.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync, sign as nodeSign } from "node:crypto";
+import { StakingClient } from "../src/client.js";
+import {
+  AttestationError,
+  GateUnavailableError,
+  SignatureError,
+  UnauthorizedError,
+} from "../src/errors.js";
+import { canonicalBytes, bytesToHex } from "../src/index.js";
+
+function makeKeypair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  // Extract raw 32-byte public key from SPKI DER: last 32 bytes.
+  const spki = publicKey.export({ format: "der", type: "spki" });
+  const rawPub = spki.subarray(spki.length - 32);
+  return { privateKey, publicKeyHex: bytesToHex(rawPub) };
+}
+
+function signPayload(privateKey: any, payload: unknown): string {
+  const sig = nodeSign(null, canonicalBytes(payload), privateKey);
+  return bytesToHex(sig);
+}
+
+function mockFetch(handler: (url: string, init: RequestInit) => Response | Promise<Response>) {
+  return async (input: any, init: any) => handler(String(input), init);
+}
+
+test("happy path: submit → poll → verify returns trusted payload", async () => {
+  const { privateKey, publicKeyHex } = makeKeypair();
+  const payload = { agentId: "a1", amount: 10, verdict: "accepted" };
+  const signature = signPayload(privateKey, payload);
+  const verdict = { payload, signature, attestation: { txHash: "0xdead", chain: "rtc" } };
+
+  let step = 0;
+  const client = new StakingClient({
+    gateUrl: "https://gate.test",
+    apiKey: "k",
+    gatePublicKey: publicKeyHex,
+    fetchImpl: mockFetch(async (url) => {
+      if (url.endsWith("/v1/stake") && step === 0) {
+        step = 1;
+        return new Response(JSON.stringify({ jobId: "j1", acceptedAt: "now" }), { status: 200 });
+      }
+      if (url.endsWith("/v1/stake/j1")) {
+        return new Response(JSON.stringify({ jobId: "j1", status: "ready", verdict }), {
+          status: 200,
+        });
+      }
+      return new Response("nope", { status: 404 });
+    }) as any,
+  });
+
+  const result = await client.stake({ agentId: "a1", amount: 10, purpose: "train" });
+  assert.equal(result.attestationTxHash, "0xdead");
+  assert.deepEqual(result.payload, payload);
+});
+
+test("bad API key → UnauthorizedError", async () => {
+  const { publicKeyHex } = makeKeypair();
+  const client = new StakingClient({
+    gateUrl: "https://gate.test",
+    apiKey: "bad",
+    gatePublicKey: publicKeyHex,
+    fetchImpl: mockFetch(async () => new Response("nope", { status: 401 })) as any,
+  });
+  await assert.rejects(client.submit({ agentId: "a", amount: 1, purpose: "p" }), UnauthorizedError);
+});
+
+test("forged signature (mismatched pubkey) → SignatureError", async () => {
+  const keyA = makeKeypair();
+  const keyB = makeKeypair();
+  const payload = { agentId: "a1", amount: 10 };
+  const signature = signPayload(keyA.privateKey, payload); // signed by A
+  const verdict = { payload, signature, attestation: { txHash: "0xabc" } };
+
+  const client = new StakingClient({
+    gateUrl: "https://gate.test",
+    apiKey: "k",
+    gatePublicKey: keyB.publicKeyHex, // verified against B → must fail
+    fetchImpl: mockFetch(async () => new Response("", { status: 200 })) as any,
+  });
+  await assert.rejects(client.verify(verdict as any), SignatureError);
+});
+
+test("tampered payload → SignatureError", async () => {
+  const { privateKey, publicKeyHex } = makeKeypair();
+  const payload = { agentId: "a1", amount: 10 };
+  const signature = signPayload(privateKey, payload);
+  const tampered = { payload: { agentId: "a1", amount: 999 }, signature, attestation: { txHash: "0xabc" } };
+
+  const client = new StakingClient({
+    gateUrl: "https://gate.test",
+    apiKey: "k",
+    gatePublicKey: publicKeyHex,
+    fetchImpl: mockFetch(async () => new Response("", { status: 200 })) as any,
+  });
+  await assert.rejects(client.verify(tampered as any), SignatureError);
+});
+
+test("gate down (network error) → GateUnavailableError", async () => {
+  const { publicKeyHex } = makeKeypair();
+  const client = new StakingClient({
+    gateUrl: "https://gate.test",
+    apiKey: "k",
+    gatePublicKey: publicKeyHex,
+    fetchImpl: mockFetch(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as any,
+  });
+  await assert.rejects(
+    client.submit({ agentId: "a", amount: 1, purpose: "p" }),
+    GateUnavailableError,
+  );
+});
+
+test("gate 503 → GateUnavailableError", async () => {
+  const { publicKeyHex } = makeKeypair();
+  const client = new StakingClient({
+    gateUrl: "https://gate.test",
+    apiKey: "k",
+    gatePublicKey: publicKeyHex,
+    fetchImpl: mockFetch(async () => new Response("", { status: 503 })) as any,
+  });
+  await assert.rejects(
+    client.submit({ agentId: "a", amount: 1, purpose: "p" }),
+    GateUnavailableError,
+  );
+});
+
+test("failed attestation → AttestationError", async () => {
+  const { privateKey, publicKeyHex } = makeKeypair();
+  const payload = { agentId: "a1" };
+  const verdict = {
+    payload,
+    signature: signPayload(privateKey, payload),
+    attestation: { txHash: "" }, // empty → default verifier rejects
+  };
+  const client = new StakingClient({
+    gateUrl: "https://gate.test",
+    apiKey: "k",
+    gatePublicKey: publicKeyHex,
+    fetchImpl: mockFetch(async () => new Response("", { status: 200 })) as any,
+  });
+  await assert.rejects(client.verify(verdict as any), AttestationError);
+});

--- a/packages/elyan-staking-js/tsconfig.json
+++ b/packages/elyan-staking-js/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Closes #14381.

Adds `packages/elyan-staking-js/` — a typed TS client for the staking gate.

## Scope
- `StakingClient` with `stake()` / `submit()` / `poll()` / `verify()`
- Bearer-auth requests; canonical-JSON bodies (sorted keys, no whitespace) so signatures match the Python reference byte-for-byte
- Ed25519 verdict verification via `node:crypto` (no third-party crypto deps)
- Pluggable on-chain attestation verifier (default rejects empty `txHash`)
- Fail-safe: any verification failure throws; caller never sees an untrusted payload

## Errors
`UnauthorizedError`, `SignatureError`, `AttestationError`, `GateUnavailableError`, base `StakingError`.

## Tests (10/10 passing)
- canonical JSON sorts keys / matches Python `json.dumps` separators
- happy path: submit → poll → verify
- bad API key → `UnauthorizedError`
- forged signature (wrong pubkey) → `SignatureError`
- tampered payload → `SignatureError`
- gate network error → `GateUnavailableError`
- gate 503 → `GateUnavailableError`
- empty attestation → `AttestationError`

```
$ npm test
✔ 10 tests pass (441ms)
$ npx tsc --noEmit   # clean
```

## Hygiene
- BCOS-L1 (new SDK code, not payout/claim/secrets logic)
- SPDX-License-Identifier: MIT header in every new code file
- No runtime dependencies; Node 18+ only

Please add the `BCOS-L1` label on merge. RTC wallet for claim will be added per maintainer template.

---
*This PR was created with the assistance of Claude sonnet-4.5 by Anthropic. Happy to make any adjustments!*