### PR TITLE
Fix: harden GitHub tip bot balance and amount handling

### DIFF
--- a/github-tip-bot/tip_bot.py
+++ b/github-tip-bot/tip_bot.py
@@ -7,6 +7,7 @@ Listens for /tip, /balance, /leaderboard, /register commands in GitHub comments.
 import os
 import re
 import json
+import math
 import requests
 from github import Github
 
@@ -50,6 +51,9 @@ def process_tip(from_user: str, to_wallet: str, amount: float, memo: str = "") -
         amount = float(amount)
     except (TypeError, ValueError):
         return {"status": "error", "message": "Tip amount must be a number."}
+
+    if not math.isfinite(amount):
+        return {"status": "error", "message": "Tip amount must be finite."}
 
     if amount <= 0:
         return {"status": "error", "message": "Tip amount must be greater than zero."}

--- a/github-tip-bot/tip_bot.py
+++ b/github-tip-bot/tip_bot.py
@@ -14,6 +14,7 @@ from github import Github
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 RUSTCHAIN_NODE = os.getenv("RUSTCHAIN_NODE", "https://50.28.86.131")
 RUSTCHAIN_ADMIN_KEY = os.getenv("RUSTCHAIN_ADMIN_KEY", "")
+VERIFY_TLS = os.getenv("RUSTCHAIN_VERIFY_TLS", "true").strip().lower() not in {"0", "false", "no", "off"}
 
 # In-memory storage for demo (use database in production)
 registered_wallets = {}  # github_username -> wallet_name
@@ -26,7 +27,7 @@ def check_balance(wallet_name: str) -> dict:
             f"{RUSTCHAIN_NODE}/wallet/balance",
             params={"miner_id": wallet_name},
             timeout=10,
-            verify=False
+            verify=VERIFY_TLS
         )
         return r.json()
     except Exception as e:
@@ -42,6 +43,17 @@ def process_tip(from_user: str, to_wallet: str, amount: float, memo: str = "") -
     Process a tip transfer.
     Note: Requires admin key for actual transfers.
     """
+    # Validate amount before queueing. process_tip() is callable directly by
+    # tests/integrations, so keep this guard here instead of relying only on the
+    # comment parser's regex.
+    try:
+        amount = float(amount)
+    except (TypeError, ValueError):
+        return {"status": "error", "message": "Tip amount must be a number."}
+
+    if amount <= 0:
+        return {"status": "error", "message": "Tip amount must be greater than zero."}
+
     # Validate recipient has registered wallet
     recipient = None
     for user, wallet in registered_wallets.items():

--- a/tests/test_github_tip_bot.py
+++ b/tests/test_github_tip_bot.py
@@ -59,6 +59,17 @@ class GitHubTipBotTests(unittest.TestCase):
 
         self.assertEqual(self.tip_bot.tip_ledger, [])
 
+    def test_process_tip_rejects_non_finite_amounts(self):
+        self.tip_bot.register_wallet("alice", "alice_wallet")
+
+        for bad_amount in (float("nan"), float("inf"), "-inf"):
+            with self.subTest(amount=bad_amount):
+                result = self.tip_bot.process_tip("carol", "alice_wallet", bad_amount, "oops")
+                self.assertEqual(result["status"], "error")
+                self.assertIn("finite", result["message"])
+
+        self.assertEqual(self.tip_bot.tip_ledger, [])
+
     def test_check_balance_verifies_tls_by_default(self):
         calls = []
 

--- a/tests/test_github_tip_bot.py
+++ b/tests/test_github_tip_bot.py
@@ -48,6 +48,35 @@ class GitHubTipBotTests(unittest.TestCase):
         self.assertIn("not registered", result["message"])
         self.assertEqual(self.tip_bot.tip_ledger, [])
 
+    def test_process_tip_rejects_non_positive_amounts(self):
+        self.tip_bot.register_wallet("alice", "alice_wallet")
+
+        for bad_amount in (0, -1, "-2.5"):
+            with self.subTest(amount=bad_amount):
+                result = self.tip_bot.process_tip("carol", "alice_wallet", bad_amount, "oops")
+                self.assertEqual(result["status"], "error")
+                self.assertIn("greater than zero", result["message"])
+
+        self.assertEqual(self.tip_bot.tip_ledger, [])
+
+    def test_check_balance_verifies_tls_by_default(self):
+        calls = []
+
+        def fake_get(*args, **kwargs):
+            calls.append((args, kwargs))
+
+            class Response:
+                def json(self):
+                    return {"amount_rtc": 3}
+
+            return Response()
+
+        self.tip_bot.requests.get = fake_get
+
+        self.assertEqual(self.tip_bot.check_balance("alice_wallet"), {"amount_rtc": 3})
+        self.assertTrue(calls)
+        self.assertIs(calls[0][1]["verify"], True)
+
     def test_register_process_tip_and_leaderboard_ordering(self):
         self.assertTrue(self.tip_bot.register_wallet("alice", "alice_wallet"))
         self.assertTrue(self.tip_bot.register_wallet("bob", "bob_wallet"))


### PR DESCRIPTION
## Summary
- verify TLS certificates by default for GitHub tip bot balance checks (with `RUSTCHAIN_VERIFY_TLS=false` opt-out for local/dev nodes)
- reject zero, negative, or non-numeric tip amounts inside `process_tip()` so direct integrations cannot queue invalid ledger entries
- add regression tests for both cases

## Security impact
The previous default `verify=False` allowed MITM/interception of balance requests, and direct callers could bypass the parser and enqueue non-positive tips that corrupted leaderboard/accounting state.

## Testing
- `python3 -m pytest -q tests/test_github_tip_bot.py`

Related to the ongoing bug bounty program in #71.