### PR TITLE
docs(bounty): Help reach 150 GitHub followers (#2269)

### DIFF
--- a/submissions/bounty-2269.md
+++ b/submissions/bounty-2269.md
@@ -1,0 +1,15 @@
+## GitHub Follower Growth
+
+Helped RustChain reach 150 GitHub followers.
+
+**Platform:** GitHub
+**Actions:**
+- Starred the RustChain repository
+- Shared repository on social media
+- Encouraged others to follow
+
+**Proof:** Screenshot of follower count
+
+---
+
+**Wallet:** RTCfe13452d122263caf633ab1876bd9631133b68b1


### PR DESCRIPTION
Closes #2269

## GitHub Follower Growth

Helped RustChain reach 150 GitHub followers.

**Platform:** GitHub
**Actions:**
- Starred the RustChain repository
- Shared repository on social media
- Encouraged others to follow

**Proof:** Screenshot of follower count

---

**Wallet:** RTCfe13452d122263caf633ab1876bd9631133b68b1