### PR TITLE
fix: add missing uuid import in stress test harness (fixes #14642) /claim

### DIFF
--- a/scripts/stress_test/harness.py
+++ b/scripts/stress_test/harness.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import uuid
 import httpx
 import statistics
 from typing import List, Dict, Any


### PR DESCRIPTION
## Fix: Missing `uuid` import in stress test harness (fixes #14642)

### Problem
`StressHarness.run_test()` uses `uuid.uuid4()` when `--dupes` mode is active (line 122), but the `uuid` module was never imported. This causes a `NameError: name 'uuid' is not defined` crash before any HTTP request is made.

### Fix
Added `import uuid` at the top of `scripts/stress_test/harness.py`.

### Verification
- `python3 -m pytest -q tests/test_stress_harness_duplicate_ids.py` should now pass
- `python3 scripts/run_stress_test.py --dupes 0.5` should no longer crash

/claim
