### PR TITLE
fix: retry transient VPS connection failures in auto-pay

### DIFF
--- a/scripts/auto-pay.py
+++ b/scripts/auto-pay.py
@@ -139,12 +139,21 @@ def post_comment(repo: str, pr_number: str, body: str) -> None:
 
 
 def transfer_rtc(vps_host: str, admin_key: str, to_wallet: str,
-                 amount: float, memo: str, idempotency_key: str) -> dict:
+                 amount: float, memo: str, idempotency_key: str,
+                 max_attempts: int = 3, retry_delay: float = 5.0) -> dict:
     """Call the RustChain VPS transfer endpoint.
 
     The idempotency_key is per-PR, so the node de-duplicates any retry or
     concurrent run to a single transfer — the single serialization point
     that makes a double-pay impossible even if the workflow runs twice.
+
+    Retries on transient connection failures / timeouts (e.g. the VPS
+    restarting for a few seconds) up to `max_attempts` times before giving
+    up. HTTP error responses (4xx/5xx from `raise_for_status()`) are NOT
+    retried — those are a real answer from the node, not a dropped
+    connection, and get surfaced to the caller immediately. Retrying is
+    still fail-safe even on a genuine transient failure: the idempotency
+    key means at most one of the attempts can ever actually move funds.
     """
     url = f"http://{vps_host}:{VPS_PORT}/wallet/transfer"
     payload = {
@@ -158,9 +167,24 @@ def transfer_rtc(vps_host: str, admin_key: str, to_wallet: str,
         "Content-Type": "application/json",
         "X-Admin-Key": admin_key,
     }
-    resp = requests.post(url, headers=headers, json=payload, timeout=30)
-    resp.raise_for_status()
-    return resp.json()
+
+    last_exc: Exception = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            resp = requests.post(url, headers=headers, json=payload, timeout=30)
+            resp.raise_for_status()
+            return resp.json()
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            last_exc = e
+            if attempt < max_attempts:
+                print(f"::warning::Attempt {attempt}/{max_attempts} to reach VPS "
+                      f"failed ({e.__class__.__name__}) — retrying in {retry_delay:g}s...")
+                time.sleep(retry_delay)
+
+    # Exhausted retries on a transient error — re-raise so the caller's
+    # existing except clauses handle it the same way as before (fail-safe:
+    # no transfer recorded, no confirmation comment posted).
+    raise last_exc
 
 
 def fetch_pr_files(repo: str, pr_number: str) -> list:

--- a/scripts/test_auto_pay.py
+++ b/scripts/test_auto_pay.py
@@ -14,6 +14,9 @@ to deny. These tests pin the bypass shut.
 import importlib.util
 import os
 import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
 
 # The module file name contains a hyphen, so load it by path.
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -75,6 +78,94 @@ class SensitivePathGuard(unittest.TestCase):
             auto_pay.SENSITIVE_PREFIXES_LC,
             tuple(p.lower() for p in auto_pay.SENSITIVE_PREFIXES),
         )
+
+
+class TransferRetry(unittest.TestCase):
+    """Regression tests for the transient-failure retry added to
+    transfer_rtc() (issue: a brief VPS restart caused
+    requests.exceptions.ConnectionError to crash the whole job with no
+    retry, spamming CI failure notifications for what was really a few
+    seconds of downtime).
+
+    Retrying must stay fail-safe: no more than one HTTP call may ever
+    "succeed" per invocation (checked via call_count), and a genuine HTTP
+    error response (a real answer from the node, e.g. insufficient
+    balance) must NOT be retried — only dropped-connection / timeout
+    cases are.
+    """
+
+    def _call(self, **overrides):
+        kwargs = dict(
+            vps_host="203.0.113.1",
+            admin_key="k",
+            to_wallet="alice",
+            amount=3.0,
+            memo="test",
+            idempotency_key="idem-1",
+            max_attempts=3,
+            retry_delay=0,  # no real sleeping in tests
+        )
+        kwargs.update(overrides)
+        return auto_pay.transfer_rtc(**kwargs)
+
+    @patch("time.sleep", return_value=None)
+    @patch("requests.post")
+    def test_succeeds_after_transient_connection_errors(self, mock_post, _sleep):
+        ok_resp = MagicMock()
+        ok_resp.raise_for_status.return_value = None
+        ok_resp.json.return_value = {"ok": True, "pending_id": "p1"}
+
+        mock_post.side_effect = [
+            requests.exceptions.ConnectionError("refused"),
+            requests.exceptions.Timeout("timed out"),
+            ok_resp,
+        ]
+
+        result = self._call()
+
+        self.assertEqual(result, {"ok": True, "pending_id": "p1"})
+        self.assertEqual(mock_post.call_count, 3)
+
+    @patch("time.sleep", return_value=None)
+    @patch("requests.post")
+    def test_raises_after_exhausting_retries(self, mock_post, _sleep):
+        mock_post.side_effect = requests.exceptions.ConnectionError("refused")
+
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            self._call(max_attempts=3)
+
+        # Exactly max_attempts calls — bounded, no runaway retry loop.
+        self.assertEqual(mock_post.call_count, 3)
+
+    @patch("time.sleep", return_value=None)
+    @patch("requests.post")
+    def test_http_error_is_not_retried(self, mock_post, _sleep):
+        bad_resp = MagicMock()
+        bad_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "400 Client Error", response=MagicMock(status_code=400, text="bad")
+        )
+        mock_post.return_value = bad_resp
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self._call(max_attempts=3)
+
+        # A real rejection from the node is surfaced immediately — retrying
+        # a 4xx/5xx response wouldn't change the answer.
+        self.assertEqual(mock_post.call_count, 1)
+
+    @patch("time.sleep", return_value=None)
+    @patch("requests.post")
+    def test_single_attempt_never_double_calls(self, mock_post, _sleep):
+        """Baseline: the common case (VPS reachable) makes exactly one
+        HTTP call — the retry loop must not add extra calls on success."""
+        ok_resp = MagicMock()
+        ok_resp.raise_for_status.return_value = None
+        ok_resp.json.return_value = {"ok": True}
+        mock_post.return_value = ok_resp
+
+        self._call()
+
+        self.assertEqual(mock_post.call_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `RTC Auto-Pay on PR Merge` has failed 93 times historically (63 in the volume Scott flagged). Every failure I sampled is `requests.exceptions.ConnectionError` talking to the RustChain VPS on port 8099, clustered in tight bursts a few seconds apart - consistent with the VPS process restarting, not a code bug. Zero failures in the last 19 days, so this looks stabilized on the infra side already, but the same brief-restart pattern could recur.
- Fix: `transfer_rtc()` now retries up to 3 times (short delay between attempts) on `ConnectionError` / `Timeout` only. `HTTPError` (a real answer from the node, e.g. insufficient balance) is still raised immediately with zero retries, same as before.
- **No payout behavior change.** The idempotency_key is unchanged and still per-PR, so the node still de-duplicates any of these attempts to at most one transfer - this is the same guarantee that already made retries-across-separate-workflow-runs safe, just applied within a single run too. If all retries are exhausted, the script still exits 1 and posts nothing (fail-safe, same as before).

## Test plan
- [x] `python3 -m pytest scripts/test_auto_pay.py -q` - 8/8 passed (4 pre-existing + 4 new)
- [x] New tests added and passing:
  - recovers after 2 transient errors then succeeds (3 calls total)
  - gives up after `max_attempts` with no extra calls (bounded retry, no runaway loop)
  - HTTP error response is NOT retried (1 call only)
  - success path still makes exactly 1 HTTP call (no accidental double-call)
- [x] `python3 -m py_compile scripts/auto-pay.py`

Not merging - this is payout-pipeline-adjacent code, flagging for review per the caution rule even though the change itself doesn't touch what/how much gets paid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)