### PR TITLE
fix(stress-test): import uuid so --dupes mode no longer crashes (#14642)

### DIFF
--- a/scripts/stress_test/harness.py
+++ b/scripts/stress_test/harness.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import uuid
 import httpx
 import statistics
 from typing import List, Dict, Any
@@ -105,6 +106,16 @@ class StressHarness:
         stats["error"] = "Max retries exceeded (429)"
         return None
 
+    @staticmethod
+    def _generate_duplicate_base_id() -> str:
+        """Builds the shared miner ID used to simulate duplicate/replay miners.
+
+        Kept as a small helper so the --dupes setup can be exercised in
+        isolation without launching any network sessions (see the regression
+        test for the missing-``uuid``-import crash).
+        """
+        return f"duplicate-miner-{uuid.uuid4().hex[:4]}"
+
     async def run_test(self, num_miners: int, duplicate_ratio: float = 0.0, test_malformed: bool = False, test_epoch_boundary: bool = False):
         """Launches a massive attack with the specified number of miners."""
         print(f"🚀 Starting stress test with {num_miners} simulated miners...")
@@ -119,7 +130,7 @@ class StressHarness:
 
         if duplicate_ratio > 0:
             num_dupes = int(num_miners * duplicate_ratio)
-            base_id = f"duplicate-miner-{uuid.uuid4().hex[:4]}"
+            base_id = self._generate_duplicate_base_id()
             for i in range(num_dupes):
                 force_ids[i] = base_id
 

--- a/tests/test_stress_harness_duplicate_ids.py
+++ b/tests/test_stress_harness_duplicate_ids.py
@@ -1,0 +1,42 @@
+"""Regression tests for scripts/stress_test/harness.py duplicate-ID setup — Bounty Issue #14642
+
+The ``--dupes`` stress-test mode builds a shared miner ID via ``uuid.uuid4()``,
+but ``harness.py`` never imported the stdlib ``uuid`` module. As a result the
+duplicate-miner path crashed with ``NameError: name 'uuid' is not defined``
+inside ``StressHarness.run_test()`` before a single simulated session started,
+breaking the RIP-200 duplicate-attestation / replay-resistance scenario.
+
+These tests exercise the duplicate base-ID generation in isolation (no network),
+so they fail on the pre-fix code and pass once ``uuid`` is imported.
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "scripts"))
+
+from stress_test.harness import StressHarness
+
+
+def test_harness_imports_uuid_module():
+    """The module must import stdlib ``uuid`` (root cause of the crash)."""
+    import stress_test.harness as harness
+
+    assert hasattr(harness, "uuid"), "harness.py must import the stdlib uuid module"
+
+
+def test_generate_duplicate_base_id_format():
+    """Duplicate base ID matches ``duplicate-miner-<4 hex>`` and does not raise."""
+    base_id = StressHarness._generate_duplicate_base_id()
+
+    assert re.fullmatch(r"duplicate-miner-[0-9a-f]{4}", base_id), base_id
+
+
+def test_generate_duplicate_base_id_varies():
+    """Successive IDs are drawn from uuid4, not a constant stub."""
+    ids = {StressHarness._generate_duplicate_base_id() for _ in range(64)}
+
+    # 4 hex chars => 65536 possibilities; all-identical across 64 draws would
+    # signal the randomness (and thus the uuid import) was lost.
+    assert len(ids) > 1


### PR DESCRIPTION
## Summary
Fixes #14642. The `--dupes` stress-test mode crashed with `NameError: name 'uuid' is not defined` before launching any simulated session, because `scripts/stress_test/harness.py` used `uuid.uuid4()` (in the duplicate-ID setup of `StressHarness.run_test()`) without importing the stdlib `uuid` module. This broke the RIP-200 duplicate-attestation / replay-resistance scenario advertised by `--dupes`.

## Root cause
`harness.py` imported `asyncio`, `time`, `httpx`, `statistics` — but not `uuid` — while line 122 built `f"duplicate-miner-{uuid.uuid4().hex[:4]}"`.

## Fix
- `import uuid` in `scripts/stress_test/harness.py`.
- Extracted `StressHarness._generate_duplicate_base_id()` helper so the duplicate-ID setup can be exercised in isolation, without launching network sessions.
- Added `tests/test_stress_harness_duplicate_ids.py` (the regression file referenced in the issue) with 3 tests: uuid is importable on the module, the base ID matches `duplicate-miner-<4 hex>`, and successive IDs vary (not a constant stub).

## Verification
```
# BEFORE (pristine main): reproduce the crash
$ python3 -c "... run_test(num_miners=4, duplicate_ratio=0.5) ..."
REPRO NameError: name 'uuid' is not defined

# AFTER
$ python3 -m pytest -q tests/test_stress_harness_duplicate_ids.py
3 passed
$ python3 -m pytest -q tests/test_stress_reporter.py   # adjacent suite unaffected
10 passed
```
Repro command from the issue (`python3 scripts/run_stress_test.py --url http://127.0.0.1:1 --miners 4 --concurrency 2 --dupes 0.5 --timeout 1`) now proceeds to the network stage instead of crashing on ID setup.

/claim #14642

RTC payout wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
