### PR TITLE
Add JUnit artifact Judge for community gate

### DIFF
--- a/community/judges/junit-artifact-judge/README.md
+++ b/community/judges/junit-artifact-judge/README.md
@@ -1,0 +1,48 @@
+# JUnit Artifact Judge
+
+This is a community implementation of the open `Judge` interface for bounty
+#14382. It judges submitted JUnit XML test artifacts rather than executing
+untrusted code.
+
+## What It Judges
+
+- Accepts legacy `junit_xml` payloads and nested `test_artifacts.junit_xml`.
+- Passes only when at least one test is reported and there are zero failures
+  and zero errors.
+- Returns `(passed, reasons)` through the exported `judge(request)` function.
+- Provides a small `POST /judge` adapter for reference gate servers that call a
+  local HTTP judge.
+- Signs verdict envelopes with an Ed25519 key using Node's built-in `crypto`
+  module.
+
+## Run
+
+```bash
+node community/judges/junit-artifact-judge/test.mjs
+```
+
+To run the HTTP adapter, provide a PEM-encoded Ed25519 private key:
+
+```bash
+export JUNIT_JUDGE_PRIVATE_KEY_PEM="$(cat ed25519-private.pem)"
+node community/judges/junit-artifact-judge/judge.mjs
+```
+
+Then post:
+
+```json
+{
+  "junit_xml": "<testsuite tests=\"1\" failures=\"0\" errors=\"0\"><testcase name=\"ok\"/></testsuite>"
+}
+```
+
+## Limits
+
+This judge does not execute tests, inspect source code, or verify that the XML
+artifact came from a trusted CI system. It is intentionally narrow: use it only
+as a gate for already-produced test result artifacts, and combine it with CI
+provenance checks when the source of the artifact matters.
+
+## Wallet
+
+RTC payout wallet: qiann0512-gif

--- a/community/judges/junit-artifact-judge/judge.mjs
+++ b/community/judges/junit-artifact-judge/judge.mjs
@@ -1,0 +1,194 @@
+import crypto from "node:crypto";
+import http from "node:http";
+
+const DEFAULT_PORT = 8787;
+const MAX_XML_BYTES = 512 * 1024;
+
+function asText(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function attrNumber(attrs, name) {
+  const match = attrs.match(new RegExp(`\\b${name}\\s*=\\s*["']([^"']+)["']`, "i"));
+  if (!match) return 0;
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+export function extractJunitXml(request = {}) {
+  const direct = asText(request.junit_xml);
+  if (direct) return direct;
+
+  const artifacts = request.artifacts || request.test_artifacts || {};
+  if (typeof artifacts === "string") return artifacts;
+  if (artifacts && typeof artifacts === "object") {
+    return asText(artifacts.junit_xml || artifacts.junit || artifacts.xml);
+  }
+  return "";
+}
+
+export function parseJunitSummary(xml) {
+  if (!xml || typeof xml !== "string") {
+    throw new Error("missing_junit_xml");
+  }
+  if (Buffer.byteLength(xml, "utf8") > MAX_XML_BYTES) {
+    throw new Error("junit_xml_too_large");
+  }
+
+  const suiteMatches = [...xml.matchAll(/<testsuite\b([^>]*)>/gi)];
+  const testcaseCount = (xml.match(/<testcase\b/gi) || []).length;
+
+  let tests = 0;
+  let failures = 0;
+  let errors = 0;
+  let skipped = 0;
+
+  for (const match of suiteMatches) {
+    const attrs = match[1] || "";
+    tests += attrNumber(attrs, "tests");
+    failures += attrNumber(attrs, "failures");
+    errors += attrNumber(attrs, "errors");
+    skipped += attrNumber(attrs, "skipped");
+  }
+
+  if (suiteMatches.length === 0) {
+    tests = testcaseCount;
+    failures = (xml.match(/<failure\b/gi) || []).length;
+    errors = (xml.match(/<error\b/gi) || []).length;
+    skipped = (xml.match(/<skipped\b/gi) || []).length;
+  }
+
+  return {
+    suites: suiteMatches.length,
+    tests,
+    failures,
+    errors,
+    skipped,
+    testcase_count: testcaseCount,
+  };
+}
+
+export function judge(request = {}) {
+  const reasons = [];
+  let summary;
+
+  try {
+    summary = parseJunitSummary(extractJunitXml(request));
+  } catch (error) {
+    return [false, [`JUnit artifact rejected: ${error.message}`]];
+  }
+
+  if (summary.tests <= 0 && summary.testcase_count <= 0) {
+    return [false, ["JUnit artifact rejected: no executed tests were reported"]];
+  }
+
+  if (summary.failures > 0 || summary.errors > 0) {
+    reasons.push(
+      `JUnit artifact rejected: ${summary.failures} failure(s), ${summary.errors} error(s) across ${summary.tests || summary.testcase_count} test(s)`,
+    );
+    return [false, reasons];
+  }
+
+  reasons.push(
+    `JUnit artifact accepted: ${summary.tests || summary.testcase_count} test(s) passed with no failures or errors`,
+  );
+  if (summary.skipped > 0) {
+    reasons.push(`Informational: ${summary.skipped} test(s) were skipped`);
+  }
+  return [true, reasons];
+}
+
+export function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function createEphemeralKeyPair() {
+  return crypto.generateKeyPairSync("ed25519");
+}
+
+export function privateKeyFromEnv() {
+  const pem = process.env.JUNIT_JUDGE_PRIVATE_KEY_PEM;
+  if (!pem) return null;
+  return crypto.createPrivateKey(pem.replace(/\\n/g, "\n"));
+}
+
+export function signVerdict(verdict, privateKey = privateKeyFromEnv()) {
+  if (!privateKey) {
+    throw new Error("missing_ed25519_private_key");
+  }
+  const payload = canonicalJson(verdict);
+  return crypto.sign(null, Buffer.from(payload), privateKey).toString("base64");
+}
+
+export function verifyVerdict(verdict, signature, publicKey) {
+  const payload = canonicalJson(verdict);
+  return crypto.verify(
+    null,
+    Buffer.from(payload),
+    publicKey,
+    Buffer.from(signature, "base64"),
+  );
+}
+
+export function createSignedVerdict(request, privateKey = privateKeyFromEnv()) {
+  const [passed, reasons] = judge(request);
+  const verdict = {
+    judge: "junit-artifact-judge",
+    passed,
+    reasons,
+    summary: parseJunitSummary(extractJunitXml(request)),
+    issued_at: new Date().toISOString(),
+  };
+  return {
+    ...verdict,
+    signature_algorithm: "Ed25519",
+    signature: signVerdict(verdict, privateKey),
+  };
+}
+
+export function createServer({ privateKey = privateKeyFromEnv() } = {}) {
+  return http.createServer((req, res) => {
+    if (req.method !== "POST" || req.url !== "/judge") {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "not_found" }));
+      return;
+    }
+
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      body += chunk;
+      if (Buffer.byteLength(body, "utf8") > MAX_XML_BYTES * 2) {
+        req.destroy(new Error("request_too_large"));
+      }
+    });
+    req.on("end", () => {
+      try {
+        const request = body ? JSON.parse(body) : {};
+        const verdict = createSignedVerdict(request, privateKey);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(verdict));
+      } catch (error) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: error.message }));
+      }
+    });
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = Number(process.env.PORT || DEFAULT_PORT);
+  const server = createServer();
+  server.listen(port, () => {
+    console.log(`junit-artifact-judge listening on :${port}`);
+  });
+}

--- a/community/judges/junit-artifact-judge/test.mjs
+++ b/community/judges/junit-artifact-judge/test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canonicalJson,
+  createEphemeralKeyPair,
+  createSignedVerdict,
+  judge,
+  parseJunitSummary,
+  verifyVerdict,
+} from "./judge.mjs";
+
+const GREEN_XML = `
+<testsuites>
+  <testsuite name="unit" tests="3" failures="0" errors="0" skipped="1">
+    <testcase classname="a" name="one"/>
+    <testcase classname="a" name="two"/>
+    <testcase classname="a" name="three"><skipped/></testcase>
+  </testsuite>
+</testsuites>`;
+
+const RED_XML = `
+<testsuite name="unit" tests="2" failures="1" errors="1">
+  <testcase classname="a" name="one"><failure>boom</failure></testcase>
+  <testcase classname="a" name="two"><error>bad</error></testcase>
+</testsuite>`;
+
+test("passes green JUnit XML artifacts", () => {
+  const [passed, reasons] = judge({ junit_xml: GREEN_XML });
+  assert.equal(passed, true);
+  assert.match(reasons.join(" "), /3 test\(s\) passed/);
+});
+
+test("rejects failing JUnit XML artifacts", () => {
+  const [passed, reasons] = judge({ test_artifacts: { junit_xml: RED_XML } });
+  assert.equal(passed, false);
+  assert.match(reasons.join(" "), /1 failure\(s\), 1 error\(s\)/);
+});
+
+test("rejects empty or missing artifacts", () => {
+  assert.equal(judge({})[0], false);
+  assert.equal(judge({ junit_xml: "<testsuite tests=\"0\"/>" })[0], false);
+});
+
+test("parses testcase-only XML fallback", () => {
+  const summary = parseJunitSummary("<testcase/><testcase><failure/></testcase>");
+  assert.deepEqual(summary, {
+    suites: 0,
+    tests: 2,
+    failures: 1,
+    errors: 0,
+    skipped: 0,
+    testcase_count: 2,
+  });
+});
+
+test("canonical JSON is key-order stable", () => {
+  assert.equal(canonicalJson({ b: 2, a: 1 }), canonicalJson({ a: 1, b: 2 }));
+});
+
+test("signed verdict verifies with Ed25519 public key", () => {
+  const { privateKey, publicKey } = createEphemeralKeyPair();
+  const signed = createSignedVerdict({ junit_xml: GREEN_XML }, privateKey);
+  const { signature, signature_algorithm, ...verdict } = signed;
+
+  assert.equal(signature_algorithm, "Ed25519");
+  assert.equal(typeof signature, "string");
+  assert.equal(verifyVerdict(verdict, signature, publicKey), true);
+});


### PR DESCRIPTION
## Summary
- add a distinct JUnit artifact Judge implementation for bounty #14382
- judge(request) accepts raw or nested JUnit XML artifacts and returns (passed, reasons)
- reject missing, empty, failing, errored, or oversized artifacts without executing untrusted code
- sign verdict envelopes with Ed25519 using Node's built-in crypto module
- include a small POST /judge adapter plus README describing scope and limits

## Validation
- /Users/qiann/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node community/judges/junit-artifact-judge/test.mjs

## Wallet
qiann0512-gif