### PR TITLE
fix: stop Auto Triage Claims crashing on cross-repo stargazers 403

### DIFF
--- a/.github/workflows/auto-triage-claims.yml
+++ b/.github/workflows/auto-triage-claims.yml
@@ -27,6 +27,16 @@ jobs:
       - name: Run Auto Triage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: a fine-grained PAT (public repo read access is enough)
+          # used only for cross-repo star checks (Rustchain, bottube,
+          # beacon-skill). The default Actions GITHUB_TOKEN cannot list
+          # stargazers on any repo other than the one running the workflow
+          # (GitHub returns 403 "Resource not accessible by integration"
+          # even though the repos are public). Without this secret, the
+          # script still runs fine, it just marks star-gated claims as
+          # `star_check_unavailable` instead of verifying them. Set the
+          # STAR_CHECK_TOKEN repo secret to restore real verification.
+          STAR_CHECK_TOKEN: ${{ secrets.STAR_CHECK_TOKEN }}
           SINCE_HOURS: "168"
           LEDGER_REPO: "rustchain-bounties"
           LEDGER_ISSUE: "104"

--- a/scripts/auto_triage_claims.py
+++ b/scripts/auto_triage_claims.py
@@ -408,10 +408,69 @@ def _ignored_users() -> Set[str]:
     return ignored
 
 
+def _is_dry_run() -> bool:
+    return os.environ.get("DRY_RUN", "").strip().lower() in {"1", "true", "yes"}
+
+
+def _fetch_star_cache(
+    repos: List[str],
+    token: str,
+    star_token: Optional[str] = None,
+) -> tuple[Dict[str, Set[str]], Dict[str, str]]:
+    """Fetch stargazer logins for each repo.
+
+    The GitHub REST "List stargazers" endpoint returns HTTP 403
+    ("Resource not accessible by integration") for the default Actions
+    GITHUB_TOKEN when the target repo is not the one the workflow is
+    running in -- this is true even for public repos, because the
+    Actions installation token is scoped only to its own repository.
+    Regular issue/comment reads across public repos are not affected,
+    only this social-graph-style endpoint.
+
+    Because of that, cross-repo star checks can legitimately be
+    unavailable at runtime. Rather than let that crash the whole triage
+    run (which previously took down every bounty target, not just the
+    ones that need a star check), record the failure per-repo and let
+    the caller degrade to a "can't verify" blocker instead of a hard
+    exit.
+
+    An optional `star_token` (e.g. a fine-grained PAT with public read
+    access, wired up via the STAR_CHECK_TOKEN secret) can be supplied to
+    restore real cross-repo star verification; it is tried first and
+    falls back to `token` only if unset.
+    """
+    cache: Dict[str, Set[str]] = {}
+    errors: Dict[str, str] = {}
+    effective_token = star_token or token
+    for repo in sorted(repos):
+        try:
+            users = _gh_paginated(f"/repos/Scottcjn/{repo}/stargazers", effective_token)
+            cache[repo] = {u.get("login") for u in users if u.get("login")}
+        except urllib.error.HTTPError as exc:
+            print(
+                f"WARN: could not fetch stargazers for Scottcjn/{repo}: "
+                f"HTTP {exc.code} {exc.reason}. Star checks for this repo "
+                "will be marked as unavailable instead of failing the run.",
+                file=sys.stderr,
+            )
+            cache[repo] = set()
+            errors[repo] = f"HTTP {exc.code}"
+        except urllib.error.URLError as exc:
+            print(
+                f"WARN: could not fetch stargazers for Scottcjn/{repo}: {exc}",
+                file=sys.stderr,
+            )
+            cache[repo] = set()
+            errors[repo] = str(exc.reason)
+    return cache, errors
+
+
 def main() -> int:
     token = _env("GITHUB_TOKEN")
+    star_token = os.environ.get("STAR_CHECK_TOKEN", "").strip() or None
     since_hours = int(_env("SINCE_HOURS", "72"))
     risk_policy = _env("TRIAGE_RISK_POLICY", "balanced")
+    dry_run = _is_dry_run()
     ignored_users = _ignored_users()
     targets_json = os.environ.get("TRIAGE_TARGETS_JSON", "").strip()
     if targets_json:
@@ -425,10 +484,9 @@ def main() -> int:
         for repo in t.get("required_stars", []):
             required_star_repos.add(repo)
 
-    star_cache: Dict[str, Set[str]] = {}
-    for repo in sorted(required_star_repos):
-        users = _gh_paginated(f"/repos/Scottcjn/{repo}/stargazers", token)
-        star_cache[repo] = {u.get("login") for u in users if u.get("login")}
+    star_cache, star_fetch_errors = _fetch_star_cache(
+        sorted(required_star_repos), token, star_token
+    )
 
     user_cache: Dict[str, Dict[str, Any]] = {}
     cutoff = _now_utc() - timedelta(hours=since_hours)
@@ -448,14 +506,25 @@ def main() -> int:
         issue_ref = f"{owner}/{repo}#{issue}"
         try:
             issue_obj = _gh_request("GET", f"/repos/{owner}/{repo}/issues/{issue}", token)
+            comments_url = issue_obj["comments_url"]
+            comments = _gh_paginated(comments_url, token)
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
                 print(f"WARN: {issue_ref} not found (HTTP 404), skipping target")
-                results_by_issue[issue_ref] = []
-                continue
-            raise
-        comments_url = issue_obj["comments_url"]
-        comments = _gh_paginated(comments_url, token)
+            else:
+                # Don't let one inaccessible/rate-limited target take down
+                # triage for every other bounty. Log it loudly and move on.
+                print(
+                    f"WARN: {issue_ref} fetch failed (HTTP {exc.code} {exc.reason}), "
+                    "skipping target",
+                    file=sys.stderr,
+                )
+            results_by_issue[issue_ref] = []
+            continue
+        except urllib.error.URLError as exc:
+            print(f"WARN: {issue_ref} fetch failed ({exc}), skipping target", file=sys.stderr)
+            results_by_issue[issue_ref] = []
+            continue
 
         # Merge multi-comment claims per user (users often add follow-ups).
         per_user: Dict[str, Dict[str, Any]] = {}
@@ -524,7 +593,12 @@ def main() -> int:
                 blockers.append("missing_proof_link")
 
             for star_repo in req_stars:
-                if user not in star_cache.get(star_repo, set()):
+                if star_repo in star_fetch_errors:
+                    # We couldn't verify stars for this repo at all (e.g. the
+                    # cross-repo stargazers API rejected our token). Stay
+                    # fail-safe: never treat "unknown" as "eligible".
+                    blockers.append(f"star_check_unavailable:{star_repo}")
+                elif user not in star_cache.get(star_repo, set()):
                     blockers.append(f"missing_star:{star_repo}")
 
             rows.append(
@@ -549,23 +623,38 @@ def main() -> int:
 
     generated_at = _now_utc().isoformat().replace("+00:00", "Z")
     report = _build_report_md(generated_at, results_by_issue, since_hours, risk_policy)
+    if star_fetch_errors:
+        note = "; ".join(f"{repo} ({err})" for repo, err in sorted(star_fetch_errors.items()))
+        report = (
+            f"> WARN: star verification unavailable for: {note}. "
+            f"Affected claims are flagged `star_check_unavailable:<repo>` and "
+            f"left in `needs-action`, not auto-approved.\n\n{report}"
+        )
     print(report)
 
     ledger_repo = os.environ.get("LEDGER_REPO", "").strip()
     ledger_issue = os.environ.get("LEDGER_ISSUE", "").strip()
+    if dry_run:
+        print("\nDRY_RUN set: skipping ledger issue update.")
+        return 0
     if ledger_repo and ledger_issue:
         issue_path = f"/repos/Scottcjn/{ledger_repo}/issues/{int(ledger_issue)}"
-        ledger = _gh_request("GET", issue_path, token)
-        body = ledger.get("body") or ""
-        new_block = f"{MARKER_START}\n{report}\n{MARKER_END}"
-        if MARKER_START in body and MARKER_END in body:
-            start = body.index(MARKER_START)
-            end = body.index(MARKER_END) + len(MARKER_END)
-            updated = f"{body[:start]}{new_block}{body[end:]}"
-        else:
-            updated = f"{body}\n\n{new_block}\n"
-        _gh_request("PATCH", issue_path, token, data={"body": updated})
-        print(f"\nUpdated ledger issue: Scottcjn/{ledger_repo}#{ledger_issue}")
+        try:
+            ledger = _gh_request("GET", issue_path, token)
+            body = ledger.get("body") or ""
+            new_block = f"{MARKER_START}\n{report}\n{MARKER_END}"
+            if MARKER_START in body and MARKER_END in body:
+                start = body.index(MARKER_START)
+                end = body.index(MARKER_END) + len(MARKER_END)
+                updated = f"{body[:start]}{new_block}{body[end:]}"
+            else:
+                updated = f"{body}\n\n{new_block}\n"
+            _gh_request("PATCH", issue_path, token, data={"body": updated})
+            print(f"\nUpdated ledger issue: Scottcjn/{ledger_repo}#{ledger_issue}")
+        except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+            # The report already printed above (and is visible in the Action
+            # log) even if we can't write it back to the ledger issue.
+            print(f"WARN: failed to update ledger issue: {exc}", file=sys.stderr)
 
     return 0
 

--- a/tests/test_auto_triage_claims.py
+++ b/tests/test_auto_triage_claims.py
@@ -1,4 +1,6 @@
 import unittest
+import urllib.error
+from unittest import mock
 
 from scripts.auto_triage_claims import (
     ClaimResult,
@@ -6,6 +8,7 @@ from scripts.auto_triage_claims import (
     _build_report_md,
     _extract_bottube_user,
     _extract_wallet,
+    _fetch_star_cache,
     _has_proof_link,
     _looks_like_claim,
 )
@@ -79,6 +82,51 @@ class AutoTriageClaimsTests(unittest.TestCase):
         self.assertIn("#### Suspicious Claims", report)
         self.assertIn("@fresh-bot", report)
         self.assertIn("ACCOUNT_AGE", report)
+
+    def test_fetch_star_cache_survives_cross_repo_403(self):
+        # This reproduces the real failure: GitHub's "List stargazers"
+        # endpoint returns 403 "Resource not accessible by integration"
+        # for the default Actions GITHUB_TOKEN when the repo isn't the one
+        # the workflow runs in, even for public repos. That used to raise
+        # out of _gh_paginated and crash the whole triage run for every
+        # bounty target, not just the ones needing that star.
+        forbidden = urllib.error.HTTPError(
+            url="https://api.github.com/repos/Scottcjn/Rustchain/stargazers",
+            code=403,
+            msg="Forbidden",
+            hdrs=None,
+            fp=None,
+        )
+
+        def fake_paginated(path, token):
+            if "good-repo" in path:
+                return [{"login": "alice"}, {"login": "bob"}]
+            raise forbidden
+
+        with mock.patch(
+            "scripts.auto_triage_claims._gh_paginated", side_effect=fake_paginated
+        ):
+            cache, errors = _fetch_star_cache(["good-repo", "blocked-repo"], "tok")
+
+        self.assertEqual(cache["good-repo"], {"alice", "bob"})
+        self.assertEqual(cache["blocked-repo"], set())
+        self.assertNotIn("good-repo", errors)
+        self.assertIn("blocked-repo", errors)
+        self.assertIn("403", errors["blocked-repo"])
+
+    def test_fetch_star_cache_prefers_star_token_when_set(self):
+        seen_tokens = []
+
+        def fake_paginated(path, token):
+            seen_tokens.append(token)
+            return [{"login": "alice"}]
+
+        with mock.patch(
+            "scripts.auto_triage_claims._gh_paginated", side_effect=fake_paginated
+        ):
+            _fetch_star_cache(["some-repo"], "default-tok", star_token="pat-tok")
+
+        self.assertEqual(seen_tokens, ["pat-tok"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What was broken

Auto Triage Claims has failed on every single scheduled run since 2026-07-03 (40+ failures in a row, hourly), spamming failure notifications. It always died at the same line:

```
users = _gh_paginated(f"/repos/Scottcjn/{repo}/stargazers", token)
...
urllib.error.HTTPError: HTTP Error 403: Forbidden
```

## Root cause

GitHub's "List stargazers" endpoint returns `403 Resource not accessible by integration` for the default Actions `GITHUB_TOKEN` when the target repo is not the repo the workflow is running in. This is true even though Rustchain, bottube, and beacon-skill are all public repos, and even though the same token has no problem doing a normal issue/comment GET on those same repos.

I confirmed this directly by pushing a temporary read-only probe workflow and inspecting the live `GITHUB_TOKEN` behavior (see the run log, not included in this PR):

- `GET /repos/Scottcjn/rustchain-bounties/stargazers` (same repo) -> 200
- `GET /repos/Scottcjn/Rustchain/issues/47` (cross-repo issue) -> 200
- `GET /repos/Scottcjn/Rustchain/stargazers` (cross-repo stars) -> **403** `Resource not accessible by integration`
- `GET /repos/Scottcjn/bottube/stargazers` (cross-repo stars) -> **403** same

So this isn't a code bug in the usual sense, it's an unhandled case: the script assumed cross-repo star checks would always work, and had no error handling for when they don't. Once that first cross-repo stargazers call throws, the whole script exits before it even gets to the other 6 bounty targets, so nothing gets triaged and the ledger issue (#104) never updates.

The 60 successful runs before 2026-07-03 show this used to work. I could not find a code change in that window, so this looks like GitHub tightening enforcement of installation-token scoping on the starring endpoint specifically, not something we did. Either way, we shouldn't be crashing hourly on it.

## Fix

- `_fetch_star_cache()` now catches `HTTPError`/`URLError` per repo instead of letting one inaccessible repo take down the whole run.
- Claims that need a star we couldn't verify get a new `star_check_unavailable:<repo>` blocker and stay in `needs-action`. This keeps the same fail-safe posture (never auto-mark eligible when we can't check) while making the failure visible in the report instead of crashing silently.
- Same defensive handling added around the per-target issue/comments fetch (same class of cross-repo dependency).
- Added an optional `STAR_CHECK_TOKEN` secret (a fine-grained PAT with public-repo read access would restore real cross-repo star verification, since a normal PAT doesn't have this installation-token restriction). Falls back to `GITHUB_TOKEN` and degrades gracefully if not set. **This secret does not exist yet** - the workflow runs fine without it, just with stars unverifiable.
- Added `DRY_RUN=1` support: prints the report but skips the ledger PATCH, so this can be exercised safely.
- Added two tests covering the new error handling.

**No change to payout logic.** This script has never labeled or commented on claim issues, despite the workflow name - the only write it does is patching the body of the ledger report issue (#104) with a markdown table. That behavior is unchanged; I only made it survive partial failures instead of crashing before reaching it.

## Verification

- `python3 -m pytest tests/test_auto_triage_claims.py -q` -> 9 passed (7 existing + 2 new)
- `python3 -m py_compile scripts/auto_triage_claims.py` -> clean
- Ran the full script locally against the real GitHub API with `DRY_RUN=1` using a normal token -> produces the expected report, skips the ledger write, no exceptions.
- Ran it again with `_gh_paginated` monkeypatched to reproduce the exact production 403 on stargazers calls -> confirmed it no longer crashes, exits 0, prints a `WARN: star verification unavailable for: ...` banner, and flags the one affected claim as `star_check_unavailable:beacon-skill` instead of silently passing or dying.
- Did not run it against production without `DRY_RUN` (would have written to ledger issue #104), and did not touch any claim issue's labels/comments.

## Please double check before merging

- I added `STAR_CHECK_TOKEN` as an optional secret reference in the workflow. It's unset today, so nothing changes until/unless you add a PAT for it. If you don't want that at all, it's a two-line removal.
- The `star_check_unavailable:<repo>` blocker is new text that will show up in the ledger issue report. If any downstream tooling parses specific blocker strings from that report, it doesn't currently look like it does (grepped for `missing_star`/`blockers` usage, only this script writes/reads that report), but worth a glance.
- I pushed and then deleted a temporary diagnostic branch (`diag/token-scope-probe`) to confirm the 403 behavior with a live token. It only performed GET requests, no writes anywhere, and touched no issue in any repo. It's not part of this PR.
