### PR TITLE
feat: add JS LangChain MCP staking tools

### DIFF
--- a/submissions/14383-langchain-mcp-staking-js/README.md
+++ b/submissions/14383-langchain-mcp-staking-js/README.md
@@ -1,0 +1,98 @@
+# LangChain + MCP Staking Tool
+
+JavaScript/TypeScript-friendly delivery for bounty #14383. It wraps the open Elyan staking gate as:
+
+- a LangChain-compatible `stake_and_acquire` tool
+- a dependency-free MCP stdio server exposing the same tool
+- a shared verifier that returns a signed verdict plus on-chain attestation on success
+
+The package is dependency-free for tests and runtime smoke checks. If `@langchain/core` and `zod` are installed, `createLangChainTool()` returns a real `DynamicStructuredTool`; otherwise it returns a compatible fallback object with `name`, `description`, `schema`, `call()`, `_call()`, and `invoke()`.
+
+## Quickstart: LangChain JS
+
+```js
+import { createLangChainTool } from "./src/index.js";
+
+const tool = await createLangChainTool({
+  gateUrl: process.env.ELYAN_GATE_URL,
+  apiKey: process.env.ELYAN_GATE_API_KEY,
+  gatePublicKeyPem: process.env.ELYAN_GATE_PUBLIC_KEY_PEM,
+});
+
+const resultJson = await tool.call({
+  skill: "self-improve:tests",
+  bond_rtc: 2,
+  agent: "my-agent",
+  metadata: { repo: "owner/repo", run: "ci-123" },
+});
+
+console.log(JSON.parse(resultJson));
+```
+
+## Quickstart: MCP
+
+```bash
+cd submissions/14383-langchain-mcp-staking-js
+ELYAN_GATE_URL=https://gate.example.com \
+ELYAN_GATE_API_KEY=... \
+ELYAN_GATE_PUBLIC_KEY_PEM="$(cat gate.pub.pem)" \
+node src/mcp-server.mjs
+```
+
+MCP tool:
+
+```json
+{
+  "name": "stake_and_acquire",
+  "arguments": {
+    "skill": "self-improve:lint",
+    "bond_rtc": 1,
+    "agent": "my-agent"
+  }
+}
+```
+
+## Fail-Safe Semantics
+
+The tool never hides stake safety from the caller:
+
+- gate available + verdict passes + signature/attestation verify: `ok: true`, `refunded: false`
+- gate returns 4xx/5xx or network failure: `ok: false`, `refunded: true`, `refund_reason: "gate_unavailable"`
+- gate denies the skill: `ok: false`, `refunded: true`, `refund_reason: "gate_denied"`
+- signature or attestation verification fails: `ok: false`, `refunded: true`, `refund_reason: "verification_failed"`
+
+Successful results verify:
+
+- Ed25519 signature over canonical JSON
+- configured gate public key match
+- attestation status
+- request hash
+- verdict hash
+
+## Environment
+
+```text
+ELYAN_GATE_URL=https://gate.example.com
+ELYAN_GATE_PATH=/stake
+ELYAN_GATE_API_KEY=optional-bearer-token
+ELYAN_GATE_PUBLIC_KEY_PEM=-----BEGIN PUBLIC KEY-----...
+ELYAN_AGENT_ID=lxx197818
+```
+
+## Tests
+
+```bash
+node --test test/stake-and-acquire.test.mjs
+```
+
+Covered cases:
+
+- successful LangChain/MCP staking call
+- signed Ed25519 verdict verification
+- confirmed attestation hash verification
+- gate unavailable refund path
+- gate denial refund path
+- invalid signature fail-closed path
+- MCP `tools/list` and `tools/call`
+
+Wallet ID for claim: `lxx197818`

--- a/submissions/14383-langchain-mcp-staking-js/package.json
+++ b/submissions/14383-langchain-mcp-staking-js/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@elyan/staking-agent-tools",
+  "version": "0.1.0",
+  "description": "LangChain JS tool and MCP stdio server for the open Elyan staking gate.",
+  "type": "module",
+  "private": true,
+  "bin": {
+    "elyan-staking-mcp": "./src/mcp-server.mjs"
+  },
+  "exports": {
+    ".": "./src/index.js",
+    "./langchain": "./src/langchain-tool.js",
+    "./mcp": "./src/mcp-server.mjs"
+  },
+  "scripts": {
+    "test": "node --test test/stake-and-acquire.test.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "@langchain/core": {
+      "optional": true
+    },
+    "zod": {
+      "optional": true
+    }
+  }
+}

--- a/submissions/14383-langchain-mcp-staking-js/src/core.js
+++ b/submissions/14383-langchain-mcp-staking-js/src/core.js
@@ -1,0 +1,199 @@
+import crypto from "node:crypto";
+
+export class StakeToolError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = this.constructor.name;
+    this.details = details;
+  }
+}
+
+export class StakeInputError extends StakeToolError {}
+export class StakeVerificationError extends StakeToolError {}
+
+export function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object" && value.constructor === Object) {
+    return Object.fromEntries(
+      Object.keys(value).sort().map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function sha256Hex(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function normalizeStakeInput(input = {}) {
+  const skill = String(input.skill || "").trim();
+  if (!skill) throw new StakeInputError("skill is required");
+
+  const bondRtc = Number(input.bondRtc ?? input.bond_rtc);
+  if (!Number.isFinite(bondRtc) || bondRtc <= 0) {
+    throw new StakeInputError("bond_rtc must be a positive number");
+  }
+
+  return canonicalize({
+    version: 1,
+    skill,
+    bond_rtc: bondRtc,
+    agent: input.agent || process.env.ELYAN_AGENT_ID || "langchain-mcp-agent",
+    nonce: input.nonce || crypto.randomUUID(),
+    created_at: input.createdAt || input.created_at || new Date().toISOString(),
+    metadata: input.metadata || {},
+  });
+}
+
+export function verifyEd25519Envelope(envelope, expectedPublicKeyPem = "") {
+  if (!envelope || typeof envelope !== "object") {
+    throw new StakeVerificationError("missing signed verdict envelope");
+  }
+
+  const publicKeyPem = expectedPublicKeyPem || envelope.public_key_pem;
+  if (!publicKeyPem) throw new StakeVerificationError("missing gate public key");
+  if (expectedPublicKeyPem && envelope.public_key_pem && envelope.public_key_pem !== expectedPublicKeyPem) {
+    throw new StakeVerificationError("verdict public key does not match configured key");
+  }
+
+  const { signature, ...payload } = envelope;
+  if (!signature) throw new StakeVerificationError("missing verdict signature");
+
+  const ok = crypto.verify(
+    null,
+    Buffer.from(canonicalJson(payload)),
+    publicKeyPem,
+    Buffer.from(signature, "base64"),
+  );
+
+  if (!ok) throw new StakeVerificationError("invalid verdict signature");
+  return true;
+}
+
+export function verifyAttestation(attestation, { requestHash, verdictHash } = {}) {
+  if (!attestation || typeof attestation !== "object") {
+    throw new StakeVerificationError("missing on-chain attestation");
+  }
+
+  const status = String(attestation.status || "").toLowerCase();
+  if (!["confirmed", "finalized", "success"].includes(status)) {
+    throw new StakeVerificationError("attestation is not confirmed");
+  }
+  if (requestHash && attestation.request_hash !== requestHash) {
+    throw new StakeVerificationError("attestation request hash mismatch");
+  }
+  if (verdictHash && attestation.verdict_hash !== verdictHash) {
+    throw new StakeVerificationError("attestation verdict hash mismatch");
+  }
+  if (!attestation.tx_id && !attestation.transaction_id) {
+    throw new StakeVerificationError("attestation missing transaction id");
+  }
+
+  return true;
+}
+
+export function verifiedResult(response, request, gatePublicKeyPem = "") {
+  const envelope = response.verdict || response;
+  verifyEd25519Envelope(envelope, gatePublicKeyPem);
+
+  const requestHash = sha256Hex(canonicalJson(request));
+  const verdictPayload = envelope.verdict || {};
+  const verdictHash = sha256Hex(canonicalJson(verdictPayload));
+  const attestation = response.attestation || envelope.attestation;
+
+  verifyAttestation(attestation, { requestHash, verdictHash });
+
+  return {
+    ok: true,
+    refunded: false,
+    request,
+    request_hash: requestHash,
+    verdict: envelope,
+    attestation,
+    verification: {
+      signature: true,
+      attestation: true,
+      verdict_hash: verdictHash,
+    },
+  };
+}
+
+export function refundedResult(request, reason, details = {}) {
+  return {
+    ok: false,
+    refunded: true,
+    refund_reason: reason,
+    request,
+    request_hash: sha256Hex(canonicalJson(request)),
+    details,
+  };
+}
+
+export class StakeAndAcquireClient {
+  constructor(options = {}) {
+    this.gateUrl = String(options.gateUrl || process.env.ELYAN_GATE_URL || "").replace(/\/$/, "");
+    this.gatePath = options.gatePath || process.env.ELYAN_GATE_PATH || "/stake";
+    this.apiKey = options.apiKey || process.env.ELYAN_GATE_API_KEY || "";
+    this.gatePublicKeyPem = options.gatePublicKeyPem || process.env.ELYAN_GATE_PUBLIC_KEY_PEM || "";
+    this.fetch = options.fetch || globalThis.fetch;
+    if (!this.fetch) throw new StakeInputError("fetch is not available; pass fetch in options");
+  }
+
+  async stakeAndAcquire(input) {
+    const request = normalizeStakeInput(input);
+    if (!this.gateUrl) return refundedResult(request, "gate_not_configured");
+
+    let response;
+    try {
+      response = await this.submit(request);
+    } catch (error) {
+      return refundedResult(request, "gate_unavailable", {
+        error: error.message,
+        status: error.details?.status,
+        body: error.details?.body,
+      });
+    }
+
+    const passed = response?.verdict?.verdict?.passed ?? response?.verdict?.passed;
+    if (passed === false) {
+      return refundedResult(request, "gate_denied", {
+        verdict: response.verdict,
+        attestation: response.attestation,
+      });
+    }
+
+    try {
+      return verifiedResult(response, request, this.gatePublicKeyPem);
+    } catch (error) {
+      return refundedResult(request, "verification_failed", {
+        error: error.message,
+      });
+    }
+  }
+
+  async submit(request) {
+    const res = await this.fetch(`${this.gateUrl}${this.gatePath}`, {
+      method: "POST",
+      headers: {
+        "accept": "application/json",
+        "content-type": "application/json",
+        ...(this.apiKey ? { "authorization": `Bearer ${this.apiKey}` } : {}),
+      },
+      body: canonicalJson(request),
+    });
+
+    const text = await res.text();
+    const body = text ? JSON.parse(text) : {};
+    if (!res.ok) {
+      throw new StakeToolError("gate returned non-success status", {
+        status: res.status,
+        body,
+      });
+    }
+    return body;
+  }
+}

--- a/submissions/14383-langchain-mcp-staking-js/src/core.js
+++ b/submissions/14383-langchain-mcp-staking-js/src/core.js
@@ -102,6 +102,9 @@ export function verifiedResult(response, request, gatePublicKeyPem = "") {
 
   const requestHash = sha256Hex(canonicalJson(request));
   const verdictPayload = envelope.verdict || {};
+  if (verdictPayload.passed !== true) {
+    throw new StakeVerificationError("verdict did not pass");
+  }
   const verdictHash = sha256Hex(canonicalJson(verdictPayload));
   const attestation = response.attestation || envelope.attestation;
 

--- a/submissions/14383-langchain-mcp-staking-js/src/index.js
+++ b/submissions/14383-langchain-mcp-staking-js/src/index.js
@@ -1,0 +1,2 @@
+export * from "./core.js";
+export * from "./langchain-tool.js";

--- a/submissions/14383-langchain-mcp-staking-js/src/langchain-tool.js
+++ b/submissions/14383-langchain-mcp-staking-js/src/langchain-tool.js
@@ -1,0 +1,77 @@
+import { StakeAndAcquireClient } from "./core.js";
+
+export const stakeAndAcquireSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    skill: {
+      type: "string",
+      description: "Skill or capability to acquire, for example self-improve:lint.",
+    },
+    bond_rtc: {
+      type: "number",
+      description: "RTC bond to stake for the acquisition attempt.",
+      minimum: 0,
+      exclusiveMinimum: true,
+    },
+    agent: {
+      type: "string",
+      description: "Public agent identifier to bind into the canonical request.",
+    },
+    metadata: {
+      type: "object",
+      description: "Optional public metadata such as repo, run id, or policy tag.",
+    },
+  },
+  required: ["skill", "bond_rtc"],
+};
+
+export class ElyanStakeAndAcquireTool {
+  constructor(options = {}) {
+    this.name = options.name || "stake_and_acquire";
+    this.description = options.description || [
+      "Stake RTC to acquire a self-improvement skill through the open Elyan gate.",
+      "Returns a verified signed attestation on success.",
+      "If the gate is unavailable or denies the request, returns refunded=true with the reason.",
+    ].join(" ");
+    this.schema = stakeAndAcquireSchema;
+    this.client = options.client || new StakeAndAcquireClient(options);
+  }
+
+  async call(input) {
+    return JSON.stringify(await this.invoke(input));
+  }
+
+  async _call(input) {
+    return this.call(input);
+  }
+
+  async invoke(input) {
+    return this.client.stakeAndAcquire(input);
+  }
+}
+
+export async function createLangChainTool(options = {}) {
+  let DynamicStructuredTool;
+  let z;
+
+  try {
+    ({ DynamicStructuredTool } = await import("@langchain/core/tools"));
+    ({ z } = await import("zod"));
+  } catch {
+    return new ElyanStakeAndAcquireTool(options);
+  }
+
+  const client = options.client || new StakeAndAcquireClient(options);
+  return new DynamicStructuredTool({
+    name: options.name || "stake_and_acquire",
+    description: options.description || "Stake RTC for self-improvement and return verified attestation or refunded fail-safe result.",
+    schema: z.object({
+      skill: z.string().min(1),
+      bond_rtc: z.number().positive(),
+      agent: z.string().optional(),
+      metadata: z.record(z.unknown()).optional(),
+    }),
+    func: async (input) => JSON.stringify(await client.stakeAndAcquire(input)),
+  });
+}

--- a/submissions/14383-langchain-mcp-staking-js/src/langchain-tool.js
+++ b/submissions/14383-langchain-mcp-staking-js/src/langchain-tool.js
@@ -11,8 +11,7 @@ export const stakeAndAcquireSchema = {
     bond_rtc: {
       type: "number",
       description: "RTC bond to stake for the acquisition attempt.",
-      minimum: 0,
-      exclusiveMinimum: true,
+      exclusiveMinimum: 0,
     },
     agent: {
       type: "string",

--- a/submissions/14383-langchain-mcp-staking-js/src/mcp-server.mjs
+++ b/submissions/14383-langchain-mcp-staking-js/src/mcp-server.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import { createInterface } from "node:readline";
+import { stdin as input, stdout as output } from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { StakeAndAcquireClient } from "./core.js";
+import { stakeAndAcquireSchema } from "./langchain-tool.js";
+
+export const toolDefinition = {
+  name: "stake_and_acquire",
+  description: "Stake RTC to acquire a self-improvement skill and return a verified attestation or refunded fail-safe result.",
+  inputSchema: stakeAndAcquireSchema,
+};
+
+function rpcResult(id, result) {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function rpcError(id, code, message, data = undefined) {
+  return { jsonrpc: "2.0", id, error: { code, message, ...(data ? { data } : {}) } };
+}
+
+export async function handleMcpMessage(message, { client = new StakeAndAcquireClient() } = {}) {
+  if (message.method === "initialize") {
+    return rpcResult(message.id, {
+      protocolVersion: "2025-11-25",
+      serverInfo: {
+        name: "elyan-staking-agent-tools",
+        version: "0.1.0",
+      },
+      capabilities: {
+        tools: {},
+      },
+    });
+  }
+
+  if (message.method === "tools/list") {
+    return rpcResult(message.id, { tools: [toolDefinition] });
+  }
+
+  if (message.method === "tools/call") {
+    if (message.params?.name !== "stake_and_acquire") {
+      return rpcError(message.id, -32602, "unknown tool", { name: message.params?.name });
+    }
+    const result = await client.stakeAndAcquire(message.params?.arguments || {});
+    return rpcResult(message.id, {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+      isError: result.ok === false && result.refunded !== true,
+    });
+  }
+
+  if (message.method === "notifications/initialized") {
+    return undefined;
+  }
+
+  return rpcError(message.id, -32601, "method not found", { method: message.method });
+}
+
+export async function runStdioServer({ client = new StakeAndAcquireClient() } = {}) {
+  const rl = createInterface({ input, crlfDelay: Infinity });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let response;
+    try {
+      response = await handleMcpMessage(JSON.parse(trimmed), { client });
+    } catch (error) {
+      response = rpcError(null, -32603, "internal error", { error: error.message });
+    }
+
+    if (response) output.write(`${JSON.stringify(response)}\n`);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runStdioServer();
+}

--- a/submissions/14383-langchain-mcp-staking-js/src/mcp-server.mjs
+++ b/submissions/14383-langchain-mcp-staking-js/src/mcp-server.mjs
@@ -50,7 +50,7 @@ export async function handleMcpMessage(message, { client = new StakeAndAcquireCl
           text: JSON.stringify(result, null, 2),
         },
       ],
-      isError: result.ok === false && result.refunded !== true,
+      isError: result.ok === false,
     });
   }
 

--- a/submissions/14383-langchain-mcp-staking-js/test/stake-and-acquire.test.mjs
+++ b/submissions/14383-langchain-mcp-staking-js/test/stake-and-acquire.test.mjs
@@ -1,0 +1,165 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+
+import {
+  ElyanStakeAndAcquireTool,
+  StakeAndAcquireClient,
+  canonicalJson,
+  createLangChainTool,
+  sha256Hex,
+} from "../src/index.js";
+import { handleMcpMessage } from "../src/mcp-server.mjs";
+
+function keyPair() {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  return {
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }),
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }),
+  };
+}
+
+function sign(privateKeyPem, payload) {
+  return crypto.sign(null, Buffer.from(canonicalJson(payload)), privateKeyPem).toString("base64");
+}
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function gateFetch({ privateKeyPem, publicKeyPem, passed = true }) {
+  return async (_url, init) => {
+    const request = JSON.parse(init.body);
+    const verdict = {
+      passed,
+      reasons: passed ? [] : ["skill_not_available"],
+      request_hash: sha256Hex(canonicalJson(request)),
+      issued_at: "2026-06-26T00:00:00.000Z",
+    };
+    const envelopePayload = {
+      verdict,
+      public_key_pem: publicKeyPem,
+      signature_algorithm: "Ed25519",
+    };
+    const envelope = {
+      ...envelopePayload,
+      signature: sign(privateKeyPem, envelopePayload),
+    };
+    return jsonResponse(200, {
+      verdict: envelope,
+      attestation: {
+        status: "confirmed",
+        tx_id: "rtc-test-tx",
+        request_hash: verdict.request_hash,
+        verdict_hash: sha256Hex(canonicalJson(verdict)),
+      },
+    });
+  };
+}
+
+test("client returns verified result and signed attestation on success", async () => {
+  const keys = keyPair();
+  const client = new StakeAndAcquireClient({
+    gateUrl: "https://gate.example",
+    gatePublicKeyPem: keys.publicKeyPem,
+    fetch: gateFetch(keys),
+  });
+
+  const result = await client.stakeAndAcquire({
+    skill: "self-improve:tests",
+    bond_rtc: 2,
+    agent: "lxx197818",
+    nonce: "fixed",
+    createdAt: "2026-06-26T00:00:00.000Z",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.refunded, false);
+  assert.equal(result.verification.signature, true);
+  assert.equal(result.verification.attestation, true);
+});
+
+test("gate unavailable is surfaced as refunded fail-safe", async () => {
+  const client = new StakeAndAcquireClient({
+    gateUrl: "https://gate.example",
+    fetch: async () => jsonResponse(503, { error: "down" }),
+  });
+  const result = await client.stakeAndAcquire({ skill: "x", bond_rtc: 1, nonce: "n" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.refunded, true);
+  assert.equal(result.refund_reason, "gate_unavailable");
+});
+
+test("gate denial is surfaced as refunded fail-safe", async () => {
+  const keys = keyPair();
+  const client = new StakeAndAcquireClient({
+    gateUrl: "https://gate.example",
+    gatePublicKeyPem: keys.publicKeyPem,
+    fetch: gateFetch({ ...keys, passed: false }),
+  });
+  const result = await client.stakeAndAcquire({ skill: "not-ready", bond_rtc: 1, nonce: "n" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.refunded, true);
+  assert.equal(result.refund_reason, "gate_denied");
+});
+
+test("invalid signature fails closed with refunded verification_failed", async () => {
+  const good = keyPair();
+  const wrong = keyPair();
+  const client = new StakeAndAcquireClient({
+    gateUrl: "https://gate.example",
+    gatePublicKeyPem: wrong.publicKeyPem,
+    fetch: gateFetch(good),
+  });
+  const result = await client.stakeAndAcquire({ skill: "x", bond_rtc: 1, nonce: "n" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.refunded, true);
+  assert.equal(result.refund_reason, "verification_failed");
+});
+
+test("LangChain-compatible fallback tool invokes the same client", async () => {
+  const keys = keyPair();
+  const tool = await createLangChainTool({
+    gateUrl: "https://gate.example",
+    gatePublicKeyPem: keys.publicKeyPem,
+    fetch: gateFetch(keys),
+  });
+
+  assert.ok(tool instanceof ElyanStakeAndAcquireTool || tool.name === "stake_and_acquire");
+  const text = await tool.call({ skill: "self-improve:lint", bond_rtc: 1, nonce: "n" });
+  const result = JSON.parse(text);
+  assert.equal(result.ok, true);
+});
+
+test("MCP server lists and calls stake_and_acquire", async () => {
+  const keys = keyPair();
+  const client = new StakeAndAcquireClient({
+    gateUrl: "https://gate.example",
+    gatePublicKeyPem: keys.publicKeyPem,
+    fetch: gateFetch(keys),
+  });
+
+  const listed = await handleMcpMessage({ jsonrpc: "2.0", id: 1, method: "tools/list" }, { client });
+  assert.equal(listed.result.tools[0].name, "stake_and_acquire");
+
+  const called = await handleMcpMessage({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "stake_and_acquire",
+      arguments: { skill: "self-improve:review", bond_rtc: 3, nonce: "n" },
+    },
+  }, { client });
+
+  const result = JSON.parse(called.result.content[0].text);
+  assert.equal(result.ok, true);
+  assert.equal(result.refunded, false);
+});

--- a/submissions/14383-langchain-mcp-staking-js/test/stake-and-acquire.test.mjs
+++ b/submissions/14383-langchain-mcp-staking-js/test/stake-and-acquire.test.mjs
@@ -5,9 +5,11 @@ import crypto from "node:crypto";
 import {
   ElyanStakeAndAcquireTool,
   StakeAndAcquireClient,
+  StakeVerificationError,
   canonicalJson,
   createLangChainTool,
   sha256Hex,
+  verifiedResult,
 } from "../src/index.js";
 import { handleMcpMessage } from "../src/mcp-server.mjs";
 
@@ -109,6 +111,47 @@ test("gate denial is surfaced as refunded fail-safe", async () => {
   assert.equal(result.refund_reason, "gate_denied");
 });
 
+test("verified result rejects signed denied verdicts", () => {
+  const keys = keyPair();
+  const request = {
+    version: 1,
+    skill: "not-ready",
+    bond_rtc: 1,
+    agent: "lxx197818",
+    nonce: "n",
+    created_at: "2026-06-26T00:00:00.000Z",
+    metadata: {},
+  };
+  const verdict = {
+    passed: false,
+    reasons: ["skill_not_available"],
+    request_hash: sha256Hex(canonicalJson(request)),
+    issued_at: "2026-06-26T00:00:00.000Z",
+  };
+  const envelopePayload = {
+    verdict,
+    public_key_pem: keys.publicKeyPem,
+    signature_algorithm: "Ed25519",
+  };
+  const envelope = {
+    ...envelopePayload,
+    signature: sign(keys.privateKeyPem, envelopePayload),
+  };
+
+  assert.throws(
+    () => verifiedResult({
+      verdict: envelope,
+      attestation: {
+        status: "confirmed",
+        tx_id: "rtc-test-tx",
+        request_hash: verdict.request_hash,
+        verdict_hash: sha256Hex(canonicalJson(verdict)),
+      },
+    }, request, keys.publicKeyPem),
+    StakeVerificationError,
+  );
+});
+
 test("invalid signature fails closed with refunded verification_failed", async () => {
   const good = keyPair();
   const wrong = keyPair();
@@ -162,4 +205,28 @@ test("MCP server lists and calls stake_and_acquire", async () => {
   const result = JSON.parse(called.result.content[0].text);
   assert.equal(result.ok, true);
   assert.equal(result.refunded, false);
+});
+
+test("MCP server marks refunded fail-safe results as errors", async () => {
+  const keys = keyPair();
+  const client = new StakeAndAcquireClient({
+    gateUrl: "https://gate.example",
+    gatePublicKeyPem: keys.publicKeyPem,
+    fetch: gateFetch({ ...keys, passed: false }),
+  });
+
+  const called = await handleMcpMessage({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: {
+      name: "stake_and_acquire",
+      arguments: { skill: "not-ready", bond_rtc: 1, nonce: "n" },
+    },
+  }, { client });
+
+  const result = JSON.parse(called.result.content[0].text);
+  assert.equal(result.ok, false);
+  assert.equal(result.refunded, true);
+  assert.equal(called.result.isError, true);
 });


### PR DESCRIPTION
## Bounty Claim - #14383 (100 RTC)

Wallet ID: `lxx197818`

This is a JavaScript/TypeScript ecosystem implementation for the LangChain + MCP staking bounty, intentionally separate from the existing Python submission. It pairs naturally with the JS staking SDK submitted for #14381.

### What is included

```
submissions/14383-langchain-mcp-staking-js/
├── src/core.js              # canonical request, gate call, refund-safe wrapper, Ed25519 + attestation verification
├── src/langchain-tool.js    # LangChain DynamicStructuredTool adapter with dependency-free fallback
├── src/mcp-server.mjs       # dependency-free MCP stdio server exposing stake_and_acquire
├── test/stake-and-acquire.test.mjs
├── package.json
└── README.md
```

### Acceptance coverage

- LangChain tool: `stake_and_acquire(skill, bond_rtc)` via `createLangChainTool()` / `ElyanStakeAndAcquireTool`
- MCP server: stdio server with `tools/list` and `tools/call`
- Verified result + signed attestation: Ed25519 canonical JSON verification plus attestation request/verdict hash checks
- Fail-safe semantics: gate unavailable, denial, or verification failure returns `refunded: true` with a concrete `refund_reason`
- Quickstart README for LangChain JS and MCP
- Open interface only; no SophiaCore dependency

### Validation

```text
node --test test/stake-and-acquire.test.mjs
# 6 passed

'{jsonrpc:2.0,id:1,method:initialize}' | node src/mcp-server.mjs
# returns MCP initialize result

git diff --check -- submissions/14383-langchain-mcp-staking-js
# passed
```

Refs #14383