### PR TITLE
Diff-Bounds Judge — bound diff geometry on the open Judge interface (#14382)

### DIFF
--- a/submissions/14382-diff-bounds-judge/README.md
+++ b/submissions/14382-diff-bounds-judge/README.md
@@ -1,0 +1,110 @@
+# Diff-Bounds Judge
+
+A community gate for the open **Judge** interface (`judge(request) -> (passed, reasons)`)
+on the staking self-improvement rails. Submitted for **Bounty #14382** (multi-claim).
+
+This is a **distinct, non-overlapping** judge. It judges *only the geometry and
+containment of a self-improvement diff* — not its content, not its lint quality,
+and it does not run the test suite. It is meant to run **alongside** the other
+community judges:
+
+| Judge | What it checks | This one? |
+|-------|----------------|-----------|
+| Policy judge | configurable content rules (secrets, shape, scope) | ❌ different |
+| Test-runner judge | runs the suite, passes iff green | ❌ different |
+| Static-analysis judge | lint / AST checks on the code | ❌ different |
+| **Diff-Bounds judge** | **size limits + anti-test-deletion + protected paths** | ✅ |
+
+## Why this judge exists
+
+An autonomous agent that stakes RTC to "self-improve" has an incentive to *game*
+the gate — e.g. delete the failing tests, strip assertions, quietly disable CI,
+or dump an unreviewably huge change. A content/lint/test judge does not catch any
+of those by itself. The Diff-Bounds judge closes that gap by reasoning about the
+**shape of the change**.
+
+## What it checks
+
+Given a request carrying a unified `diff` (or `patch`), it runs four checks:
+
+1. **parseable** — the request actually contains a well-formed unified diff.
+2. **size** — the change stays within bounds: `maxFiles` (25), `maxAddedLines`
+   (800), `maxRemovedLines` (600). All configurable.
+3. **test_integrity** — the diff does **not** delete a test file and does **not**
+   net-remove test assertions (`assert*`, `expect`, `it(`, `test(`, `self.assert*`).
+   This is the anti-gaming guard.
+4. **protected_paths** — the diff does not silently edit CI config (`.github/`) or
+   lockfiles (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Cargo.lock`,
+   `poetry.lock`). An explicit `allow_protected: ["path", ...]` in the request
+   whitelists intended changes.
+
+The verdict is signed with the judge's own **Ed25519** key in the same canonical
+JSON envelope used across the staking rails (sorted keys, no whitespace), so the
+open SDK's signature verification passes byte-for-byte.
+
+## Interface compatibility
+
+`createJudge(options).judge(request)` returns a signed verdict envelope:
+
+```json
+{
+  "verdict": { "judge_id": "...", "passed": true, "reasons": [], "checks": [...], "stats": {...} },
+  "signature_algorithm": "Ed25519",
+  "public_key_pem": "-----BEGIN PUBLIC KEY-----\n...",
+  "signature": "<base64>"
+}
+```
+
+`judge.verify(signedVerdict)` re-derives the canonical payload and checks the
+signature against the embedded public key — identical to what the SDK does
+against the gate pubkey. Tampering with any field, or substituting a forged key,
+fails verification (covered by tests).
+
+It plugs into the reference gate server **unmodified**: the included
+`gate-server.mjs` exposes `POST /judge` (request → signed verdict) and
+`GET /health`, the same surface the other community judges use.
+
+## Run it
+
+```bash
+# Generate a key pair (optional — omit to auto-generate an ephemeral one):
+node -e 'import("./diff-bounds-judge.mjs").then(m=>{const k=m.generateJudgeKeyPair();console.log(k.privateKeyPem);console.error(k.publicKeyPem)})'
+
+# Serve the gate:
+JUDGE_PRIVATE_KEY_PEM="$(cat key.pem)" PORT=8788 node gate-server.mjs
+
+# Judge a diff:
+curl -s -X POST http://127.0.0.1:8788/judge \
+  -H 'content-type: application/json' \
+  -d '{"summary":"harden add()","diff":"diff --git a/s.js b/s.js\n--- a/s.js\n+++ b/s.js\n@@ -1 +1 @@\n-x\n+y"}'
+```
+
+Programmatic:
+
+```js
+import { createJudge } from "./diff-bounds-judge.mjs";
+
+const judge = createJudge({ limits: { maxFiles: 10, maxAddedLines: 200 } });
+const signed = judge.judge({ summary: "...", diff: unifiedDiffText });
+if (!signed.verdict.passed) console.log(signed.verdict.reasons);
+console.log("signature ok:", judge.verify(signed));
+```
+
+## Tests
+
+```bash
+node --test     # 12 tests: happy path, oversize, too-many-files,
+                # test-deletion, assertion-stripping, protected paths,
+                # tamper detection, forged-key rejection, canonical determinism
+```
+
+## Limits
+
+- It analyses diff **geometry**, not semantics: it cannot tell whether a same-size
+  change is a *good* change (that is the test-runner / static-analysis judge's job).
+- Assertion counting is heuristic (regex over added/removed lines) and language-
+  agnostic; it is a guard against blatant test-gaming, not a coverage tool.
+- It trusts that the supplied diff matches what was actually applied; pairing it
+  with the on-chain attestation of the artifact closes that loop.
+
+Add your RTC wallet to the claim. — MIT licensed.

--- a/submissions/14382-diff-bounds-judge/diff-bounds-judge.mjs
+++ b/submissions/14382-diff-bounds-judge/diff-bounds-judge.mjs
@@ -50,6 +50,15 @@ export function generateJudgeKeyPair() {
   };
 }
 
+// Derive the spki public-key PEM from an Ed25519 private-key PEM so that a judge
+// configured with only JUDGE_PRIVATE_KEY_PEM advertises the public key that
+// actually verifies its signatures (no fresh/unrelated key).
+export function derivePublicKeyPem(privateKeyPem) {
+  return crypto
+    .createPublicKey(privateKeyPem)
+    .export({ type: "spki", format: "pem" });
+}
+
 export function signCanonical(privateKeyPem, payload) {
   return crypto
     .sign(null, Buffer.from(canonicalJson(payload)), privateKeyPem)
@@ -105,12 +114,14 @@ export function parseUnifiedDiff(diffText) {
         isDeleted: false,
         addedAssertions: 0,
         removedAssertions: 0,
+        hunks: 0,
       };
       continue;
     }
     if (!current) continue;
 
-    if (line.startsWith("new file mode")) current.isNew = true;
+    if (line.startsWith("@@")) current.hunks += 1;
+    else if (line.startsWith("new file mode")) current.isNew = true;
     else if (line.startsWith("deleted file mode")) current.isDeleted = true;
     else if (line.startsWith("rename to ")) current.path = line.slice("rename to ".length).trim();
     else if (line.startsWith("+++ ")) {
@@ -153,9 +164,21 @@ export const DEFAULT_LIMITS = {
 
 export class DiffBoundsJudge {
   constructor({ privateKeyPem, publicKeyPem, limits = {}, now = () => new Date() } = {}) {
-    const generated = privateKeyPem && publicKeyPem ? null : generateJudgeKeyPair();
-    this.privateKeyPem = privateKeyPem || generated.privateKeyPem;
-    this.publicKeyPem = publicKeyPem || generated.publicKeyPem;
+    if (privateKeyPem) {
+      this.privateKeyPem = privateKeyPem;
+      // Always derive the advertised key from the signing key so the documented
+      // JUDGE_PRIVATE_KEY_PEM-only flow emits self-consistent verdicts. An
+      // explicit publicKeyPem is honoured only when no private key is supplied
+      // (verify-only construction).
+      this.publicKeyPem = derivePublicKeyPem(privateKeyPem);
+    } else if (publicKeyPem) {
+      this.publicKeyPem = publicKeyPem;
+      this.privateKeyPem = null;
+    } else {
+      const generated = generateJudgeKeyPair();
+      this.privateKeyPem = generated.privateKeyPem;
+      this.publicKeyPem = generated.publicKeyPem;
+    }
     this.limits = {
       ...DEFAULT_LIMITS,
       ...limits,
@@ -223,14 +246,23 @@ export class DiffBoundsJudge {
   // --- individual checks ---------------------------------------------------
 
   checkParseable(diffText, files) {
-    const passed = typeof diffText === "string" && diffText.trim().length > 0 && files.length > 0;
-    return {
-      id: "parseable",
-      passed,
-      reason: passed
-        ? "request carries a well-formed unified diff"
-        : "request must include a non-empty unified `diff`/`patch` (no parseable file headers found)",
-    };
+    // A well-formed unified diff needs a file header AND at least one real hunk
+    // (`@@`). Header-only/malformed input (a bare `diff --git` line) must NOT
+    // pass the parseable guard, otherwise it would slip through every size /
+    // integrity bound with zero scrutinised content.
+    const hasHunk = files.some((f) => f.hunks > 0);
+    const passed =
+      typeof diffText === "string" &&
+      diffText.trim().length > 0 &&
+      files.length > 0 &&
+      hasHunk;
+    let reason;
+    if (passed) reason = "request carries a well-formed unified diff";
+    else if (files.length > 0 && !hasHunk)
+      reason = "diff has file headers but no `@@` hunk — header-only/malformed patch rejected";
+    else
+      reason = "request must include a non-empty unified `diff`/`patch` (no parseable file headers found)";
+    return { id: "parseable", passed, reason };
   }
 
   checkSize(files) {

--- a/submissions/14382-diff-bounds-judge/diff-bounds-judge.mjs
+++ b/submissions/14382-diff-bounds-judge/diff-bounds-judge.mjs
@@ -1,0 +1,292 @@
+import crypto from "node:crypto";
+
+// Diff-Bounds Judge — a distinct, non-overlapping community gate for the open
+// Judge interface (`judge(request) -> (passed, reasons)`).
+//
+// It judges ONLY the *geometry and containment* of a self-improvement diff:
+//   - the change stays within size bounds (files / added / removed lines),
+//   - it does not delete test files or strip test assertions (anti-gaming),
+//   - it does not silently edit protected paths (CI config, lockfiles),
+//   - the diff is well-formed and parseable.
+//
+// It deliberately does NOT run tests (that is a test-runner judge), does NOT do
+// lint/AST analysis (a static-analysis judge), and does NOT apply a generic
+// content policy (a policy judge). Those are separate, complementary gates.
+
+export const JUDGE_ID = "diff-bounds-judge-v1";
+
+// ---------------------------------------------------------------------------
+// Canonical JSON + Ed25519 envelope — byte-for-byte compatible with the open
+// SDK and the reference gate server (sorted keys, no whitespace).
+// ---------------------------------------------------------------------------
+
+export function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value && typeof value === "object" && value.constructor === Object) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function sha256Hex(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function generateJudgeKeyPair() {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  return {
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }),
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }),
+  };
+}
+
+export function signCanonical(privateKeyPem, payload) {
+  return crypto
+    .sign(null, Buffer.from(canonicalJson(payload)), privateKeyPem)
+    .toString("base64");
+}
+
+export function verifyCanonical(publicKeyPem, payload, signatureBase64) {
+  return crypto.verify(
+    null,
+    Buffer.from(canonicalJson(payload)),
+    publicKeyPem,
+    Buffer.from(signatureBase64, "base64"),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Unified-diff parser (dependency-free). Returns per-file stats.
+// ---------------------------------------------------------------------------
+
+function isTestPath(path) {
+  return (
+    /(^|\/)(tests?|spec|__tests__)\//i.test(path) ||
+    /\.(test|spec)\.[a-z0-9]+$/i.test(path) ||
+    /(^|\/)test_[^/]+\.py$/i.test(path) ||
+    /_test\.[a-z0-9]+$/i.test(path)
+  );
+}
+
+const ASSERTION_PATTERN =
+  /\b(assert\w*|expect|should|t\.(?:is|ok|deepEqual|throws)|self\.assert\w*)\b|\bit\s*\(|\btest\s*\(/;
+
+export function parseUnifiedDiff(diffText) {
+  const files = [];
+  let current = null;
+  const lines = String(diffText).split(/\r?\n/);
+
+  const push = () => {
+    if (current) files.push(current);
+    current = null;
+  };
+
+  for (const line of lines) {
+    if (line.startsWith("diff --git ")) {
+      push();
+      // diff --git a/path b/path
+      const match = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+      const path = match ? match[2] : line.slice("diff --git ".length).trim();
+      current = {
+        path,
+        added: 0,
+        removed: 0,
+        isNew: false,
+        isDeleted: false,
+        addedAssertions: 0,
+        removedAssertions: 0,
+      };
+      continue;
+    }
+    if (!current) continue;
+
+    if (line.startsWith("new file mode")) current.isNew = true;
+    else if (line.startsWith("deleted file mode")) current.isDeleted = true;
+    else if (line.startsWith("rename to ")) current.path = line.slice("rename to ".length).trim();
+    else if (line.startsWith("+++ ")) {
+      const p = line.slice(4).trim();
+      if (p === "/dev/null") current.isDeleted = true;
+      else if (p.startsWith("b/")) current.path = p.slice(2);
+    } else if (line.startsWith("--- ")) {
+      const p = line.slice(4).trim();
+      if (p === "/dev/null") current.isNew = true;
+    } else if (line.startsWith("+") && !line.startsWith("+++")) {
+      current.added += 1;
+      if (ASSERTION_PATTERN.test(line.slice(1))) current.addedAssertions += 1;
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      current.removed += 1;
+      if (ASSERTION_PATTERN.test(line.slice(1))) current.removedAssertions += 1;
+    }
+  }
+  push();
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Judge
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_LIMITS = {
+  maxFiles: 25,
+  maxAddedLines: 800,
+  maxRemovedLines: 600,
+  // Paths an autonomous self-improvement may not silently rewrite.
+  protectedPaths: [
+    /(^|\/)\.github\//i,
+    /(^|\/)package-lock\.json$/i,
+    /(^|\/)yarn\.lock$/i,
+    /(^|\/)pnpm-lock\.yaml$/i,
+    /(^|\/)Cargo\.lock$/i,
+    /(^|\/)poetry\.lock$/i,
+  ],
+};
+
+export class DiffBoundsJudge {
+  constructor({ privateKeyPem, publicKeyPem, limits = {}, now = () => new Date() } = {}) {
+    const generated = privateKeyPem && publicKeyPem ? null : generateJudgeKeyPair();
+    this.privateKeyPem = privateKeyPem || generated.privateKeyPem;
+    this.publicKeyPem = publicKeyPem || generated.publicKeyPem;
+    this.limits = {
+      ...DEFAULT_LIMITS,
+      ...limits,
+      protectedPaths: limits.protectedPaths || DEFAULT_LIMITS.protectedPaths,
+    };
+    this.now = now;
+  }
+
+  judge(request) {
+    const normalized = canonicalize(request || {});
+    const diffText = normalized.diff || normalized.patch || "";
+    const files = diffText ? parseUnifiedDiff(diffText) : [];
+
+    const checks = [
+      this.checkParseable(diffText, files),
+      this.checkSize(files),
+      this.checkTestIntegrity(files),
+      this.checkProtectedPaths(files, normalized),
+    ];
+
+    const passed = checks.every((check) => check.passed);
+    const verdict = {
+      judge_id: JUDGE_ID,
+      interface: "Judge.judge(request)->(passed,reasons)",
+      passed,
+      reasons: checks.filter((check) => !check.passed).map((check) => check.reason),
+      checks,
+      stats: this.summarize(files),
+      limits: {
+        maxFiles: this.limits.maxFiles,
+        maxAddedLines: this.limits.maxAddedLines,
+        maxRemovedLines: this.limits.maxRemovedLines,
+      },
+      request_hash: sha256Hex(canonicalJson(normalized)),
+      issued_at: this.now().toISOString(),
+    };
+    return this.signVerdict(verdict);
+  }
+
+  summarize(files) {
+    return {
+      files: files.length,
+      added: files.reduce((n, f) => n + f.added, 0),
+      removed: files.reduce((n, f) => n + f.removed, 0),
+    };
+  }
+
+  signVerdict(verdict) {
+    const envelope = {
+      verdict: canonicalize(verdict),
+      signature_algorithm: "Ed25519",
+      public_key_pem: this.publicKeyPem,
+    };
+    return {
+      ...envelope,
+      signature: signCanonical(this.privateKeyPem, envelope),
+    };
+  }
+
+  verify(signedVerdict) {
+    const { signature, ...payload } = signedVerdict;
+    return verifyCanonical(signedVerdict.public_key_pem, payload, signature);
+  }
+
+  // --- individual checks ---------------------------------------------------
+
+  checkParseable(diffText, files) {
+    const passed = typeof diffText === "string" && diffText.trim().length > 0 && files.length > 0;
+    return {
+      id: "parseable",
+      passed,
+      reason: passed
+        ? "request carries a well-formed unified diff"
+        : "request must include a non-empty unified `diff`/`patch` (no parseable file headers found)",
+    };
+  }
+
+  checkSize(files) {
+    const { added, removed, files: n } = this.summarize(files);
+    const within =
+      n <= this.limits.maxFiles &&
+      added <= this.limits.maxAddedLines &&
+      removed <= this.limits.maxRemovedLines;
+    return {
+      id: "size",
+      passed: within,
+      reason: within
+        ? `change is within bounds (${n} files, +${added}/-${removed})`
+        : `change exceeds bounds: ${n}/${this.limits.maxFiles} files, ` +
+          `+${added}/${this.limits.maxAddedLines} added, -${removed}/${this.limits.maxRemovedLines} removed`,
+    };
+  }
+
+  checkTestIntegrity(files) {
+    const offenders = [];
+    let netAssertions = 0;
+    for (const f of files) {
+      if (!isTestPath(f.path)) continue;
+      if (f.isDeleted) offenders.push(`deletes test file ${f.path}`);
+      netAssertions += f.addedAssertions - f.removedAssertions;
+    }
+    if (netAssertions < 0) {
+      offenders.push(`net removal of ${-netAssertions} test assertion(s)`);
+    }
+    const passed = offenders.length === 0;
+    return {
+      id: "test_integrity",
+      passed,
+      reason: passed
+        ? "diff does not delete tests or strip assertions"
+        : `diff weakens the test suite: ${offenders.join("; ")}`,
+    };
+  }
+
+  checkProtectedPaths(files, request) {
+    const allow = Array.isArray(request.allow_protected) ? request.allow_protected : [];
+    const offenders = files
+      .map((f) => f.path)
+      .filter((p) => this.limits.protectedPaths.some((re) => re.test(p)))
+      .filter((p) => !allow.includes(p));
+    const passed = offenders.length === 0;
+    return {
+      id: "protected_paths",
+      passed,
+      reason: passed
+        ? "diff does not touch protected paths"
+        : `diff edits protected paths without allow_protected: ${offenders.join(", ")}`,
+    };
+  }
+}
+
+export function createJudge(options = {}) {
+  return new DiffBoundsJudge(options);
+}

--- a/submissions/14382-diff-bounds-judge/gate-server.mjs
+++ b/submissions/14382-diff-bounds-judge/gate-server.mjs
@@ -1,0 +1,44 @@
+import http from "node:http";
+
+import { createJudge } from "./diff-bounds-judge.mjs";
+
+// Reference gate adapter — plugs the Diff-Bounds Judge into the open staking
+// rails unmodified: POST /judge -> signed verdict envelope; GET /health.
+const judge = createJudge({
+  privateKeyPem: process.env.JUDGE_PRIVATE_KEY_PEM,
+  publicKeyPem: process.env.JUDGE_PUBLIC_KEY_PEM,
+});
+
+async function readJson(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw ? JSON.parse(raw) : {};
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.method === "GET" && req.url === "/health") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, judge: "diff-bounds-judge" }));
+      return;
+    }
+    if (req.method !== "POST" || req.url !== "/judge") {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "not_found" }));
+      return;
+    }
+    const request = await readJson(req);
+    const signedVerdict = judge.judge(request);
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(signedVerdict, null, 2));
+  } catch (error) {
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "bad_request", message: error.message }));
+  }
+});
+
+const port = Number(process.env.PORT || 8788);
+server.listen(port, () => {
+  console.log(`diff-bounds judge listening on http://127.0.0.1:${port}/judge`);
+});

--- a/submissions/14382-diff-bounds-judge/package.json
+++ b/submissions/14382-diff-bounds-judge/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@community/diff-bounds-judge",
+  "version": "1.0.0",
+  "description": "A diff-geometry gate for the open Judge interface: bounds change size and forbids deleting tests or editing protected paths.",
+  "type": "module",
+  "main": "diff-bounds-judge.mjs",
+  "scripts": {
+    "test": "node --test",
+    "serve": "node gate-server.mjs"
+  },
+  "license": "MIT"
+}

--- a/submissions/14382-diff-bounds-judge/test.mjs
+++ b/submissions/14382-diff-bounds-judge/test.mjs
@@ -1,0 +1,161 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+
+import {
+  createJudge,
+  generateJudgeKeyPair,
+  parseUnifiedDiff,
+  verifyCanonical,
+  canonicalJson,
+} from "./diff-bounds-judge.mjs";
+
+// Fixed key pair so verdicts are reproducible across instances.
+const KEYS = generateJudgeKeyPair();
+const fixedNow = () => new Date("2026-06-26T00:00:00.000Z");
+
+function makeJudge(limits = {}) {
+  return createJudge({ ...KEYS, limits, now: fixedNow });
+}
+
+const SMALL_CLEAN_DIFF = `diff --git a/src/util.js b/src/util.js
+--- a/src/util.js
++++ b/src/util.js
+@@ -1,3 +1,4 @@
+ export function add(a, b) {
+-  return a + b;
++  return Number(a) + Number(b);
+ }
++export const VERSION = "1.1.0";
+diff --git a/tests/util.test.js b/tests/util.test.js
+--- a/tests/util.test.js
++++ b/tests/util.test.js
+@@ -1,2 +1,4 @@
+ import { add } from "../src/util.js";
++test("coerces strings", () => { expect(add("1", "2")).toBe(3); });
++test("adds numbers", () => { expect(add(1, 2)).toBe(3); });
+`;
+
+test("happy path: small, test-positive diff passes", () => {
+  const v = makeJudge().judge({ summary: "harden add()", diff: SMALL_CLEAN_DIFF });
+  assert.equal(v.verdict.passed, true, JSON.stringify(v.verdict.reasons));
+  assert.equal(v.verdict.stats.files, 2);
+  assert.ok(v.verdict.stats.added > 0);
+});
+
+test("signed verdict verifies, and tampering breaks verification", () => {
+  const judge = makeJudge();
+  const v = judge.judge({ summary: "x", diff: SMALL_CLEAN_DIFF });
+  assert.equal(judge.verify(v), true);
+
+  // Tamper with the verdict body -> signature no longer matches.
+  const tampered = structuredClone(v);
+  tampered.verdict.passed = !tampered.verdict.passed;
+  assert.equal(judge.verify(tampered), false);
+});
+
+test("forged / mismatched public key fails verification (MITM / forgery)", () => {
+  const judge = makeJudge();
+  const v = judge.judge({ summary: "x", diff: SMALL_CLEAN_DIFF });
+  const attacker = generateJudgeKeyPair();
+  const { signature, ...payload } = { ...v, public_key_pem: attacker.publicKeyPem };
+  // Verifying the real signature against the attacker's key must fail.
+  assert.equal(verifyCanonical(attacker.publicKeyPem, payload, signature), false);
+});
+
+test("empty / gate-down request fails parseable check", () => {
+  const v = makeJudge().judge({ summary: "nothing here" });
+  assert.equal(v.verdict.passed, false);
+  assert.ok(v.verdict.checks.find((c) => c.id === "parseable").passed === false);
+});
+
+test("oversized change exceeds size bounds", () => {
+  const body = Array.from({ length: 50 }, (_, i) => `+line ${i}`).join("\n");
+  const big = `diff --git a/src/big.js b/src/big.js
+--- a/src/big.js
++++ b/src/big.js
+@@ -0,0 +1,50 @@
+${body}
+`;
+  const v = makeJudge({ maxAddedLines: 10 }).judge({ summary: "huge", diff: big });
+  assert.equal(v.verdict.passed, false);
+  assert.equal(v.verdict.checks.find((c) => c.id === "size").passed, false);
+});
+
+test("too many files exceeds size bounds", () => {
+  const diff = Array.from({ length: 5 }, (_, i) =>
+    `diff --git a/src/f${i}.js b/src/f${i}.js\n--- a/src/f${i}.js\n+++ b/src/f${i}.js\n@@ -0,0 +1 @@\n+const x = ${i};`,
+  ).join("\n");
+  const v = makeJudge({ maxFiles: 3 }).judge({ summary: "many", diff });
+  assert.equal(v.verdict.checks.find((c) => c.id === "size").passed, false);
+});
+
+test("deleting a test file fails test_integrity", () => {
+  const diff = `diff --git a/tests/core.test.js b/tests/core.test.js
+deleted file mode 100644
+--- a/tests/core.test.js
++++ /dev/null
+@@ -1,2 +0,0 @@
+-test("keeps working", () => { expect(1).toBe(1); });
+-test("still works", () => { expect(2).toBe(2); });
+`;
+  const v = makeJudge().judge({ summary: "drop tests", diff });
+  assert.equal(v.verdict.passed, false);
+  assert.equal(v.verdict.checks.find((c) => c.id === "test_integrity").passed, false);
+});
+
+test("net removal of assertions fails test_integrity", () => {
+  const diff = `diff --git a/tests/core.test.js b/tests/core.test.js
+--- a/tests/core.test.js
++++ b/tests/core.test.js
+@@ -1,4 +1,2 @@
+ import { f } from "../src/f.js";
+-test("a", () => { expect(f(1)).toBe(1); });
+-test("b", () => { expect(f(2)).toBe(2); });
++// removed the failing tests to make the gate green
+`;
+  const v = makeJudge().judge({ summary: "gaming", diff });
+  assert.equal(v.verdict.checks.find((c) => c.id === "test_integrity").passed, false);
+});
+
+test("editing a protected path fails, but allow_protected overrides", () => {
+  const diff = `diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1,1 +1,1 @@
+-      run: npm test
++      run: echo skip
+`;
+  const blocked = makeJudge().judge({ summary: "disable ci", diff });
+  assert.equal(blocked.verdict.checks.find((c) => c.id === "protected_paths").passed, false);
+
+  const allowed = makeJudge().judge({
+    summary: "intended ci change",
+    diff,
+    allow_protected: [".github/workflows/ci.yml"],
+  });
+  assert.equal(allowed.verdict.checks.find((c) => c.id === "protected_paths").passed, true);
+});
+
+test("parseUnifiedDiff counts added/removed and flags new/deleted files", () => {
+  const files = parseUnifiedDiff(SMALL_CLEAN_DIFF);
+  assert.equal(files.length, 2);
+  const util = files.find((f) => f.path === "src/util.js");
+  assert.equal(util.added, 2);
+  assert.equal(util.removed, 1);
+});
+
+test("canonical JSON sorts keys deterministically", () => {
+  assert.equal(canonicalJson({ b: 1, a: 2 }), canonicalJson({ a: 2, b: 1 }));
+  assert.equal(canonicalJson({ b: 1, a: 2 }), '{"a":2,"b":1}');
+});
+
+test("verdict signature is reproducible for identical input", () => {
+  const a = createJudge({ ...KEYS, now: fixedNow }).judge({ summary: "x", diff: SMALL_CLEAN_DIFF });
+  const b = createJudge({ ...KEYS, now: fixedNow }).judge({ summary: "x", diff: SMALL_CLEAN_DIFF });
+  assert.equal(a.signature, b.signature);
+  assert.equal(
+    crypto.createHash("sha256").update(a.signature).digest("hex"),
+    crypto.createHash("sha256").update(b.signature).digest("hex"),
+  );
+});

--- a/submissions/14382-diff-bounds-judge/test.mjs
+++ b/submissions/14382-diff-bounds-judge/test.mjs
@@ -159,3 +159,29 @@ test("verdict signature is reproducible for identical input", () => {
     crypto.createHash("sha256").update(b.signature).digest("hex"),
   );
 });
+
+test("private-key-only construction derives a matching public key (documented flow)", () => {
+  // Reproduces the JUDGE_PRIVATE_KEY_PEM-only server command: supply ONLY the
+  // private key. The advertised public key must verify the signature.
+  const judge = createJudge({ privateKeyPem: KEYS.privateKeyPem, now: fixedNow });
+  const signed = judge.judge({ summary: "x", diff: SMALL_CLEAN_DIFF });
+
+  // Advertised key is derived from the supplied private key, not a fresh one.
+  const expectedPub = crypto
+    .createPublicKey(KEYS.privateKeyPem)
+    .export({ type: "spki", format: "pem" });
+  assert.equal(signed.public_key_pem, expectedPub);
+
+  // And the verdict actually verifies under the advertised key.
+  const { signature, ...payload } = signed;
+  assert.ok(verifyCanonical(signed.public_key_pem, payload, signature));
+});
+
+test("header-only diff (no @@ hunk) fails parseable", () => {
+  const headerOnly = "diff --git a/src/x.js b/src/x.js\n";
+  const v = makeJudge().judge({ summary: "noop", diff: headerOnly });
+  assert.equal(v.verdict.passed, false);
+  const parseable = v.verdict.checks.find((c) => c.id === "parseable");
+  assert.equal(parseable.passed, false);
+  assert.match(parseable.reason, /no `@@` hunk|header-only/);
+});


### PR DESCRIPTION
Bounty claim/submission for #14382 (multi-claim). PR adds a **distinct, non-overlapping** judge for the open `Judge` interface.

## Diff-Bounds Judge
The three suggested ideas (policy / test-runner / static-analysis) are already taken, so this is a fourth, genuinely separate judge. It reasons about the **geometry and containment of the diff itself** — it does NOT run tests, does NOT lint/AST, and does NOT apply a content policy. It is meant to run *alongside* the others.

### Why it matters
An agent staking RTC to self-improve has an incentive to game the gate: delete the failing tests, strip assertions, quietly disable CI, or dump an unreviewably huge change. Content/lint/test judges don't catch those by themselves. This judge closes that gap.

### Checks (request carries a unified `diff`/`patch`)
1. **parseable** — well-formed unified diff present
2. **size** — within `maxFiles`/`maxAddedLines`/`maxRemovedLines` (configurable)
3. **test_integrity** — no test-file deletion, no net removal of assertions (`assert*`/`expect`/`it(`/`test(`)
4. **protected_paths** — no silent edits to `.github/` or lockfiles unless `allow_protected` whitelists them

### Acceptance
- ✅ Implements `Judge.judge(request) -> (passed, reasons)`; plugs into the reference gate server unmodified (`gate-server.mjs`: `POST /judge` + `GET /health`)
- ✅ Signs verdicts with its own **Ed25519** key in the same canonical-JSON envelope (sorted keys) the SDK verifies — `verify()` passes, tampering and forged keys fail
- ✅ Tests + README on what it judges and its limits

### Validation
`node --test` → **12 passed / 0 failed** (happy path, oversize, too-many-files, test deletion, assertion stripping, protected paths, tamper detection, forged-key rejection, canonical determinism). Dependency-free (Node `crypto` only). Gate server smoke-tested: `/health` 200, `POST /judge` returns a signed verdict.

Files: `submissions/14382-diff-bounds-judge/` (judge, gate-server, package.json, test.mjs, README).

RTC wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`

— Bohdan