### PR TITLE
feat: add community policy judge

### DIFF
--- a/submissions/14382-community-policy-judge/README.md
+++ b/submissions/14382-community-policy-judge/README.md
@@ -1,0 +1,81 @@
+# Community Policy Judge
+
+Open Judge implementation for bounty #14382.
+
+This judge is deliberately small and auditable. It implements the open interface:
+
+```text
+judge(request) -> (passed, reasons)
+```
+
+The returned verdict is wrapped in an Ed25519-signed envelope so a staking SDK or gate server can verify that the verdict was produced by this judge key.
+
+## What It Judges
+
+The default policy checks that a proposed self-improvement request:
+
+- has a non-trivial summary and a reviewable artifact (`diff`, `patch`, `repository`, or `artifact_url`)
+- includes passing test or validation evidence
+- avoids obvious secret leakage and unsafe execution patterns
+- declares or implies a bounded improvement scope
+
+This is meant for community-run gates that want a conservative "is this work reviewable and safe enough to advance?" check. It is not SophiaCore and does not attempt semantic code correctness beyond the policy checks above.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `policy-judge.mjs` | `CommunityPolicyJudge`, canonical JSON, Ed25519 sign/verify helpers |
+| `gate-server.mjs` | Minimal HTTP adapter exposing `POST /judge` for a reference gate |
+| `test.mjs` | Node built-in test suite for passing, failing, and tampered verdicts |
+| `package.json` | Local scripts, no external dependencies |
+
+## Run
+
+```bash
+cd submissions/14382-community-policy-judge
+npm test
+node gate-server.mjs
+```
+
+Example request:
+
+```bash
+curl -sS http://127.0.0.1:8787/judge \
+  -H 'content-type: application/json' \
+  -d '{
+    "summary": "Add typed validation around the gate request parser.",
+    "scope": "code",
+    "diff": "diff --git a/gate.js b/gate.js\n+ validate payload before submit",
+    "tests": [{"name":"node --test","status":"passed"}]
+  }'
+```
+
+## Key Handling
+
+For demos and tests the judge generates an ephemeral Ed25519 key pair. For a persistent community gate, provide the key pair through environment variables:
+
+```bash
+JUDGE_PRIVATE_KEY_PEM="$(cat judge_private.pem)" \
+JUDGE_PUBLIC_KEY_PEM="$(cat judge_public.pem)" \
+node gate-server.mjs
+```
+
+The response includes:
+
+- `verdict.passed`
+- `verdict.reasons`
+- `verdict.request_hash`
+- `public_key_pem`
+- `signature_algorithm: Ed25519`
+- `signature`
+
+SDK verification succeeds by verifying the canonical envelope, excluding the `signature` field, with `public_key_pem`.
+
+## Limits
+
+- This judge is a policy gate, not a deep theorem prover or full test runner.
+- It cannot prove a diff is correct; it checks that the request is bounded, reviewable, tested, and free of obvious unsafe patterns.
+- It is intentionally dependency-free so agents can run it inside constrained environments.
+
+Wallet ID for claim: `lxx197818`

--- a/submissions/14382-community-policy-judge/README.md
+++ b/submissions/14382-community-policy-judge/README.md
@@ -8,7 +8,7 @@ This judge is deliberately small and auditable. It implements the open interface
 judge(request) -> (passed, reasons)
 ```
 
-The returned verdict is wrapped in an Ed25519-signed envelope so a staking SDK or gate server can verify that the verdict was produced by this judge key.
+`judge(request)` returns the flat verdict shape with top-level `passed` and `reasons` fields. Use `judgeSigned(request)` or the HTTP gate adapter when a signed Ed25519 envelope is needed for downstream verification.
 
 ## What It Judges
 
@@ -25,7 +25,7 @@ This is meant for community-run gates that want a conservative "is this work rev
 
 | File | Purpose |
 | --- | --- |
-| `policy-judge.mjs` | `CommunityPolicyJudge`, canonical JSON, Ed25519 sign/verify helpers |
+| `policy-judge.mjs` | `CommunityPolicyJudge`, flat judge verdicts, canonical JSON, Ed25519 sign/verify helpers |
 | `gate-server.mjs` | Minimal HTTP adapter exposing `POST /judge` for a reference gate |
 | `test.mjs` | Node built-in test suite for passing, failing, and tampered verdicts |
 | `package.json` | Local scripts, no external dependencies |
@@ -61,7 +61,15 @@ JUDGE_PUBLIC_KEY_PEM="$(cat judge_public.pem)" \
 node gate-server.mjs
 ```
 
-The response includes:
+`judge(request)` returns:
+
+- `passed`
+- `reasons`
+- `checks`
+- `request_hash`
+- `issued_at`
+
+`judgeSigned(request)` and `POST /judge` wrap that verdict in a signed envelope containing:
 
 - `verdict.passed`
 - `verdict.reasons`
@@ -70,7 +78,7 @@ The response includes:
 - `signature_algorithm: Ed25519`
 - `signature`
 
-SDK verification succeeds by verifying the canonical envelope, excluding the `signature` field, with `public_key_pem`.
+SDK verification succeeds by verifying the canonical envelope, excluding the `signature` field, with the pinned judge public key. The verifier must not trust a public key supplied only by an untrusted envelope.
 
 ## Limits
 

--- a/submissions/14382-community-policy-judge/gate-server.mjs
+++ b/submissions/14382-community-policy-judge/gate-server.mjs
@@ -7,9 +7,18 @@ const judge = createJudge({
   publicKeyPem: process.env.JUDGE_PUBLIC_KEY_PEM,
 });
 
+const MAX_BODY_BYTES = Number(process.env.MAX_BODY_BYTES || 1_048_576);
+
 async function readJson(req) {
   const chunks = [];
-  for await (const chunk of req) chunks.push(chunk);
+  let received = 0;
+  for await (const chunk of req) {
+    received += chunk.length;
+    if (received > MAX_BODY_BYTES) {
+      throw new Error(`request body exceeds ${MAX_BODY_BYTES} byte limit`);
+    }
+    chunks.push(chunk);
+  }
   const raw = Buffer.concat(chunks).toString("utf8");
   return raw ? JSON.parse(raw) : {};
 }

--- a/submissions/14382-community-policy-judge/gate-server.mjs
+++ b/submissions/14382-community-policy-judge/gate-server.mjs
@@ -27,7 +27,7 @@ const server = http.createServer(async (req, res) => {
       return;
     }
     const request = await readJson(req);
-    const signedVerdict = judge.judge(request);
+    const signedVerdict = judge.judgeSigned(request);
     res.writeHead(200, { "content-type": "application/json" });
     res.end(JSON.stringify(signedVerdict, null, 2));
   } catch (error) {

--- a/submissions/14382-community-policy-judge/gate-server.mjs
+++ b/submissions/14382-community-policy-judge/gate-server.mjs
@@ -1,0 +1,42 @@
+import http from "node:http";
+
+import { createJudge } from "./policy-judge.mjs";
+
+const judge = createJudge({
+  privateKeyPem: process.env.JUDGE_PRIVATE_KEY_PEM,
+  publicKeyPem: process.env.JUDGE_PUBLIC_KEY_PEM,
+});
+
+async function readJson(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw ? JSON.parse(raw) : {};
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.method === "GET" && req.url === "/health") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, judge: "community-policy-judge" }));
+      return;
+    }
+    if (req.method !== "POST" || req.url !== "/judge") {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "not_found" }));
+      return;
+    }
+    const request = await readJson(req);
+    const signedVerdict = judge.judge(request);
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(signedVerdict, null, 2));
+  } catch (error) {
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "bad_request", message: error.message }));
+  }
+});
+
+const port = Number(process.env.PORT || 8787);
+server.listen(port, () => {
+  console.log(`community policy judge listening on http://127.0.0.1:${port}/judge`);
+});

--- a/submissions/14382-community-policy-judge/package.json
+++ b/submissions/14382-community-policy-judge/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "rustchain-community-policy-judge",
+  "version": "0.1.0",
+  "description": "Open Judge implementation for RustChain community gate bounty #14382.",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "node --test test.mjs",
+    "demo": "node gate-server.mjs"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/submissions/14382-community-policy-judge/policy-judge.mjs
+++ b/submissions/14382-community-policy-judge/policy-judge.mjs
@@ -67,6 +67,12 @@ function hasAny(text, patterns) {
   return patterns.some((pattern) => pattern.test(text));
 }
 
+function hasReviewableArtifact(request) {
+  return [request.diff, request.patch, request.artifact_url, request.repository].some(
+    (artifact) => typeof artifact === "string" && artifact.trim().length > 0,
+  );
+}
+
 export class CommunityPolicyJudge {
   constructor({ privateKeyPem, publicKeyPem, now = () => new Date() } = {}) {
     if ((privateKeyPem && !publicKeyPem) || (!privateKeyPem && publicKeyPem)) {
@@ -127,11 +133,7 @@ export class CommunityPolicyJudge {
 
   checkShape(request) {
     const hasSummary = typeof request.summary === "string" && request.summary.trim().length >= 12;
-    const hasArtifact =
-      typeof request.diff === "string" ||
-      typeof request.patch === "string" ||
-      typeof request.artifact_url === "string" ||
-      typeof request.repository === "string";
+    const hasArtifact = hasReviewableArtifact(request);
     return {
       id: "shape",
       passed: hasSummary && hasArtifact,

--- a/submissions/14382-community-policy-judge/policy-judge.mjs
+++ b/submissions/14382-community-policy-judge/policy-judge.mjs
@@ -1,0 +1,184 @@
+import crypto from "node:crypto";
+
+export const JUDGE_ID = "lxx197818-community-policy-judge-v1";
+
+export function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value && typeof value === "object" && value.constructor === Object) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function sha256Hex(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function generateJudgeKeyPair() {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  return {
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }),
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }),
+  };
+}
+
+export function signCanonical(privateKeyPem, payload) {
+  return crypto
+    .sign(null, Buffer.from(canonicalJson(payload)), privateKeyPem)
+    .toString("base64");
+}
+
+export function verifyCanonical(publicKeyPem, payload, signatureBase64) {
+  return crypto.verify(
+    null,
+    Buffer.from(canonicalJson(payload)),
+    publicKeyPem,
+    Buffer.from(signatureBase64, "base64"),
+  );
+}
+
+function asText(request) {
+  return [
+    request.summary,
+    request.diff,
+    request.patch,
+    request.readme,
+    request.evidence,
+    JSON.stringify(request.metadata || {}),
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function hasAny(text, patterns) {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+export class CommunityPolicyJudge {
+  constructor({ privateKeyPem, publicKeyPem, now = () => new Date() } = {}) {
+    const generated = privateKeyPem && publicKeyPem ? null : generateJudgeKeyPair();
+    this.privateKeyPem = privateKeyPem || generated.privateKeyPem;
+    this.publicKeyPem = publicKeyPem || generated.publicKeyPem;
+    this.now = now;
+  }
+
+  judge(request) {
+    const normalized = canonicalize(request || {});
+    const text = asText(normalized);
+    const checks = [
+      this.checkShape(normalized),
+      this.checkEvidence(normalized, text),
+      this.checkSafety(text),
+      this.checkScope(normalized, text),
+    ];
+    const passed = checks.every((check) => check.passed);
+    const verdict = {
+      judge_id: JUDGE_ID,
+      interface: "Judge.judge(request)->(passed,reasons)",
+      passed,
+      reasons: checks.filter((check) => !check.passed).map((check) => check.reason),
+      checks,
+      request_hash: sha256Hex(canonicalJson(normalized)),
+      issued_at: this.now().toISOString(),
+    };
+    return this.signVerdict(verdict);
+  }
+
+  signVerdict(verdict) {
+    const envelope = {
+      verdict: canonicalize(verdict),
+      signature_algorithm: "Ed25519",
+      public_key_pem: this.publicKeyPem,
+    };
+    return {
+      ...envelope,
+      signature: signCanonical(this.privateKeyPem, envelope),
+    };
+  }
+
+  verify(signedVerdict) {
+    const { signature, ...payload } = signedVerdict;
+    return verifyCanonical(signedVerdict.public_key_pem, payload, signature);
+  }
+
+  checkShape(request) {
+    const hasSummary = typeof request.summary === "string" && request.summary.trim().length >= 12;
+    const hasArtifact =
+      typeof request.diff === "string" ||
+      typeof request.patch === "string" ||
+      typeof request.artifact_url === "string" ||
+      typeof request.repository === "string";
+    return {
+      id: "shape",
+      passed: hasSummary && hasArtifact,
+      reason: hasSummary && hasArtifact
+        ? "request includes a reviewable summary and artifact"
+        : "request must include a non-trivial summary and a diff/patch/repository artifact",
+    };
+  }
+
+  checkEvidence(request, text) {
+    const tests = Array.isArray(request.tests) ? request.tests : [];
+    const passedTest = tests.some((test) => {
+      const status = String(test.status || test.result || "").toLowerCase();
+      return status === "pass" || status === "passed" || status === "success";
+    });
+    const textualProof = /\b(test|pytest|npm test|cargo test|go test|node --test)\b/i.test(text)
+      && /\b(pass|passed|success|green|0 failed)\b/i.test(text);
+    const passed = passedTest || textualProof;
+    return {
+      id: "evidence",
+      passed,
+      reason: passed
+        ? "request contains test or validation evidence"
+        : "request needs at least one passing test or validation artifact",
+    };
+  }
+
+  checkSafety(text) {
+    const dangerous = [
+      /BEGIN (RSA|OPENSSH|EC|DSA) PRIVATE KEY/i,
+      /sk-[a-z0-9_-]{20,}/i,
+      /process\.env\.[A-Z0-9_]*(SECRET|TOKEN|PRIVATE|KEY)/i,
+      /rejectUnauthorized\s*:\s*false/i,
+      /curl\s+[^|]*\|\s*(sh|bash)/i,
+      /rm\s+-rf\s+(\/|\$HOME|~)/i,
+    ];
+    const passed = !hasAny(text, dangerous);
+    return {
+      id: "safety",
+      passed,
+      reason: passed
+        ? "no obvious secret leakage or unsafe execution pattern detected"
+        : "request contains a secret-like or unsafe execution pattern",
+    };
+  }
+
+  checkScope(request, text) {
+    const scope = String(request.scope || request.category || "").toLowerCase();
+    const declared = ["code", "test", "policy", "documentation", "integration"].includes(scope);
+    const contextual = /\b(fix|feature|test|policy|integration|docs|readme|sdk|gate)\b/i.test(text);
+    const passed = declared || contextual;
+    return {
+      id: "scope",
+      passed,
+      reason: passed
+        ? "request declares or implies a bounded improvement scope"
+        : "request needs a bounded improvement scope",
+    };
+  }
+}
+
+export function createJudge(options = {}) {
+  return new CommunityPolicyJudge(options);
+}

--- a/submissions/14382-community-policy-judge/policy-judge.mjs
+++ b/submissions/14382-community-policy-judge/policy-judge.mjs
@@ -54,6 +54,9 @@ function asText(request) {
     request.patch,
     request.readme,
     request.evidence,
+    request.artifact_url,
+    request.repository,
+    JSON.stringify(request.tests || []),
     JSON.stringify(request.metadata || {}),
   ]
     .filter(Boolean)
@@ -66,6 +69,9 @@ function hasAny(text, patterns) {
 
 export class CommunityPolicyJudge {
   constructor({ privateKeyPem, publicKeyPem, now = () => new Date() } = {}) {
+    if ((privateKeyPem && !publicKeyPem) || (!privateKeyPem && publicKeyPem)) {
+      throw new Error("JUDGE_PRIVATE_KEY_PEM and JUDGE_PUBLIC_KEY_PEM must be provided together");
+    }
     const generated = privateKeyPem && publicKeyPem ? null : generateJudgeKeyPair();
     this.privateKeyPem = privateKeyPem || generated.privateKeyPem;
     this.publicKeyPem = publicKeyPem || generated.publicKeyPem;
@@ -91,7 +97,11 @@ export class CommunityPolicyJudge {
       request_hash: sha256Hex(canonicalJson(normalized)),
       issued_at: this.now().toISOString(),
     };
-    return this.signVerdict(verdict);
+    return verdict;
+  }
+
+  judgeSigned(request) {
+    return this.signVerdict(this.judge(request));
   }
 
   signVerdict(verdict) {
@@ -106,9 +116,13 @@ export class CommunityPolicyJudge {
     };
   }
 
-  verify(signedVerdict) {
+  verify(signedVerdict, expectedPublicKeyPem = this.publicKeyPem) {
+    if (!expectedPublicKeyPem) throw new Error("missing pinned judge public key");
+    if (signedVerdict.public_key_pem && signedVerdict.public_key_pem !== expectedPublicKeyPem) {
+      return false;
+    }
     const { signature, ...payload } = signedVerdict;
-    return verifyCanonical(signedVerdict.public_key_pem, payload, signature);
+    return verifyCanonical(expectedPublicKeyPem, payload, signature);
   }
 
   checkShape(request) {

--- a/submissions/14382-community-policy-judge/test.mjs
+++ b/submissions/14382-community-policy-judge/test.mjs
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CommunityPolicyJudge,
+  canonicalJson,
+  createJudge,
+  generateJudgeKeyPair,
+  verifyCanonical,
+} from "./policy-judge.mjs";
+
+const fixedNow = () => new Date("2026-06-26T00:00:00.000Z");
+
+test("canonicalJson sorts nested object keys byte-for-byte", () => {
+  assert.equal(
+    canonicalJson({ z: 1, a: { b: 2, a: 1 }, list: [{ y: 2, x: 1 }] }),
+    '{"a":{"a":1,"b":2},"list":[{"x":1,"y":2}],"z":1}',
+  );
+});
+
+test("judge passes a bounded request with test evidence", () => {
+  const judge = new CommunityPolicyJudge({ now: fixedNow });
+  const result = judge.judge({
+    summary: "Add typed validation around the gate request parser.",
+    scope: "code",
+    diff: "diff --git a/gate.js b/gate.js\n+ validate payload before submit",
+    tests: [{ name: "node --test", status: "passed" }],
+  });
+
+  assert.equal(result.verdict.passed, true);
+  assert.deepEqual(result.verdict.reasons, []);
+  assert.equal(judge.verify(result), true);
+  assert.equal(result.signature_algorithm, "Ed25519");
+});
+
+test("judge rejects missing validation evidence", () => {
+  const judge = createJudge({ now: fixedNow });
+  const result = judge.judge({
+    summary: "Add a code change with no proof.",
+    scope: "code",
+    diff: "+ unverified change",
+  });
+
+  assert.equal(result.verdict.passed, false);
+  assert.match(result.verdict.reasons.join("\n"), /validation artifact/);
+  assert.equal(judge.verify(result), true);
+});
+
+test("judge rejects obvious secret-like payloads", () => {
+  const judge = createJudge({ now: fixedNow });
+  const result = judge.judge({
+    summary: "Patch includes an unsafe secret use.",
+    scope: "code",
+    diff: "const token = process.env.PRIVATE_KEY; fetch(url, { rejectUnauthorized: false })",
+    tests: [{ name: "node --test", status: "passed" }],
+  });
+
+  assert.equal(result.verdict.passed, false);
+  assert.match(result.verdict.reasons.join("\n"), /unsafe/);
+});
+
+test("signature verification fails after verdict tampering", () => {
+  const keys = generateJudgeKeyPair();
+  const judge = new CommunityPolicyJudge({ ...keys, now: fixedNow });
+  const result = judge.judge({
+    summary: "Add README guidance for the gate.",
+    scope: "documentation",
+    repository: "Scottcjn/rustchain-bounties",
+    evidence: "markdownlint passed",
+  });
+
+  const { signature, ...payload } = result;
+  assert.equal(verifyCanonical(result.public_key_pem, payload, signature), true);
+
+  const tampered = structuredClone(payload);
+  tampered.verdict.passed = true;
+  assert.equal(verifyCanonical(result.public_key_pem, tampered, signature), false);
+});

--- a/submissions/14382-community-policy-judge/test.mjs
+++ b/submissions/14382-community-policy-judge/test.mjs
@@ -20,49 +20,69 @@ test("canonicalJson sorts nested object keys byte-for-byte", () => {
 
 test("judge passes a bounded request with test evidence", () => {
   const judge = new CommunityPolicyJudge({ now: fixedNow });
-  const result = judge.judge({
+  const verdict = judge.judge({
     summary: "Add typed validation around the gate request parser.",
     scope: "code",
     diff: "diff --git a/gate.js b/gate.js\n+ validate payload before submit",
     tests: [{ name: "node --test", status: "passed" }],
   });
 
-  assert.equal(result.verdict.passed, true);
-  assert.deepEqual(result.verdict.reasons, []);
-  assert.equal(judge.verify(result), true);
-  assert.equal(result.signature_algorithm, "Ed25519");
+  assert.equal(verdict.passed, true);
+  assert.deepEqual(verdict.reasons, []);
+
+  const signed = judge.judgeSigned({
+    summary: "Add typed validation around the gate request parser.",
+    scope: "code",
+    diff: "diff --git a/gate.js b/gate.js\n+ validate payload before submit",
+    tests: [{ name: "node --test", status: "passed" }],
+  });
+  assert.equal(judge.verify(signed), true);
+  assert.equal(signed.signature_algorithm, "Ed25519");
 });
 
 test("judge rejects missing validation evidence", () => {
   const judge = createJudge({ now: fixedNow });
-  const result = judge.judge({
+  const verdict = judge.judge({
     summary: "Add a code change with no proof.",
     scope: "code",
     diff: "+ unverified change",
   });
 
-  assert.equal(result.verdict.passed, false);
-  assert.match(result.verdict.reasons.join("\n"), /validation artifact/);
-  assert.equal(judge.verify(result), true);
+  assert.equal(verdict.passed, false);
+  assert.match(verdict.reasons.join("\n"), /validation artifact/);
 });
 
 test("judge rejects obvious secret-like payloads", () => {
   const judge = createJudge({ now: fixedNow });
-  const result = judge.judge({
+  const verdict = judge.judge({
     summary: "Patch includes an unsafe secret use.",
     scope: "code",
     diff: "const token = process.env.PRIVATE_KEY; fetch(url, { rejectUnauthorized: false })",
     tests: [{ name: "node --test", status: "passed" }],
   });
 
-  assert.equal(result.verdict.passed, false);
-  assert.match(result.verdict.reasons.join("\n"), /unsafe/);
+  assert.equal(verdict.passed, false);
+  assert.match(verdict.reasons.join("\n"), /unsafe/);
+});
+
+test("safety scan includes repository, artifact URL, and tests fields", () => {
+  const judge = createJudge({ now: fixedNow });
+  const verdict = judge.judge({
+    summary: "Submit a repository artifact with validation evidence.",
+    scope: "code",
+    repository: "https://example.test/repo?token=sk-leakedsecret000000000000",
+    artifact_url: "https://example.test/artifact",
+    tests: [{ name: "node --test", status: "passed" }],
+  });
+
+  assert.equal(verdict.passed, false);
+  assert.match(verdict.reasons.join("\n"), /unsafe/);
 });
 
 test("signature verification fails after verdict tampering", () => {
   const keys = generateJudgeKeyPair();
   const judge = new CommunityPolicyJudge({ ...keys, now: fixedNow });
-  const result = judge.judge({
+  const result = judge.judgeSigned({
     summary: "Add README guidance for the gate.",
     scope: "documentation",
     repository: "Scottcjn/rustchain-bounties",
@@ -75,4 +95,31 @@ test("signature verification fails after verdict tampering", () => {
   const tampered = structuredClone(payload);
   tampered.verdict.passed = true;
   assert.equal(verifyCanonical(result.public_key_pem, tampered, signature), false);
+});
+
+test("verification uses the pinned judge key instead of the envelope key", () => {
+  const good = generateJudgeKeyPair();
+  const wrong = generateJudgeKeyPair();
+  const judge = new CommunityPolicyJudge({ ...good, now: fixedNow });
+  const result = judge.judgeSigned({
+    summary: "Add README guidance for the gate.",
+    scope: "documentation",
+    repository: "Scottcjn/rustchain-bounties",
+    evidence: "markdownlint passed",
+  });
+
+  result.public_key_pem = wrong.publicKeyPem;
+  assert.equal(judge.verify(result), false);
+});
+
+test("partial key configuration fails instead of generating a new pair", () => {
+  const keys = generateJudgeKeyPair();
+  assert.throws(
+    () => new CommunityPolicyJudge({ privateKeyPem: keys.privateKeyPem }),
+    /must be provided together/,
+  );
+  assert.throws(
+    () => new CommunityPolicyJudge({ publicKeyPem: keys.publicKeyPem }),
+    /must be provided together/,
+  );
 });

--- a/submissions/14382-community-policy-judge/test.mjs
+++ b/submissions/14382-community-policy-judge/test.mjs
@@ -52,6 +52,19 @@ test("judge rejects missing validation evidence", () => {
   assert.match(verdict.reasons.join("\n"), /validation artifact/);
 });
 
+test("judge rejects empty or whitespace-only review artifacts", () => {
+  const judge = createJudge({ now: fixedNow });
+  const verdict = judge.judge({
+    summary: "Submit a claim that has passing tests but no reviewable artifact.",
+    scope: "code",
+    diff: "   \n\t ",
+    tests: [{ name: "node --test", status: "passed" }],
+  });
+
+  assert.equal(verdict.passed, false);
+  assert.match(verdict.reasons.join("\n"), /diff\/patch\/repository artifact/);
+});
+
 test("judge rejects obvious secret-like payloads", () => {
   const judge = createJudge({ now: fixedNow });
   const verdict = judge.judge({


### PR DESCRIPTION
## Description
Adds a dependency-free open Judge implementation for bounty #14382. The Community Policy Judge implements `judge(request) -> (passed, reasons)`, wraps verdicts in an Ed25519-signed envelope, and includes a minimal HTTP adapter for `POST /judge`.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- `node --test test.mjs` from `submissions/14382-community-policy-judge` — 5 passed
- HTTP smoke test against `gate-server.mjs` returned `passed=true`, `signature_algorithm=Ed25519`, and a non-empty signature

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested changes locally

## Bounty Claim
If this PR addresses a bounty issue:
- Issue number: #14382
- Wallet ID: lxx197818

Closes #14382