### PR TITLE
Secret-Leak Judge — distinct community gate for the open Judge interface (bounty #14382)

### DIFF
--- a/submissions/14382-secret-leak-judge/README.md
+++ b/submissions/14382-secret-leak-judge/README.md
@@ -1,0 +1,136 @@
+# Secret-Leak Judge
+
+A community gate for the open **Judge** interface (`judge(request) -> (passed, reasons)`)
+on the staking self-improvement rails. Submitted for **Bounty #14382** (multi-claim).
+
+This is a **distinct, non-overlapping** judge. It judges *only one thing*: whether
+a self-improvement diff **introduces a hardcoded secret in its added lines**. It is
+meant to run **alongside** the other community judges, not replace them:
+
+| Judge | What it checks | This one? |
+|-------|----------------|-----------|
+| Diff-bounds judge | size limits + anti-test-deletion + protected paths | ❌ different |
+| Test-runner judge | runs the suite, passes iff green | ❌ different |
+| Static-analysis judge | lint / AST checks on the code | ❌ different |
+| Dependency-policy judge | allowed/blocked dependency sets | ❌ different |
+| **Secret-Leak judge** | **no hardcoded keys / tokens / credentials in added lines** | ✅ |
+
+## Why this judge exists
+
+An autonomous agent that stakes RTC to "self-improve" rewrites its own source. One
+careless edit and a private key, an AWS secret, a vendor token or a password literal
+lands in the repo — and from there into git history forever, where rotation is the
+only remedy. A size judge, a lint judge or a test-runner judge will happily pass such
+a change: the code still builds, still lints, still goes green. This judge closes that
+gap by scanning the **content that was added**.
+
+It only inspects **added (`+`) lines** — *removing* a secret (e.g. replacing a
+hardcoded password with `os.environ[...]`) is exactly what you want and passes.
+
+## What it checks
+
+Given a request carrying a unified `diff` (or `patch`), it runs two checks:
+
+1. **parseable** — the request actually contains a well-formed unified diff (a file
+   header **and** at least one `@@` hunk). Header-only/empty input is rejected so it
+   can never trivially "pass" with nothing scanned.
+2. **no_hardcoded_secrets** — none of the added lines match a high-confidence secret
+   rule. The rules are vendor-anchored or structurally specific to keep false
+   positives low:
+
+   | rule | catches |
+   |------|---------|
+   | `private_key_block` | `-----BEGIN ... PRIVATE KEY-----` (RSA/EC/OpenSSH/PGP/…) |
+   | `aws_access_key_id` | `AKIA…` / `ASIA…` access key ids |
+   | `github_token` | `ghp_…`, `gho_…`, `github_pat_…` |
+   | `slack_token` | `xoxb-…`, `xoxp-…`, `xoxa/r/s-…` |
+   | `google_api_key` | `AIza…` |
+   | `stripe_secret_key` | `sk_live_…`, `rk_live_…`, `sk_test_…` |
+   | `openai_key` | `sk-…`, `sk-proj-…`, `sk-ant-…` |
+   | `basic_auth_url` | `scheme://user:password@host` |
+   | `hardcoded_credential_assignment` | `password`/`secret`/`api_key`/`token`/… `= "literal"` |
+
+### False-positive guards
+
+The credential-assignment and URL rules **do not** fire when the value is:
+
+- a placeholder — `changeme`, `<your-api-key>`, `xxxxxxxx`, `${VAULT_SECRET}`,
+  `{{ ... }}`, `example`, `dummy`, `redacted`, …
+- an environment / config reference — `process.env.X`, `os.environ[...]`,
+  `getenv(...)`, `config.*`, `vault.*`, `${ENV_VAR}`, …
+
+An explicit `allow_secrets: ["path/to/file", "substring", ...]` in the request
+whitelists an intended addition (e.g. a **public** test fixture or a key the
+project genuinely ships). An entry matches either the file path or a substring of
+the offending line.
+
+The verdict never echoes a live secret back: any long token in a finding's
+`snippet` is **redacted** (`ghp_…cd[redacted 40 chars]`).
+
+## Interface compatibility
+
+`createJudge(options).judge(request)` returns a signed verdict envelope in the same
+canonical JSON shape (sorted keys, no whitespace) used across the staking rails, so
+the open SDK's Ed25519 verification passes byte-for-byte:
+
+```json
+{
+  "verdict": {
+    "judge_id": "secret-leak-judge-v1",
+    "interface": "Judge.judge(request)->(passed,reasons)",
+    "passed": false,
+    "reasons": ["added lines introduce 1 hardcoded secret(s): AWS access key id in deploy.sh (+line 1)"],
+    "checks": [ ... ],
+    "findings": [{ "rule": "aws_access_key_id", "label": "AWS access key id", "path": "deploy.sh", "added_line": 1, "snippet": "..." }],
+    "stats": { "files": 1, "added_lines": 1, "secrets_found": 1 }
+  },
+  "signature_algorithm": "Ed25519",
+  "public_key_pem": "-----BEGIN PUBLIC KEY-----\n...",
+  "signature": "<base64>"
+}
+```
+
+`judge.verify(signedVerdict)` re-derives the canonical payload and checks the
+signature against the embedded public key — identical to what the SDK does against
+the gate pubkey. Tampering with any field, or substituting a forged key, fails
+verification (fail-safe against MITM/forgery).
+
+### Keys
+
+Configure the gate with **only** a private key — the advertised public key is
+*derived* from it (`crypto.createPublicKey`), so the documented `JUDGE_PRIVATE_KEY_PEM`-only
+server flow is always self-consistent:
+
+```bash
+JUDGE_PRIVATE_KEY_PEM="$(cat judge.key)" node gate-server.mjs
+```
+
+With no key configured, a fresh Ed25519 pair is generated at startup (handy for
+local/dev). Supplying only a public key gives a verify-only instance.
+
+## Run it
+
+```bash
+node --test          # 19 tests: happy path, each detector, placeholder/env guards,
+                     # removal-is-ok, allow_secrets, redaction, forged-key, reproducibility
+node gate-server.mjs # POST /judge -> signed verdict; GET /health
+```
+
+```bash
+curl -s -X POST http://127.0.0.1:8789/judge -H 'content-type: application/json' \
+  -d '{"summary":"add deploy key","diff":"diff --git a/deploy.sh b/deploy.sh\n--- a/deploy.sh\n+++ b/deploy.sh\n@@ -1,1 +1,2 @@\n #!/bin/sh\n+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n"}'
+# -> verdict.passed = false, findings[0].rule = "aws_access_key_id"
+```
+
+## Limits (honest scope)
+
+- It is a **lexical** scanner over added diff lines, not a data-flow analysis. It
+  targets *committed* secrets (the common, high-impact mistake), not secrets that are
+  computed/assembled at runtime.
+- High-confidence rules favour precision over recall: a bespoke in-house token format
+  with no recognizable prefix and a generic variable name may pass. It is a gate
+  against the **obvious, irreversible** leak, complementary to the other judges — not
+  a replacement for a full secret-scanning product.
+- Dependency-free, Node ≥ 16 (`node:crypto` Ed25519). MIT.
+
+— submitted by `@Vyacheslav-Tomashevskiy`

--- a/submissions/14382-secret-leak-judge/gate-server.mjs
+++ b/submissions/14382-secret-leak-judge/gate-server.mjs
@@ -1,0 +1,44 @@
+import http from "node:http";
+
+import { createJudge } from "./secret-leak-judge.mjs";
+
+// Reference gate adapter — plugs the Secret-Leak Judge into the open staking
+// rails unmodified: POST /judge -> signed verdict envelope; GET /health.
+const judge = createJudge({
+  privateKeyPem: process.env.JUDGE_PRIVATE_KEY_PEM,
+  publicKeyPem: process.env.JUDGE_PUBLIC_KEY_PEM,
+});
+
+async function readJson(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw ? JSON.parse(raw) : {};
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.method === "GET" && req.url === "/health") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, judge: "secret-leak-judge" }));
+      return;
+    }
+    if (req.method !== "POST" || req.url !== "/judge") {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "not_found" }));
+      return;
+    }
+    const request = await readJson(req);
+    const signedVerdict = judge.judge(request);
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(signedVerdict, null, 2));
+  } catch (error) {
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "bad_request", message: error.message }));
+  }
+});
+
+const port = Number(process.env.PORT || 8789);
+server.listen(port, () => {
+  console.log(`secret-leak judge listening on http://127.0.0.1:${port}/judge`);
+});

--- a/submissions/14382-secret-leak-judge/package.json
+++ b/submissions/14382-secret-leak-judge/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@community/secret-leak-judge",
+  "version": "1.0.0",
+  "description": "A secret-scanning gate for the open Judge interface: fails any self-improvement diff whose added lines introduce hardcoded private keys, vendor tokens or credential literals.",
+  "type": "module",
+  "main": "secret-leak-judge.mjs",
+  "scripts": {
+    "test": "node --test",
+    "serve": "node gate-server.mjs"
+  },
+  "license": "MIT"
+}

--- a/submissions/14382-secret-leak-judge/secret-leak-judge.mjs
+++ b/submissions/14382-secret-leak-judge/secret-leak-judge.mjs
@@ -1,0 +1,334 @@
+import crypto from "node:crypto";
+
+// Secret-Leak Judge — a distinct, non-overlapping community gate for the open
+// Judge interface (`judge(request) -> (passed, reasons)`).
+//
+// It judges ONLY one thing: whether a self-improvement diff *introduces
+// hardcoded secrets / credentials* in its ADDED lines. An autonomous agent that
+// edits its own code to "improve" is one slip away from committing a private
+// key, an AWS secret, a vendor token or a password literal straight into the
+// repository — and from there into history forever. This judge fails such a
+// change fail-safe.
+//
+// It deliberately does NOT bound diff size (that is a diff-bounds judge), does
+// NOT run the test suite (a test-runner judge), and does NOT do lint/AST
+// analysis (a static-analysis judge). Those are separate, complementary gates.
+
+export const JUDGE_ID = "secret-leak-judge-v1";
+
+// ---------------------------------------------------------------------------
+// Canonical JSON + Ed25519 envelope — byte-for-byte compatible with the open
+// SDK and the reference gate server (sorted keys, no whitespace).
+// ---------------------------------------------------------------------------
+
+export function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value && typeof value === "object" && value.constructor === Object) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function sha256Hex(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function generateJudgeKeyPair() {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  return {
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }),
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }),
+  };
+}
+
+// Derive the spki public-key PEM from an Ed25519 private-key PEM so that a judge
+// configured with only JUDGE_PRIVATE_KEY_PEM advertises the public key that
+// actually verifies its signatures (no fresh/unrelated key).
+export function derivePublicKeyPem(privateKeyPem) {
+  return crypto
+    .createPublicKey(privateKeyPem)
+    .export({ type: "spki", format: "pem" });
+}
+
+export function signCanonical(privateKeyPem, payload) {
+  return crypto
+    .sign(null, Buffer.from(canonicalJson(payload)), privateKeyPem)
+    .toString("base64");
+}
+
+export function verifyCanonical(publicKeyPem, payload, signatureBase64) {
+  return crypto.verify(
+    null,
+    Buffer.from(canonicalJson(payload)),
+    publicKeyPem,
+    Buffer.from(signatureBase64, "base64"),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Unified-diff parser (dependency-free). We only care about ADDED content:
+// removing a secret is fine, introducing one is not.
+// ---------------------------------------------------------------------------
+
+export function parseAddedLines(diffText) {
+  const files = [];
+  let current = null;
+  const lines = String(diffText).split(/\r?\n/);
+
+  const push = () => {
+    if (current) files.push(current);
+    current = null;
+  };
+
+  for (const line of lines) {
+    if (line.startsWith("diff --git ")) {
+      push();
+      const match = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+      const path = match ? match[2] : line.slice("diff --git ".length).trim();
+      current = { path, hunks: 0, added: [] };
+      continue;
+    }
+    if (!current) continue;
+
+    if (line.startsWith("@@")) current.hunks += 1;
+    else if (line.startsWith("rename to ")) current.path = line.slice("rename to ".length).trim();
+    else if (line.startsWith("+++ ")) {
+      const p = line.slice(4).trim();
+      if (p.startsWith("b/")) current.path = p.slice(2);
+    } else if (line.startsWith("+") && !line.startsWith("+++")) {
+      // Added line. Track 1-based added-line ordinal within the file for
+      // human-readable offender locations.
+      current.added.push({ text: line.slice(1), n: current.added.length + 1 });
+    }
+  }
+  push();
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Secret detectors. Each rule is high-confidence and vendor-anchored or
+// structurally specific to keep false positives low. Rules run only against
+// ADDED lines.
+// ---------------------------------------------------------------------------
+
+// A value that is obviously a placeholder, not a live secret.
+const PLACEHOLDER = /^(?:x{3,}|\.{3,}|\*{3,}|<[^>]*>|\$\{[^}]*\}|changeme|your[_-]?\w*|example|placeholder|dummy|test|fake|redacted|none|null|nil|todo|tbd|insert[_-]?\w*|replace[_-]?\w*|\{\{[^}]*\}\})$/i;
+
+// A right-hand side that references an environment variable / config lookup
+// rather than embedding a literal secret.
+const ENV_REFERENCE =
+  /(process\.env|os\.environ|getenv|System\.getenv|ENV\[|config\.|settings\.|secrets\.|vault\.|import\.meta\.env|\$\{?[A-Z][A-Z0-9_]*\}?)/;
+
+export const SECRET_RULES = [
+  {
+    id: "private_key_block",
+    label: "PEM private key material",
+    // Header line of a PEM private key block of any flavour.
+    test: (line) => /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP |ENCRYPTED )?PRIVATE KEY-----/.test(line),
+  },
+  {
+    id: "aws_access_key_id",
+    label: "AWS access key id",
+    test: (line) => /\b(?:AKIA|ASIA|AGPA|AIDA|AROA|ANPA)[0-9A-Z]{16}\b/.test(line),
+  },
+  {
+    id: "github_token",
+    label: "GitHub token",
+    test: (line) => /\b(?:ghp|gho|ghu|ghs|ghr)_[0-9A-Za-z]{36,}\b|\bgithub_pat_[0-9A-Za-z_]{60,}\b/.test(line),
+  },
+  {
+    id: "slack_token",
+    label: "Slack token",
+    test: (line) => /\bxox[baprs]-[0-9A-Za-z-]{10,}\b/.test(line),
+  },
+  {
+    id: "google_api_key",
+    label: "Google API key",
+    test: (line) => /\bAIza[0-9A-Za-z_\-]{35}\b/.test(line),
+  },
+  {
+    id: "stripe_secret_key",
+    label: "Stripe secret/restricted key",
+    test: (line) => /\b(?:sk|rk)_(?:live|test)_[0-9A-Za-z]{16,}\b/.test(line),
+  },
+  {
+    id: "openai_key",
+    label: "OpenAI / Anthropic-style API key",
+    test: (line) => /\bsk-(?:proj-|ant-)?[0-9A-Za-z_\-]{20,}\b/.test(line),
+  },
+  {
+    id: "basic_auth_url",
+    label: "credentials embedded in URL",
+    // scheme://user:password@host — flag only when the password is non-trivial
+    // and not an env reference.
+    test: (line) => {
+      const m = line.match(/\b[a-z][a-z0-9+.\-]*:\/\/[^\s/:@]+:([^\s/@]{4,})@/i);
+      if (!m) return false;
+      const pw = m[1];
+      return !PLACEHOLDER.test(pw) && !ENV_REFERENCE.test(pw);
+    },
+  },
+  {
+    id: "hardcoded_credential_assignment",
+    label: "hardcoded credential assignment",
+    // key = "literal" where key names a secret and the literal is long enough
+    // to be a real secret, not a placeholder or an env lookup.
+    test: (line) => {
+      // Anchor on a non-alphanumeric (or start) and allow a prefix such as
+      // `DB_`, `app-` etc. so `DB_PASSWORD`, `clientSecret` and friends match.
+      // `\b` cannot be used as the boundary because `_` is itself a word char.
+      const m = line.match(
+        /(?:^|[^a-z0-9])[a-z0-9_-]*(?:password|passwd|pwd|secret(?:[_-]?key)?|api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|private[_-]?key|encryption[_-]?key)\s*[:=]\s*(['"])([^'"]{8,})\1/i,
+      );
+      if (!m) return false;
+      const value = m[2];
+      if (PLACEHOLDER.test(value)) return false;
+      if (ENV_REFERENCE.test(value)) return false;
+      // Pure references like "process.env.X" captured without quotes won't reach
+      // here; quoted values that are themselves an env placeholder are excluded
+      // above. Require at least one non-space, non-word-boundary character mix.
+      return /[^\s]/.test(value);
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Judge
+// ---------------------------------------------------------------------------
+
+export class SecretLeakJudge {
+  constructor({ privateKeyPem, publicKeyPem, rules = SECRET_RULES, now = () => new Date() } = {}) {
+    if (privateKeyPem) {
+      this.privateKeyPem = privateKeyPem;
+      // Always derive the advertised key from the signing key so the documented
+      // JUDGE_PRIVATE_KEY_PEM-only flow emits self-consistent verdicts.
+      this.publicKeyPem = derivePublicKeyPem(privateKeyPem);
+    } else if (publicKeyPem) {
+      this.publicKeyPem = publicKeyPem;
+      this.privateKeyPem = null;
+    } else {
+      const generated = generateJudgeKeyPair();
+      this.privateKeyPem = generated.privateKeyPem;
+      this.publicKeyPem = generated.publicKeyPem;
+    }
+    this.rules = rules;
+    this.now = now;
+  }
+
+  judge(request) {
+    const normalized = canonicalize(request || {});
+    const diffText = normalized.diff || normalized.patch || "";
+    const files = diffText ? parseAddedLines(diffText) : [];
+    const allow = Array.isArray(normalized.allow_secrets) ? normalized.allow_secrets : [];
+
+    const parseable = this.checkParseable(diffText, files);
+    const scan = this.checkSecrets(files, allow);
+
+    const checks = [parseable, scan];
+    const passed = checks.every((check) => check.passed);
+    const verdict = {
+      judge_id: JUDGE_ID,
+      interface: "Judge.judge(request)->(passed,reasons)",
+      passed,
+      reasons: checks.filter((check) => !check.passed).map((check) => check.reason),
+      checks,
+      findings: scan.findings,
+      stats: {
+        files: files.length,
+        added_lines: files.reduce((n, f) => n + f.added.length, 0),
+        secrets_found: scan.findings.length,
+      },
+      request_hash: sha256Hex(canonicalJson(normalized)),
+      issued_at: this.now().toISOString(),
+    };
+    return this.signVerdict(verdict);
+  }
+
+  // --- individual checks ---------------------------------------------------
+
+  checkParseable(diffText, files) {
+    const hasHunk = files.some((f) => f.hunks > 0);
+    const passed =
+      typeof diffText === "string" &&
+      diffText.trim().length > 0 &&
+      files.length > 0 &&
+      hasHunk;
+    let reason;
+    if (passed) reason = "request carries a well-formed unified diff";
+    else if (files.length > 0 && !hasHunk)
+      reason = "diff has file headers but no `@@` hunk — header-only/malformed patch rejected";
+    else
+      reason = "request must include a non-empty unified `diff`/`patch` (no parseable file headers found)";
+    return { id: "parseable", passed, reason };
+  }
+
+  checkSecrets(files, allow) {
+    const findings = [];
+    for (const file of files) {
+      for (const { text, n } of file.added) {
+        for (const rule of this.rules) {
+          if (!rule.test(text)) continue;
+          const snippet = redact(text);
+          // An allow-list entry whitelists an intended addition by matching the
+          // file path or a substring of the (redacted) offending line.
+          const whitelisted = allow.some(
+            (a) => a === file.path || (typeof a === "string" && a.length >= 4 && text.includes(a)),
+          );
+          if (whitelisted) continue;
+          findings.push({ rule: rule.id, label: rule.label, path: file.path, added_line: n, snippet });
+        }
+      }
+    }
+    const passed = findings.length === 0;
+    return {
+      id: "no_hardcoded_secrets",
+      passed,
+      findings,
+      reason: passed
+        ? "added lines introduce no hardcoded secrets"
+        : `added lines introduce ${findings.length} hardcoded secret(s): ` +
+          findings.map((f) => `${f.label} in ${f.path} (+line ${f.added_line})`).join("; "),
+    };
+  }
+
+  // --- signing -------------------------------------------------------------
+
+  signVerdict(verdict) {
+    const envelope = {
+      verdict: canonicalize(verdict),
+      signature_algorithm: "Ed25519",
+      public_key_pem: this.publicKeyPem,
+    };
+    return {
+      ...envelope,
+      signature: signCanonical(this.privateKeyPem, envelope),
+    };
+  }
+
+  verify(signedVerdict) {
+    const { signature, ...payload } = signedVerdict;
+    return verifyCanonical(signedVerdict.public_key_pem, payload, signature);
+  }
+}
+
+// Redact the middle of a long token so the verdict never echoes a live secret
+// back to the caller while still leaving enough to locate it.
+export function redact(line) {
+  return line.replace(/([A-Za-z0-9_\-+/]{12,})/g, (m) =>
+    m.length <= 8 ? m : `${m.slice(0, 4)}…${m.slice(-2)}[redacted ${m.length} chars]`,
+  ).trim().slice(0, 200);
+}
+
+export function createJudge(options = {}) {
+  return new SecretLeakJudge(options);
+}

--- a/submissions/14382-secret-leak-judge/test.mjs
+++ b/submissions/14382-secret-leak-judge/test.mjs
@@ -1,0 +1,230 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+
+import {
+  createJudge,
+  generateJudgeKeyPair,
+  parseAddedLines,
+  verifyCanonical,
+  canonicalJson,
+  redact,
+} from "./secret-leak-judge.mjs";
+
+// Fixed key pair so verdicts are reproducible across instances.
+const KEYS = generateJudgeKeyPair();
+const fixedNow = () => new Date("2026-06-27T00:00:00.000Z");
+
+function makeJudge() {
+  return createJudge({ ...KEYS, now: fixedNow });
+}
+
+// A clean change that reads its secret from the environment — must pass.
+const CLEAN_DIFF = `diff --git a/src/client.js b/src/client.js
+--- a/src/client.js
++++ b/src/client.js
+@@ -1,3 +1,5 @@
+ export function makeClient() {
+-  return connect();
++  const apiKey = process.env.API_KEY;
++  return connect({ apiKey });
+ }
++export const VERSION = "1.2.0";
+`;
+
+test("happy path: env-sourced secret passes", () => {
+  const v = makeJudge().judge({ summary: "wire api key from env", diff: CLEAN_DIFF });
+  assert.equal(v.verdict.passed, true, JSON.stringify(v.verdict.reasons));
+  assert.equal(v.verdict.stats.secrets_found, 0);
+});
+
+test("PEM private key in added lines fails", () => {
+  const diff = `diff --git a/config/key.pem b/config/key.pem
+new file mode 100644
+--- /dev/null
++++ b/config/key.pem
+@@ -0,0 +1,2 @@
++-----BEGIN OPENSSH PRIVATE KEY-----
++b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQ
+`;
+  const v = makeJudge().judge({ summary: "add key", diff });
+  assert.equal(v.verdict.passed, false);
+  assert.ok(v.verdict.findings.some((f) => f.rule === "private_key_block"));
+});
+
+test("AWS access key id in added lines fails", () => {
+  const diff = `diff --git a/deploy.sh b/deploy.sh
+--- a/deploy.sh
++++ b/deploy.sh
+@@ -1,1 +1,2 @@
+ #!/bin/sh
++export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+`;
+  const v = makeJudge().judge({ summary: "deploy", diff });
+  assert.equal(v.verdict.passed, false);
+  assert.ok(v.verdict.findings.some((f) => f.rule === "aws_access_key_id"));
+});
+
+test("GitHub token in added lines fails", () => {
+  const diff = `diff --git a/ci/env b/ci/env
+--- a/ci/env
++++ b/ci/env
+@@ -1,1 +1,2 @@
+ NAME=ci
++GITHUB_TOKEN=ghp_0123456789abcdefABCDEF0123456789abcd
+`;
+  const v = makeJudge().judge({ summary: "ci", diff });
+  assert.equal(v.verdict.passed, false);
+  assert.ok(v.verdict.findings.some((f) => f.rule === "github_token"));
+});
+
+test("hardcoded password literal fails", () => {
+  const diff = `diff --git a/app.py b/app.py
+--- a/app.py
++++ b/app.py
+@@ -1,1 +1,2 @@
+ import db
++DB_PASSWORD = "S3cretSummer2026!"
+`;
+  const v = makeJudge().judge({ summary: "db creds", diff });
+  assert.equal(v.verdict.passed, false);
+  assert.ok(v.verdict.findings.some((f) => f.rule === "hardcoded_credential_assignment"));
+});
+
+test("credentials embedded in a URL fail", () => {
+  const diff = `diff --git a/fetch.js b/fetch.js
+--- a/fetch.js
++++ b/fetch.js
+@@ -1,1 +1,2 @@
+ // fetch
++const u = "https://admin:Hunter2Pass@internal.example.com/db";
+`;
+  const v = makeJudge().judge({ summary: "fetch", diff });
+  assert.equal(v.verdict.passed, false);
+  assert.ok(v.verdict.findings.some((f) => f.rule === "basic_auth_url"));
+});
+
+test("placeholder and env-reference assignments do NOT false-positive", () => {
+  const diff = `diff --git a/conf.py b/conf.py
+--- a/conf.py
++++ b/conf.py
+@@ -1,1 +1,5 @@
+ import os
++PASSWORD = "changeme"
++API_KEY = "<your-api-key>"
++SECRET = "\${VAULT_SECRET}"
++TOKEN = "xxxxxxxx"
+`;
+  const v = makeJudge().judge({ summary: "config template", diff });
+  assert.equal(v.verdict.passed, true, JSON.stringify(v.verdict.findings));
+});
+
+test("removing a secret (a `-` line) does not fail — only added lines are scanned", () => {
+  const diff = `diff --git a/app.py b/app.py
+--- a/app.py
++++ b/app.py
+@@ -1,2 +1,2 @@
+ import db
+-DB_PASSWORD = "S3cretSummer2026!"
++DB_PASSWORD = os.environ["DB_PASSWORD"]
+`;
+  const v = makeJudge().judge({ summary: "stop hardcoding", diff });
+  assert.equal(v.verdict.passed, true, JSON.stringify(v.verdict.findings));
+});
+
+test("allow_secrets whitelists an intended addition (e.g. a public test fixture)", () => {
+  const diff = `diff --git a/tests/fixtures/sample.pem b/tests/fixtures/sample.pem
+new file mode 100644
+--- /dev/null
++++ b/tests/fixtures/sample.pem
+@@ -0,0 +1,1 @@
++-----BEGIN PRIVATE KEY-----
+`;
+  const blocked = makeJudge().judge({ summary: "fixture", diff });
+  assert.equal(blocked.verdict.passed, false);
+
+  const allowed = makeJudge().judge({
+    summary: "intended test fixture",
+    diff,
+    allow_secrets: ["tests/fixtures/sample.pem"],
+  });
+  assert.equal(allowed.verdict.passed, true, JSON.stringify(allowed.verdict.findings));
+});
+
+test("findings never echo the raw secret back (redaction)", () => {
+  const diff = `diff --git a/ci/env b/ci/env
+--- a/ci/env
++++ b/ci/env
+@@ -1,1 +1,2 @@
+ NAME=ci
++GITHUB_TOKEN=ghp_0123456789abcdefABCDEF0123456789abcd
+`;
+  const v = makeJudge().judge({ summary: "ci", diff });
+  const snippet = v.verdict.findings[0].snippet;
+  assert.ok(!snippet.includes("ghp_0123456789abcdefABCDEF0123456789abcd"));
+  assert.match(snippet, /redacted/);
+});
+
+test("signed verdict verifies, and tampering breaks verification", () => {
+  const judge = makeJudge();
+  const v = judge.judge({ summary: "x", diff: CLEAN_DIFF });
+  assert.equal(judge.verify(v), true);
+
+  const tampered = structuredClone(v);
+  tampered.verdict.passed = !tampered.verdict.passed;
+  assert.equal(judge.verify(tampered), false);
+});
+
+test("forged / mismatched public key fails verification (MITM / forgery)", () => {
+  const judge = makeJudge();
+  const v = judge.judge({ summary: "x", diff: CLEAN_DIFF });
+  const attacker = generateJudgeKeyPair();
+  const { signature, ...payload } = { ...v, public_key_pem: attacker.publicKeyPem };
+  assert.equal(verifyCanonical(attacker.publicKeyPem, payload, signature), false);
+});
+
+test("empty / gate-down request fails parseable check", () => {
+  const v = makeJudge().judge({ summary: "nothing here" });
+  assert.equal(v.verdict.passed, false);
+  assert.equal(v.verdict.checks.find((c) => c.id === "parseable").passed, false);
+});
+
+test("header-only diff (no @@ hunk) fails parseable", () => {
+  const v = makeJudge().judge({ summary: "noop", diff: "diff --git a/x b/x\n" });
+  assert.equal(v.verdict.passed, false);
+  const parseable = v.verdict.checks.find((c) => c.id === "parseable");
+  assert.equal(parseable.passed, false);
+});
+
+test("private-key-only construction derives a matching public key (documented flow)", () => {
+  const judge = createJudge({ privateKeyPem: KEYS.privateKeyPem, now: fixedNow });
+  const signed = judge.judge({ summary: "x", diff: CLEAN_DIFF });
+  const expectedPub = crypto
+    .createPublicKey(KEYS.privateKeyPem)
+    .export({ type: "spki", format: "pem" });
+  assert.equal(signed.public_key_pem, expectedPub);
+  const { signature, ...payload } = signed;
+  assert.ok(verifyCanonical(signed.public_key_pem, payload, signature));
+});
+
+test("verdict signature is reproducible for identical input", () => {
+  const a = createJudge({ ...KEYS, now: fixedNow }).judge({ summary: "x", diff: CLEAN_DIFF });
+  const b = createJudge({ ...KEYS, now: fixedNow }).judge({ summary: "x", diff: CLEAN_DIFF });
+  assert.equal(a.signature, b.signature);
+});
+
+test("canonical JSON sorts keys deterministically", () => {
+  assert.equal(canonicalJson({ b: 1, a: 2 }), '{"a":2,"b":1}');
+});
+
+test("parseAddedLines collects only added content with file paths", () => {
+  const files = parseAddedLines(CLEAN_DIFF);
+  assert.equal(files.length, 1);
+  assert.equal(files[0].path, "src/client.js");
+  assert.ok(files[0].added.length >= 2);
+});
+
+test("redact shortens long tokens", () => {
+  const out = redact("token=ghp_0123456789abcdefABCDEF0123456789abcd");
+  assert.match(out, /redacted/);
+});


### PR DESCRIPTION
## Bounty #14382 (multi-claim) — Secret-Leak Judge

A **distinct, non-overlapping** community judge for the open `Judge` interface
(`judge(request) -> (passed, reasons)`). It judges exactly one axis that the other
community judges miss: **does this self-improvement diff introduce a hardcoded secret
in its added lines?**

A self-improving agent rewrites its own source; one careless edit commits a private
key / AWS secret / vendor token / password literal into history forever. A size,
lint or test-runner judge passes such a change (it still builds, lints, goes green).
This judge fails it, fail-safe.

### Why it's non-overlapping
Complementary to the static-analysis, dependency-policy, test-runner and the
diff-bounds judges. It does **not** bound size, run tests, lint, or police
dependencies — it only scans **added (`+`) lines** for committed secrets (removing a
secret passes).

### What's in `submissions/14382-secret-leak-judge/`
- `secret-leak-judge.mjs` — the judge + canonical-JSON Ed25519 envelope (dependency-free).
- `gate-server.mjs` — plugs into the reference gate unmodified: `POST /judge`, `GET /health`.
- `test.mjs` — **19 passing** `node:test` cases.
- `README.md`, `package.json`.

### Acceptance
- **Implements `Judge`, plugs into the reference gate unmodified** — `createJudge().judge(request)` → signed verdict; `gate-server.mjs` exposes it over HTTP.
- **Signs verdicts with its own Ed25519 key; SDK verification passes** — same canonical JSON envelope (sorted keys, no whitespace); private-key-only construction *derives* the advertised public key via `crypto.createPublicKey` (no fresh/unrelated pair). Tampering or a forged key fails verification.
- **Tests + README** — detectors (PEM keys, AWS/GitHub/Slack/Google/Stripe/OpenAI tokens, basic-auth URLs, credential literals), placeholder/env-reference false-positive guards, removal-is-ok, `allow_secrets` whitelist, finding redaction, reproducibility, forged-key rejection, header-only/empty rejection.

Detectors are vendor-anchored / structurally specific for high precision; placeholders
(`changeme`, `<your-key>`, `${VAULT}`) and env references (`process.env.X`,
`os.environ[...]`) are not flagged; findings redact live tokens; `allow_secrets`
whitelists intended additions (e.g. a public test fixture).

RTC wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`

— @Vyacheslav-Tomashevskiy