### PR TITLE
auto-pay: case-insensitive sensitive-path guard (closes #14543)

### DIFF
--- a/scripts/auto-pay.py
+++ b/scripts/auto-pay.py
@@ -75,6 +75,19 @@ SENSITIVE_PREFIXES = (
     "BOUNTY_LEDGER.md",
 )
 
+# Lower-cased copy used for matching. The guard MUST be case-insensitive:
+# git tracks `Scripts/`, `Node/`, `.GitHub/`, `BOUNTY_LEDGER.MD` etc. as
+# distinct from their lower-case forms, so a case-sensitive `startswith`
+# lets a PR touch consensus / money / CI code under a re-cased path and
+# still slip into the auto-tier (an auto-award the guard exists to deny).
+# Normalising both sides closes that bypass.
+SENSITIVE_PREFIXES_LC = tuple(p.lower() for p in SENSITIVE_PREFIXES)
+
+
+def is_sensitive_path(path: str) -> bool:
+    """True if `path` falls under a sensitive prefix, case-insensitively."""
+    return path.lower().startswith(SENSITIVE_PREFIXES_LC)
+
 # Marker recorded when the conservative auto-tier pays (distinct from the
 # human-directive marker so logs/audits can tell them apart). The dedup
 # check treats ANY occurrence of ALREADY_PAID_MARKER as "already paid".
@@ -245,7 +258,7 @@ def main() -> None:
         files = fetch_pr_files(repo, pr_number)
         total_changed = sum(f.get("additions", 0) + f.get("deletions", 0) for f in files)
         paths = [f.get("filename", "") for f in files]
-        sensitive = [p for p in paths if p.startswith(SENSITIVE_PREFIXES)]
+        sensitive = [p for p in paths if is_sensitive_path(p)]
 
         if sensitive:
             print(f"No directive; PR touches sensitive paths {sensitive[:3]} — "

--- a/scripts/test_auto_pay.py
+++ b/scripts/test_auto_pay.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Regression tests for the auto-pay sensitive-path guard.
 
 Run: python3 scripts/test_auto_pay.py   (or `pytest scripts/test_auto_pay.py`)

--- a/scripts/test_auto_pay.py
+++ b/scripts/test_auto_pay.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Regression tests for the auto-pay sensitive-path guard.
+
+Run: python3 scripts/test_auto_pay.py   (or `pytest scripts/test_auto_pay.py`)
+
+Focus: `is_sensitive_path` must reject consensus / money / CI paths
+*case-insensitively*. A case-sensitive `startswith` let a PR touch those
+paths under a re-cased prefix (e.g. `Scripts/`, `.GitHub/`) and still slip
+into the conservative auto-tier — an automatic RTC award the guard exists
+to deny. These tests pin the bypass shut.
+"""
+
+import importlib.util
+import os
+import unittest
+
+# The module file name contains a hyphen, so load it by path.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "auto_pay", os.path.join(_HERE, "auto-pay.py")
+)
+auto_pay = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(auto_pay)
+
+
+class SensitivePathGuard(unittest.TestCase):
+    def test_lowercase_sensitive_paths_flagged(self):
+        for p in (
+            "node/consensus.py",
+            "rips/rip-300.md",
+            "scripts/auto-pay.py",
+            ".github/workflows/pay.yml",
+            "BOUNTY_LEDGER.md",
+        ):
+            self.assertTrue(
+                auto_pay.is_sensitive_path(p), f"{p} should be sensitive"
+            )
+
+    def test_recased_sensitive_paths_still_flagged(self):
+        # The bypass vectors from the report — each maps to a sensitive file
+        # on a case-insensitive checkout, so the guard must catch them too.
+        for p in (
+            "Scripts/auto-pay.py",
+            "SCRIPTS/auto-pay.py",
+            "Node/consensus.py",
+            "NODE/consensus.py",
+            "Rips/rip-300.md",
+            ".GitHub/workflows/pay.yml",
+            ".GITHUB/workflows/pay.yml",
+            "BOUNTY_LEDGER.MD",
+            "Bounty_Ledger.md",
+        ):
+            self.assertTrue(
+                auto_pay.is_sensitive_path(p),
+                f"{p} re-cased must still be sensitive",
+            )
+
+    def test_non_sensitive_paths_not_flagged(self):
+        for p in (
+            "README.md",
+            "docs/guide.md",
+            "bounties/0123-foo.json",
+            "src/app.py",
+            "nodes_overview.md",       # 'node' substring but not the 'node/' dir
+            "scripts_notes.txt",        # 'scripts' substring but not 'scripts/'
+        ):
+            self.assertFalse(
+                auto_pay.is_sensitive_path(p),
+                f"{p} should NOT be sensitive",
+            )
+
+    def test_prefixes_lc_matches_source_tuple(self):
+        self.assertEqual(
+            auto_pay.SENSITIVE_PREFIXES_LC,
+            tuple(p.lower() for p in auto_pay.SENSITIVE_PREFIXES),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Fix: case-insensitive sensitive-path guard in auto-pay.py

Closes the **case-sensitivity bypass** reported in #14543 (vuln #2).

### The bug
`auto-pay.py`'s conservative auto-tier refuses to auto-award any PR that touches consensus / money / auth / CI paths — those must always get a human `Payment: N RTC` directive:

```python
sensitive = [p for p in paths if p.startswith(SENSITIVE_PREFIXES)]
```

`str.startswith` is **case-sensitive**, and git tracks `Scripts/`, `Node/`, `.GitHub/`, `Rips/`, `BOUNTY_LEDGER.MD` as distinct from their lower-case forms. A PR can therefore modify sensitive code under a re-cased prefix, slip past the guard, and become eligible for an automatic 3 RTC award the guard exists to deny (on a case-insensitive checkout those paths resolve to the very files the guard protects).

### The fix
- New `is_sensitive_path(path)` helper compares `path.lower()` against a lower-cased prefix tuple `SENSITIVE_PREFIXES_LC` — both sides normalised, so re-casing no longer evades the guard.
- Source `SENSITIVE_PREFIXES` is left untouched as the single source of truth; the lower-cased copy is derived from it.

Scope is intentionally narrow — this PR fixes only the concrete, exploitable case-sensitivity defect. The auto-tier design itself (size/path/idempotency limits) is left as-is.

### Tests
New `scripts/test_auto_pay.py` (stdlib `unittest`, no new deps):
- lowercase sensitive paths still flagged
- **re-cased bypass vectors** (`Scripts/auto-pay.py`, `NODE/`, `.GitHub/`, `BOUNTY_LEDGER.MD`, ...) now flagged
- non-sensitive paths (incl. `nodes_overview.md`, `scripts_notes.txt` substring traps) not flagged
- `SENSITIVE_PREFIXES_LC` stays in sync with the source tuple

`python3 scripts/test_auto_pay.py` → **4 tests, OK**.

Diff: `scripts/auto-pay.py` +14/-1, plus the new test file.

/claim
RTC wallet: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7