### PR TITLE
feat: add elyan staking sdk

### DIFF
--- a/submissions/14381-elyan-staking-sdk/README.md
+++ b/submissions/14381-elyan-staking-sdk/README.md
@@ -10,6 +10,7 @@ The client mirrors the reference staking surface:
 - `verify(response, request)`
 
 It uses canonical JSON with sorted keys, sends the canonical request to a gate endpoint with a Bearer API key, verifies the Ed25519 signed verdict against the configured gate public key, and verifies the returned on-chain attestation hashes.
+The gate public key must be pinned with `gatePublicKeyPem`; the SDK never trusts a public key supplied only by the response envelope.
 
 ## Install Locally
 
@@ -81,7 +82,9 @@ The SDK fails closed if:
 - the gate rejects the Bearer API key
 - the gate is unavailable
 - the verdict signature is forged
+- no pinned gate public key is configured
 - the verdict public key does not match the configured gate public key
+- the verdict `request_hash` does not match the submitted canonical request
 - the attestation request or verdict hash does not match the verified payload
 
 ## Tests
@@ -94,8 +97,11 @@ Covered cases:
 
 - happy path
 - bad API key
+- non-JSON auth and unavailable responses
 - forged or mismatched gate public key
+- missing pinned gate public key
 - gate-down fail-safe
+- verdict request-hash replay
 - attestation hash mismatch
 - canonical JSON byte ordering
 

--- a/submissions/14381-elyan-staking-sdk/README.md
+++ b/submissions/14381-elyan-staking-sdk/README.md
@@ -1,0 +1,102 @@
+# @elyan/staking
+
+Typed JavaScript client for the open Elyan staking gate contract, built for bounty #14381.
+
+The client mirrors the reference staking surface:
+
+- `stake(input)`
+- `submit(request)`
+- `poll(attestationUrl)`
+- `verify(response, request)`
+
+It uses canonical JSON with sorted keys, sends the canonical request to a gate endpoint with a Bearer API key, verifies the Ed25519 signed verdict against the configured gate public key, and verifies the returned on-chain attestation hashes.
+
+## Install Locally
+
+```bash
+cd submissions/14381-elyan-staking-sdk
+node --test test/staking.test.mjs
+```
+
+This package is dependency-free and runs on Node 18+. If npm is available, `npm test` runs the same command.
+
+## Example
+
+```js
+import { ElyanStakingClient } from "@elyan/staking";
+
+const client = new ElyanStakingClient({
+  gateUrl: "https://gate.example.com",
+  apiKey: process.env.ELYAN_GATE_API_KEY,
+  gatePublicKeyPem: process.env.ELYAN_GATE_PUBLIC_KEY_PEM,
+});
+
+const result = await client.stake({
+  skill: "self-improve:lint",
+  bondRtc: 3,
+  agent: "my-agent",
+  metadata: { repo: "owner/repo", run: "ci-123" },
+});
+
+console.log(result.verified);
+```
+
+## Verification Model
+
+`submit()` sends this canonical request body:
+
+```json
+{
+  "agent": "my-agent",
+  "bond_rtc": 3,
+  "created_at": "2026-06-26T00:00:00.000Z",
+  "metadata": {},
+  "nonce": "uuid",
+  "skill": "self-improve:lint",
+  "version": 1
+}
+```
+
+The gate response must contain:
+
+```json
+{
+  "verdict": {
+    "verdict": { "passed": true, "request_hash": "..." },
+    "public_key_pem": "-----BEGIN PUBLIC KEY-----...",
+    "signature_algorithm": "Ed25519",
+    "signature": "base64..."
+  },
+  "attestation": {
+    "status": "confirmed",
+    "tx_id": "rtc-tx",
+    "request_hash": "...",
+    "verdict_hash": "..."
+  }
+}
+```
+
+The SDK fails closed if:
+
+- the gate rejects the Bearer API key
+- the gate is unavailable
+- the verdict signature is forged
+- the verdict public key does not match the configured gate public key
+- the attestation request or verdict hash does not match the verified payload
+
+## Tests
+
+```bash
+node --test test/staking.test.mjs
+```
+
+Covered cases:
+
+- happy path
+- bad API key
+- forged or mismatched gate public key
+- gate-down fail-safe
+- attestation hash mismatch
+- canonical JSON byte ordering
+
+Wallet ID for claim: `lxx197818`

--- a/submissions/14381-elyan-staking-sdk/package.json
+++ b/submissions/14381-elyan-staking-sdk/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@elyan/staking",
+  "version": "0.1.0",
+  "description": "Typed JavaScript client for the open Elyan staking gate contract.",
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "types": "./src/index.d.ts"
+    }
+  },
+  "scripts": {
+    "test": "node --test test/staking.test.mjs"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "MIT"
+}

--- a/submissions/14381-elyan-staking-sdk/src/index.d.ts
+++ b/submissions/14381-elyan-staking-sdk/src/index.d.ts
@@ -1,0 +1,77 @@
+export interface StakeInput {
+  skill: string;
+  bondRtc?: number;
+  bond_rtc?: number;
+  agent?: string;
+  nonce?: string;
+  createdAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SignedVerdictEnvelope {
+  verdict: Record<string, unknown>;
+  public_key_pem?: string;
+  signature_algorithm?: "Ed25519";
+  signature: string;
+  attestation?: Attestation;
+}
+
+export interface Attestation {
+  status: "confirmed" | "finalized" | "success" | string;
+  request_hash: string;
+  verdict_hash: string;
+  tx_id?: string;
+  transaction_id?: string;
+  block_height?: number;
+}
+
+export interface GateResponse {
+  verdict: SignedVerdictEnvelope;
+  attestation: Attestation;
+}
+
+export interface ElyanStakingClientOptions {
+  gateUrl: string;
+  gatePath?: string;
+  apiKey?: string;
+  gatePublicKeyPem?: string;
+  fetch?: typeof fetch;
+}
+
+export interface VerificationResult {
+  signature: true;
+  attestation: true;
+  request_hash: string;
+  verdict_hash: string;
+}
+
+export class StakingError extends Error {
+  details: Record<string, unknown>;
+}
+
+export class AuthError extends StakingError {}
+export class GateUnavailableError extends StakingError {}
+export class VerificationError extends StakingError {}
+
+export function canonicalize<T>(value: T): T;
+export function canonicalJson(value: unknown): string;
+export function sha256Hex(value: string): string;
+export function buildCanonicalStakeRequest(input: StakeInput): Record<string, unknown>;
+export function verifyEd25519Envelope(envelope: SignedVerdictEnvelope, expectedPubkeyPem?: string): true;
+export function verifyAttestation(attestation: Attestation, hashes?: { requestHash?: string; verdictHash?: string }): true;
+
+export class ElyanStakingClient {
+  constructor(options: ElyanStakingClientOptions);
+  stake(input: StakeInput): Promise<{
+    ok: true;
+    request: Record<string, unknown>;
+    request_hash: string;
+    response: GateResponse;
+    verified: VerificationResult;
+  }>;
+  submit(request: Record<string, unknown>): Promise<GateResponse>;
+  poll(attestationUrl: string, options?: { timeoutMs?: number; intervalMs?: number }): Promise<Attestation>;
+  verify(response: GateResponse, request: Record<string, unknown>): Promise<VerificationResult>;
+}
+
+export default ElyanStakingClient;

--- a/submissions/14381-elyan-staking-sdk/src/index.d.ts
+++ b/submissions/14381-elyan-staking-sdk/src/index.d.ts
@@ -34,7 +34,7 @@ export interface ElyanStakingClientOptions {
   gateUrl: string;
   gatePath?: string;
   apiKey?: string;
-  gatePublicKeyPem?: string;
+  gatePublicKeyPem: string;
   fetch?: typeof fetch;
 }
 

--- a/submissions/14381-elyan-staking-sdk/src/index.js
+++ b/submissions/14381-elyan-staking-sdk/src/index.js
@@ -31,9 +31,8 @@ export function sha256Hex(value) {
 }
 
 export function verifyEd25519Envelope(envelope, expectedPubkeyPem) {
-  const publicKeyPem = expectedPubkeyPem || envelope.public_key_pem;
-  if (!publicKeyPem) throw new VerificationError("missing gate public key");
-  if (expectedPubkeyPem && envelope.public_key_pem && envelope.public_key_pem !== expectedPubkeyPem) {
+  if (!expectedPubkeyPem) throw new VerificationError("missing pinned gate public key");
+  if (envelope.public_key_pem && envelope.public_key_pem !== expectedPubkeyPem) {
     throw new VerificationError("verdict public key does not match configured gate key");
   }
   const { signature, ...payload } = envelope;
@@ -41,7 +40,7 @@ export function verifyEd25519Envelope(envelope, expectedPubkeyPem) {
   const ok = crypto.verify(
     null,
     Buffer.from(canonicalJson(payload)),
-    publicKeyPem,
+    expectedPubkeyPem,
     Buffer.from(signature, "base64"),
   );
   if (!ok) throw new VerificationError("invalid Ed25519 verdict signature");
@@ -130,12 +129,18 @@ export class ElyanStakingClient {
       throw new GateUnavailableError("gate unavailable", { cause: error.message });
     }
     const text = await res.text();
-    const body = text ? JSON.parse(text) : {};
     if (res.status === 401 || res.status === 403) {
-      throw new AuthError("gate rejected API key", { status: res.status, body });
+      throw new AuthError("gate rejected API key", { status: res.status, body: text });
     }
     if (!res.ok) {
-      throw new GateUnavailableError("gate returned unavailable status", { status: res.status, body });
+      throw new GateUnavailableError("gate returned unavailable status", { status: res.status, body: text });
+    }
+
+    let body;
+    try {
+      body = text ? JSON.parse(text) : {};
+    } catch (error) {
+      throw new GateUnavailableError("gate returned invalid JSON", { error: error.message, body: text });
     }
     return body;
   }
@@ -155,6 +160,9 @@ export class ElyanStakingClient {
     const envelope = response.verdict || response;
     verifyEd25519Envelope(envelope, this.gatePublicKeyPem);
     const requestHash = sha256Hex(canonicalJson(request));
+    if (envelope.verdict?.request_hash !== requestHash) {
+      throw new VerificationError("verdict request hash mismatch");
+    }
     const verdictHash = sha256Hex(canonicalJson(envelope.verdict));
     const attestation = response.attestation || envelope.attestation;
     verifyAttestation(attestation, { requestHash, verdictHash });

--- a/submissions/14381-elyan-staking-sdk/src/index.js
+++ b/submissions/14381-elyan-staking-sdk/src/index.js
@@ -1,0 +1,170 @@
+import crypto from "node:crypto";
+
+export class StakingError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = this.constructor.name;
+    this.details = details;
+  }
+}
+
+export class AuthError extends StakingError {}
+export class GateUnavailableError extends StakingError {}
+export class VerificationError extends StakingError {}
+
+export function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object" && value.constructor === Object) {
+    return Object.fromEntries(
+      Object.keys(value).sort().map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function sha256Hex(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function verifyEd25519Envelope(envelope, expectedPubkeyPem) {
+  const publicKeyPem = expectedPubkeyPem || envelope.public_key_pem;
+  if (!publicKeyPem) throw new VerificationError("missing gate public key");
+  if (expectedPubkeyPem && envelope.public_key_pem && envelope.public_key_pem !== expectedPubkeyPem) {
+    throw new VerificationError("verdict public key does not match configured gate key");
+  }
+  const { signature, ...payload } = envelope;
+  if (!signature) throw new VerificationError("missing verdict signature");
+  const ok = crypto.verify(
+    null,
+    Buffer.from(canonicalJson(payload)),
+    publicKeyPem,
+    Buffer.from(signature, "base64"),
+  );
+  if (!ok) throw new VerificationError("invalid Ed25519 verdict signature");
+  return true;
+}
+
+export function buildCanonicalStakeRequest(input) {
+  if (!input || typeof input !== "object") {
+    throw new StakingError("stake request must be an object");
+  }
+  if (!input.skill || typeof input.skill !== "string") {
+    throw new StakingError("skill is required");
+  }
+  const bondRtc = Number(input.bondRtc ?? input.bond_rtc);
+  if (!Number.isFinite(bondRtc) || bondRtc <= 0) {
+    throw new StakingError("bondRtc must be a positive number");
+  }
+  return canonicalize({
+    version: 1,
+    skill: input.skill,
+    bond_rtc: bondRtc,
+    agent: input.agent || "anonymous-js-agent",
+    nonce: input.nonce || crypto.randomUUID(),
+    created_at: input.createdAt || new Date().toISOString(),
+    metadata: input.metadata || {},
+  });
+}
+
+export function verifyAttestation(attestation, { requestHash, verdictHash } = {}) {
+  if (!attestation || typeof attestation !== "object") {
+    throw new VerificationError("missing on-chain attestation");
+  }
+  if (!["confirmed", "finalized", "success"].includes(String(attestation.status || "").toLowerCase())) {
+    throw new VerificationError("attestation is not confirmed");
+  }
+  if (requestHash && attestation.request_hash !== requestHash) {
+    throw new VerificationError("attestation request hash mismatch");
+  }
+  if (verdictHash && attestation.verdict_hash !== verdictHash) {
+    throw new VerificationError("attestation verdict hash mismatch");
+  }
+  if (!attestation.tx_id && !attestation.transaction_id) {
+    throw new VerificationError("attestation missing transaction id");
+  }
+  return true;
+}
+
+export class ElyanStakingClient {
+  constructor(options = {}) {
+    this.gateUrl = String(options.gateUrl || "").replace(/\/$/, "");
+    this.gatePath = options.gatePath || "/stake";
+    this.apiKey = options.apiKey || "";
+    this.gatePublicKeyPem = options.gatePublicKeyPem || "";
+    this.fetch = options.fetch || globalThis.fetch;
+    if (!this.fetch) throw new StakingError("fetch is not available; pass one in options");
+  }
+
+  async stake(input) {
+    const request = buildCanonicalStakeRequest(input);
+    const response = await this.submit(request);
+    const verified = await this.verify(response, request);
+    return {
+      ok: true,
+      request,
+      request_hash: sha256Hex(canonicalJson(request)),
+      response,
+      verified,
+    };
+  }
+
+  async submit(request) {
+    if (!this.gateUrl) throw new StakingError("gateUrl is required");
+    const url = `${this.gateUrl}${this.gatePath}`;
+    let res;
+    try {
+      res = await this.fetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "accept": "application/json",
+          ...(this.apiKey ? { "authorization": `Bearer ${this.apiKey}` } : {}),
+        },
+        body: canonicalJson(request),
+      });
+    } catch (error) {
+      throw new GateUnavailableError("gate unavailable", { cause: error.message });
+    }
+    const text = await res.text();
+    const body = text ? JSON.parse(text) : {};
+    if (res.status === 401 || res.status === 403) {
+      throw new AuthError("gate rejected API key", { status: res.status, body });
+    }
+    if (!res.ok) {
+      throw new GateUnavailableError("gate returned unavailable status", { status: res.status, body });
+    }
+    return body;
+  }
+
+  async poll(attestationUrl, { timeoutMs = 30000, intervalMs = 1000 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() <= deadline) {
+      const res = await this.fetch(attestationUrl, { headers: { accept: "application/json" } });
+      const body = JSON.parse(await res.text());
+      if (body.status && String(body.status).toLowerCase() !== "pending") return body;
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    throw new GateUnavailableError("attestation polling timed out");
+  }
+
+  async verify(response, request) {
+    const envelope = response.verdict || response;
+    verifyEd25519Envelope(envelope, this.gatePublicKeyPem);
+    const requestHash = sha256Hex(canonicalJson(request));
+    const verdictHash = sha256Hex(canonicalJson(envelope.verdict));
+    const attestation = response.attestation || envelope.attestation;
+    verifyAttestation(attestation, { requestHash, verdictHash });
+    return {
+      signature: true,
+      attestation: true,
+      request_hash: requestHash,
+      verdict_hash: verdictHash,
+    };
+  }
+}
+
+export default ElyanStakingClient;

--- a/submissions/14381-elyan-staking-sdk/test/staking.test.mjs
+++ b/submissions/14381-elyan-staking-sdk/test/staking.test.mjs
@@ -31,6 +31,14 @@ function jsonResponse(status, body) {
   };
 }
 
+function textResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => body,
+  };
+}
+
 function gateFetch({ privateKeyPem, publicKeyPem }) {
   const calls = [];
   const fetch = async (_url, init) => {
@@ -103,6 +111,31 @@ test("bad API key maps to AuthError", async () => {
   );
 });
 
+test("non-json auth errors still map to AuthError", async () => {
+  const client = new ElyanStakingClient({
+    gateUrl: "https://gate.example",
+    apiKey: "bad",
+    gatePublicKeyPem: keyPair().publicKeyPem,
+    fetch: async () => textResponse(401, "unauthorized"),
+  });
+  await assert.rejects(
+    () => client.stake({ skill: "x", bondRtc: 1, nonce: "n", createdAt: "2026-06-26T00:00:00.000Z" }),
+    AuthError,
+  );
+});
+
+test("non-json unavailable responses still map to GateUnavailableError", async () => {
+  const client = new ElyanStakingClient({
+    gateUrl: "https://gate.example",
+    gatePublicKeyPem: keyPair().publicKeyPem,
+    fetch: async () => textResponse(503, "service unavailable"),
+  });
+  await assert.rejects(
+    () => client.stake({ skill: "x", bondRtc: 1, nonce: "n", createdAt: "2026-06-26T00:00:00.000Z" }),
+    GateUnavailableError,
+  );
+});
+
 test("forged or mismatched gate pubkey fails closed", async () => {
   const good = keyPair();
   const wrong = keyPair();
@@ -110,6 +143,18 @@ test("forged or mismatched gate pubkey fails closed", async () => {
     gateUrl: "https://gate.example",
     gatePublicKeyPem: wrong.publicKeyPem,
     fetch: gateFetch(good),
+  });
+  await assert.rejects(
+    () => client.stake({ skill: "x", bondRtc: 1, nonce: "n", createdAt: "2026-06-26T00:00:00.000Z" }),
+    VerificationError,
+  );
+});
+
+test("missing pinned gate pubkey fails closed", async () => {
+  const keys = keyPair();
+  const client = new ElyanStakingClient({
+    gateUrl: "https://gate.example",
+    fetch: gateFetch(keys),
   });
   await assert.rejects(
     () => client.stake({ skill: "x", bondRtc: 1, nonce: "n", createdAt: "2026-06-26T00:00:00.000Z" }),
@@ -151,6 +196,43 @@ test("attestation hash mismatch is rejected", async () => {
         status: "confirmed",
         tx_id: "rtc-test-tx-2",
         request_hash: "not-the-request",
+        verdict_hash: sha256Hex(canonicalJson(verdict)),
+      },
+    });
+  };
+  const client = new ElyanStakingClient({
+    gateUrl: "https://gate.example",
+    gatePublicKeyPem: keys.publicKeyPem,
+    fetch,
+  });
+  await assert.rejects(
+    () => client.stake({ skill: "x", bondRtc: 1, nonce: "n", createdAt: "2026-06-26T00:00:00.000Z" }),
+    VerificationError,
+  );
+});
+
+test("verdict request hash replay is rejected", async () => {
+  const keys = keyPair();
+  const fetch = async (_url, init) => {
+    const request = JSON.parse(init.body);
+    const realRequestHash = sha256Hex(canonicalJson(request));
+    const verdict = {
+      passed: true,
+      reasons: [],
+      request_hash: "replayed-request",
+      issued_at: "2026-06-26T00:00:00.000Z",
+    };
+    const payload = {
+      verdict,
+      public_key_pem: keys.publicKeyPem,
+      signature_algorithm: "Ed25519",
+    };
+    return jsonResponse(200, {
+      verdict: { ...payload, signature: sign(keys.privateKeyPem, payload) },
+      attestation: {
+        status: "confirmed",
+        tx_id: "rtc-test-tx-3",
+        request_hash: realRequestHash,
         verdict_hash: sha256Hex(canonicalJson(verdict)),
       },
     });

--- a/submissions/14381-elyan-staking-sdk/test/staking.test.mjs
+++ b/submissions/14381-elyan-staking-sdk/test/staking.test.mjs
@@ -1,0 +1,167 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+
+import {
+  AuthError,
+  ElyanStakingClient,
+  GateUnavailableError,
+  VerificationError,
+  canonicalJson,
+  sha256Hex,
+} from "../src/index.js";
+
+function keyPair() {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  return {
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }),
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }),
+  };
+}
+
+function sign(privateKeyPem, payload) {
+  return crypto.sign(null, Buffer.from(canonicalJson(payload)), privateKeyPem).toString("base64");
+}
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function gateFetch({ privateKeyPem, publicKeyPem }) {
+  const calls = [];
+  const fetch = async (_url, init) => {
+    calls.push({ init });
+    const request = JSON.parse(init.body);
+    const verdict = {
+      passed: true,
+      reasons: [],
+      request_hash: sha256Hex(canonicalJson(request)),
+      issued_at: "2026-06-26T00:00:00.000Z",
+    };
+    const envelopePayload = {
+      verdict,
+      public_key_pem: publicKeyPem,
+      signature_algorithm: "Ed25519",
+    };
+    const envelope = {
+      ...envelopePayload,
+      signature: sign(privateKeyPem, envelopePayload),
+    };
+    const attestation = {
+      status: "confirmed",
+      tx_id: "rtc-test-tx-1",
+      request_hash: verdict.request_hash,
+      verdict_hash: sha256Hex(canonicalJson(verdict)),
+      block_height: 123,
+    };
+    return jsonResponse(200, { verdict: envelope, attestation });
+  };
+  fetch.calls = calls;
+  return fetch;
+}
+
+test("canonical JSON sorts keys byte-for-byte", () => {
+  assert.equal(canonicalJson({ b: 1, a: { d: 2, c: 1 } }), '{"a":{"c":1,"d":2},"b":1}');
+});
+
+test("happy path stakes, sends Bearer key, verifies signature and attestation", async () => {
+  const keys = keyPair();
+  const fetch = gateFetch(keys);
+  const client = new ElyanStakingClient({
+    gateUrl: "https://gate.example",
+    apiKey: "test-key",
+    gatePublicKeyPem: keys.publicKeyPem,
+    fetch,
+  });
+  const result = await client.stake({
+    skill: "self-improve:lint",
+    bondRtc: 3,
+    agent: "lxx197818",
+    nonce: "fixed",
+    createdAt: "2026-06-26T00:00:00.000Z",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.verified.signature, true);
+  assert.equal(result.verified.attestation, true);
+  assert.equal(fetch.calls[0].init.headers.authorization, "Bearer test-key");
+});
+
+test("bad API key maps to AuthError", async () => {
+  const client = new ElyanStakingClient({
+    gateUrl: "https://gate.example",
+    apiKey: "bad",
+    fetch: async () => jsonResponse(401, { error: "bad_api_key" }),
+  });
+  await assert.rejects(
+    () => client.stake({ skill: "x", bondRtc: 1, nonce: "n", createdAt: "2026-06-26T00:00:00.000Z" }),
+    AuthError,
+  );
+});
+
+test("forged or mismatched gate pubkey fails closed", async () => {
+  const good = keyPair();
+  const wrong = keyPair();
+  const client = new ElyanStakingClient({
+    gateUrl: "https://gate.example",
+    gatePublicKeyPem: wrong.publicKeyPem,
+    fetch: gateFetch(good),
+  });
+  await assert.rejects(
+    () => client.stake({ skill: "x", bondRtc: 1, nonce: "n", createdAt: "2026-06-26T00:00:00.000Z" }),
+    VerificationError,
+  );
+});
+
+test("gate down returns unavailable fail-safe", async () => {
+  const client = new ElyanStakingClient({
+    gateUrl: "https://gate.example",
+    fetch: async () => {
+      throw new Error("ECONNREFUSED");
+    },
+  });
+  await assert.rejects(
+    () => client.stake({ skill: "x", bondRtc: 1, nonce: "n", createdAt: "2026-06-26T00:00:00.000Z" }),
+    GateUnavailableError,
+  );
+});
+
+test("attestation hash mismatch is rejected", async () => {
+  const keys = keyPair();
+  const fetch = async (_url, init) => {
+    const request = JSON.parse(init.body);
+    const verdict = {
+      passed: true,
+      reasons: [],
+      request_hash: sha256Hex(canonicalJson(request)),
+      issued_at: "2026-06-26T00:00:00.000Z",
+    };
+    const payload = {
+      verdict,
+      public_key_pem: keys.publicKeyPem,
+      signature_algorithm: "Ed25519",
+    };
+    return jsonResponse(200, {
+      verdict: { ...payload, signature: sign(keys.privateKeyPem, payload) },
+      attestation: {
+        status: "confirmed",
+        tx_id: "rtc-test-tx-2",
+        request_hash: "not-the-request",
+        verdict_hash: sha256Hex(canonicalJson(verdict)),
+      },
+    });
+  };
+  const client = new ElyanStakingClient({
+    gateUrl: "https://gate.example",
+    gatePublicKeyPem: keys.publicKeyPem,
+    fetch,
+  });
+  await assert.rejects(
+    () => client.stake({ skill: "x", bondRtc: 1, nonce: "n", createdAt: "2026-06-26T00:00:00.000Z" }),
+    VerificationError,
+  );
+});


### PR DESCRIPTION
## Description
Adds a dependency-free typed JavaScript SDK for bounty #14381. The package is named `@elyan/staking` and implements `stake()`, `submit()`, `poll()`, and `verify()` with canonical JSON, Bearer gate requests, Ed25519 verdict verification, and on-chain attestation hash checks.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- `node --test test/staking.test.mjs` from `submissions/14381-elyan-staking-sdk` — 6 passed

Covered cases:
- happy path
- bad API key
- forged or mismatched gate public key
- gate-down fail-safe
- attestation hash mismatch
- canonical JSON byte ordering

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested changes locally

## Bounty Claim
If this PR addresses a bounty issue:
- Issue number: #14381
- Wallet ID: lxx197818

Closes #14381