### PR TITLE
Add guard-bounty-pr: flag protected-path edits from untrusted PRs

### DIFF
--- a/.github/workflows/guard-bounty-pr.yml
+++ b/.github/workflows/guard-bounty-pr.yml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+name: Guard Bounty PR Protected Paths
+
+# Flags (does not permanently block) bounty/onboarding-style PRs from
+# first-time/non-collaborator contributors that touch CI automation or
+# payout-critical paths instead of just adding their own submission
+# content. See #14981 for the incident this guards against: a "solution"
+# PR to an onboarding bounty replaced working .github/scripts/*.py
+# automation with stubs.
+#
+# This intentionally does NOT gate every path outside submissions/ --
+# real bounty work in this repo legitimately touches docs/, museum/,
+# apple2_miner/, star_tracker.py, bounties/<issue>/, etc. depending on
+# what the bounty asks for. It also never gates trusted contributors
+# (OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR) doing normal maintenance on
+# scripts/ or .github/ (see #14990, #14546). See scripts/guard_bounty_pr.py
+# for the exact logic.
+#
+# Uses pull_request_target (not pull_request) so the check can comment
+# and label on PRs from forks. This is safe here because the job never
+# checks out or executes the PR head's code -- it only reads the
+# workflow/script from the trusted base branch and calls the GitHub API
+# to list changed file paths.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: guard-bounty-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch (trusted script, not the PR head)
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Guard protected paths
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/guard_bounty_pr.py

--- a/scripts/guard_bounty_pr.py
+++ b/scripts/guard_bounty_pr.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Guard: flag bounty-submission PRs from untrusted authors that touch
+protected automation/payout paths (closes the class of bug seen in #14981,
+where a "solution" PR to an onboarding bounty gutted .github/scripts/*.py
+automation instead of adding a submission file).
+
+This is deliberately NOT a blanket "everything outside submissions/ is
+banned" rule. Real merged bounty work in this repo routinely touches
+docs/, apple2_miner/, museum/, star_tracker.py, bounties/<issue>/, and
+plenty of other paths depending on what the bounty asked for (see #2093,
+#2095, #142, #173, #2699). Banning that would break legitimate
+contributors. Likewise, trusted contributors (OWNER/MEMBER/COLLABORATOR/
+CONTRIBUTOR) routinely and legitimately touch scripts/ and .github/ as
+part of normal maintenance (see #14990, #14546) -- that is not the
+problem this guard exists to catch.
+
+What actually differentiated the #14981 incident:
+  - author_association == NONE (first-time, non-collaborator)
+  - the PR touched automation/payout-critical paths
+    (.github/workflows, .github/scripts, .github/actions,
+     scripts/, bounties.json, BOUNTY_LEDGER.md, ...)
+
+So the guard only fires when BOTH are true. It never blocks a trusted
+contributor, and it never blocks an untrusted contributor whose PR stays
+out of protected paths (which covers the overwhelming majority of real
+bounty submissions).
+
+On a hit, this posts an explanatory PR comment, applies a
+`needs-maintainer-review` label, and exits non-zero so the check shows
+red -- a request for human review, not a permanent block. A maintainer
+can always merge past a failing, non-required check.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Iterable
+
+import requests
+
+API = "https://api.github.com"
+
+# Authors at this trust level are never gated by this guard. Getting to
+# CONTRIBUTOR already requires a prior merged PR reviewed by a human.
+TRUSTED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"}
+
+# Path prefixes that carry real blast radius: CI automation, payout
+# scripts, and the ledger/registry files the payout scripts read.
+PROTECTED_PREFIXES = (
+    ".github/workflows/",
+    ".github/scripts/",
+    ".github/actions/",
+    ".github/mcp_server/",
+    "scripts/",
+)
+PROTECTED_EXACT_FILES = {
+    ".github/dependabot.yml",
+    ".github/supply-chain-allowlist.yml",
+    "bounties.json",
+    "BOUNTY_LEDGER.md",
+    "expected_miners.txt",
+}
+
+LABEL_NAME = "needs-maintainer-review"
+LABEL_COLOR = "d93f0b"
+LABEL_DESCRIPTION = "Touches protected automation/payout paths -- flagged by guard-bounty-pr for human review"
+
+
+def is_protected_path(path: str) -> bool:
+    if path in PROTECTED_EXACT_FILES:
+        return True
+    return any(path.startswith(prefix) for prefix in PROTECTED_PREFIXES)
+
+
+def fetch_changed_files(owner: str, repo: str, pr_number: int, headers: dict) -> list[str]:
+    paths: list[str] = []
+    page = 1
+    while True:
+        resp = requests.get(
+            f"{API}/repos/{owner}/{repo}/pulls/{pr_number}/files",
+            headers=headers,
+            params={"per_page": 100, "page": page},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+        paths.extend(item["filename"] for item in batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return paths
+
+
+def ensure_label(owner: str, repo: str, headers: dict) -> None:
+    resp = requests.get(f"{API}/repos/{owner}/{repo}/labels/{LABEL_NAME}", headers=headers, timeout=30)
+    if resp.status_code == 200:
+        return
+    requests.post(
+        f"{API}/repos/{owner}/{repo}/labels",
+        headers=headers,
+        json={"name": LABEL_NAME, "color": LABEL_COLOR, "description": LABEL_DESCRIPTION},
+        timeout=30,
+    )
+
+
+def apply_label(owner: str, repo: str, pr_number: int, headers: dict) -> None:
+    ensure_label(owner, repo, headers)
+    requests.post(
+        f"{API}/repos/{owner}/{repo}/issues/{pr_number}/labels",
+        headers=headers,
+        json={"labels": [LABEL_NAME]},
+        timeout=30,
+    )
+
+
+def post_comment(owner: str, repo: str, pr_number: int, protected_hits: Iterable[str], author: str, headers: dict) -> None:
+    hit_list = "\n".join(f"- `{p}`" for p in sorted(protected_hits))
+    body = (
+        "**guard-bounty-pr**: this PR is from a first-time/non-collaborator "
+        f"contributor (`{author}`) and touches automation or payout-critical paths:\n\n"
+        f"{hit_list}\n\n"
+        "Bounty/onboarding submissions are normally expected to add their own "
+        "content (docs, a submissions/ entry, a small standalone script, etc.), "
+        "not modify existing CI workflows, `.github/scripts/`, `scripts/`, or "
+        "the bounty ledger/registry files. This is exactly the pattern seen in "
+        "#14981, where a \"solution\" PR replaced working automation scripts "
+        "with stubs.\n\n"
+        "This is **not** an automatic rejection -- a maintainer needs to look "
+        "at the diff before this merges. If the changes to these paths are "
+        "legitimate and intentional, a maintainer can dismiss this and merge "
+        "normally."
+    )
+    requests.post(
+        f"{API}/repos/{owner}/{repo}/issues/{pr_number}/comments",
+        headers=headers,
+        json={"body": body},
+        timeout=30,
+    )
+
+
+def main() -> None:
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+    if not github_token:
+        sys.exit("GITHUB_TOKEN environment variable is required")
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if not event_path or not os.path.exists(event_path):
+        sys.exit("GITHUB_EVENT_PATH not found -- this script must run inside a pull_request(_target) job")
+
+    repo_slug = os.environ.get("GITHUB_REPOSITORY", "Scottcjn/rustchain-bounties")
+    headers = {
+        "Authorization": f"Bearer {github_token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    with open(event_path, encoding="utf-8") as f:
+        event = json.load(f)
+
+    pr = event.get("pull_request")
+    if not pr:
+        print("No pull_request in event payload, nothing to do.")
+        return
+
+    owner, repo = repo_slug.split("/", 1)
+    pr_number = pr["number"]
+    author = pr["user"]["login"]
+    association = (pr.get("author_association") or "NONE").upper()
+
+    if association in TRUSTED_ASSOCIATIONS:
+        print(f"Author {author} has association {association} (trusted) -- skipping guard.")
+        return
+
+    changed = fetch_changed_files(owner, repo, pr_number, headers)
+    protected_hits = [p for p in changed if is_protected_path(p)]
+
+    if not protected_hits:
+        print(f"Author {author} ({association}) touched no protected paths -- skipping guard.")
+        return
+
+    print(f"Author {author} ({association}) touched protected paths:")
+    for p in protected_hits:
+        print(f"  - {p}")
+
+    post_comment(owner, repo, pr_number, protected_hits, author, headers)
+    apply_label(owner, repo, pr_number, headers)
+
+    sys.exit(
+        "guard-bounty-pr: PR from a non-collaborator touches protected "
+        "automation/payout paths -- flagged for maintainer review "
+        f"(see {len(protected_hits)} path(s) above and the PR comment)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_guard_bounty_pr.py
+++ b/scripts/test_guard_bounty_pr.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Regression tests for the bounty-PR protected-paths guard.
+
+Run: python3 scripts/test_guard_bounty_pr.py   (or `pytest scripts/test_guard_bounty_pr.py`)
+
+Focus: `is_protected_path` and `TRUSTED_ASSOCIATIONS` must reproduce the
+exact split seen in real history --
+
+  - #14981 ("solution" PR that gutted .github/scripts/*.py) SHOULD hit
+    the guard (untrusted author + protected paths).
+  - #14990 and #14546 (legit maintenance touching scripts/ and
+    .github/workflows/) SHOULD NOT hit the guard, because they came
+    from OWNER/CONTRIBUTOR.
+  - #12741, #2094, #2095, #2093, #173 (real merged bounty submissions
+    touching docs/, museum/, apple2_miner/, star_tracker.py, etc.)
+    SHOULD NOT hit the guard even though the author was untrusted,
+    because none of those paths are protected.
+
+These tests pin that behavior so a future edit to the prefix/exact-file
+lists can't silently reintroduce false positives on legitimate
+contributors or false negatives on the #14981 pattern.
+"""
+
+import unittest
+
+import guard_bounty_pr as g
+
+
+class ProtectedPathDetection(unittest.TestCase):
+    def test_github_scripts_are_protected(self):
+        # The exact #14981 file set.
+        for p in (
+            ".github/scripts/backfill_xp_from_ledger_issue104.py",
+            ".github/scripts/file_bug_report.py",
+            ".github/scripts/update_xp_tracker.py",
+        ):
+            self.assertTrue(g.is_protected_path(p), p)
+
+    def test_github_workflows_actions_mcp_are_protected(self):
+        for p in (
+            ".github/workflows/bounty-payout.yml",
+            ".github/actions/rtc-reward-action/action.yml",
+            ".github/mcp_server/rustchain_mcp/server.py",
+        ):
+            self.assertTrue(g.is_protected_path(p), p)
+
+    def test_root_scripts_dir_is_protected(self):
+        for p in ("scripts/auto-pay.py", "scripts/bounty_payout.py", "scripts/verify_bounties.py"):
+            self.assertTrue(g.is_protected_path(p), p)
+
+    def test_ledger_and_registry_files_are_protected(self):
+        for p in (
+            "bounties.json",
+            "BOUNTY_LEDGER.md",
+            "expected_miners.txt",
+            ".github/dependabot.yml",
+            ".github/supply-chain-allowlist.yml",
+        ):
+            self.assertTrue(g.is_protected_path(p), p)
+
+    def test_real_merged_submission_paths_are_not_protected(self):
+        # Drawn from actual merged bounty-submission PRs: #12741, #2094,
+        # #2095, #2093, #173. None of these should ever trip the guard.
+        for p in (
+            "submissions/block-explorer-517-jonasxzb/report.md",
+            "star_tracker.py",
+            "museum/index.html",
+            "apple2_miner/Makefile",
+            "apple2_miner/miner.c",
+            "docs/wrtc-onboarding/README.md",
+            "docs/wrtc-pack/dexscreener-request.md",
+        ):
+            self.assertFalse(g.is_protected_path(p), p)
+
+    def test_tests_dir_is_not_protected(self):
+        # tests/ is a normal contribution area (e.g. #14990 adds a test
+        # alongside a scripts/ fix); it is not itself protected. The
+        # guard still fires on that PR because of the scripts/ file,
+        # not because of the tests/ file.
+        self.assertFalse(g.is_protected_path("tests/test_auto_triage_claims.py"))
+
+
+class TrustedAssociations(unittest.TestCase):
+    def test_owner_member_collaborator_contributor_are_trusted(self):
+        for assoc in ("OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"):
+            self.assertIn(assoc, g.TRUSTED_ASSOCIATIONS)
+
+    def test_none_and_first_timer_are_not_trusted(self):
+        for assoc in ("NONE", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER"):
+            self.assertNotIn(assoc, g.TRUSTED_ASSOCIATIONS)
+
+
+class RealWorldShapes(unittest.TestCase):
+    """End-to-end shape checks: association + changed files -> would the
+    guard fire? Mirrors the exact PRs referenced above."""
+
+    def _would_fire(self, association: str, files: list) -> bool:
+        if association.upper() in g.TRUSTED_ASSOCIATIONS:
+            return False
+        return any(g.is_protected_path(p) for p in files)
+
+    def test_pr_14981_bad_solution_fires(self):
+        self.assertTrue(
+            self._would_fire(
+                "NONE",
+                [
+                    ".github/scripts/backfill_xp_from_ledger_issue104.py",
+                    ".github/scripts/file_bug_report.py",
+                    ".github/scripts/update_xp_tracker.py",
+                ],
+            )
+        )
+
+    def test_pr_14990_owner_maintenance_does_not_fire(self):
+        self.assertFalse(
+            self._would_fire(
+                "OWNER",
+                [
+                    ".github/workflows/auto-triage-claims.yml",
+                    "scripts/auto_triage_claims.py",
+                    "tests/test_auto_triage_claims.py",
+                ],
+            )
+        )
+
+    def test_pr_14546_contributor_maintenance_does_not_fire(self):
+        self.assertFalse(
+            self._would_fire("CONTRIBUTOR", ["scripts/auto-pay.py", "scripts/test_auto_pay.py"])
+        )
+
+    def test_pr_12741_legit_submission_does_not_fire(self):
+        self.assertFalse(
+            self._would_fire(
+                "NONE",
+                [
+                    "submissions/block-explorer-517-jonasxzb/report.md",
+                    "submissions/block-explorer-517-jonasxzb/anchors-404.png",
+                ],
+            )
+        )
+
+    def test_hypothetical_ledger_tamper_fires(self):
+        self.assertTrue(self._would_fire("FIRST_TIME_CONTRIBUTOR", ["bounties.json"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

PR #14981 was a "solution" to an onboarding bounty (#2781) that overwrote working `.github/scripts/*.py` automation with stubs (one file cut from 354 lines to 36, another rewritten wholesale) instead of adding a submission. Nothing caught this automatically before a human had to notice and close it. Farmers and confused agents open this class of PR regularly.

## What this adds

`.github/workflows/guard-bounty-pr.yml` runs `scripts/guard_bounty_pr.py` on every PR (`pull_request_target`, so it also covers fork PRs). The guard only fires when **both** of these are true:

1. **Untrusted author** — `author_association` is not `OWNER`, `MEMBER`, `COLLABORATOR`, or `CONTRIBUTOR`. Reaching `CONTRIBUTOR` already requires a prior merged, human-reviewed PR.
2. **Protected path touched** — the PR modifies anything under `.github/workflows/`, `.github/scripts/`, `.github/actions/`, `.github/mcp_server/`, `scripts/`, or one of the ledger/registry files (`bounties.json`, `BOUNTY_LEDGER.md`, `expected_miners.txt`, `.github/dependabot.yml`, `.github/supply-chain-allowlist.yml`).

On a hit it posts an explanatory PR comment, applies a `needs-maintainer-review` label, and exits non-zero so the check shows red. This repo doesn't mark it as a required check, so it never permanently blocks a merge — a maintainer can look at the diff and merge past it if the change is legitimate.

## Why not "must stay under submissions/**"

I looked at how real bounty submissions in this repo actually merge before picking the allowed-paths logic (this was the original framing I was given, and it doesn't hold up against history):

- #12741 — `submissions/block-explorer-517-jonasxzb/*` (this one *is* under submissions/)
- #2094 — `star_tracker.py` (root file, not under submissions/)
- #2095 — `museum/index.html`
- #2093 — `apple2_miner/Makefile`, `apple2_miner/miner.c`
- #142 — `docs/API_REFERENCE.md`, `docs/MINERS_SETUP_GUIDE.md`
- #173 — `docs/wrtc-onboarding/*`, `docs/wrtc-pack/*`

A hard "only submissions/** may change" rule would have flagged nearly all of these. Bounty work here legitimately lands wherever the bounty issue asks it to. I also checked legitimate maintainer/contributor PRs that touch the paths I *did* end up protecting:

- #14990 (OWNER) — fixes `.github/workflows/auto-triage-claims.yml` + `scripts/auto_triage_claims.py`
- #14546 (CONTRIBUTOR) — fixes `scripts/auto-pay.py`

Gating on path alone would have flagged those too. Gating on **(untrusted author) AND (protected path)** is the actual shape of the #14981 incident (author association `NONE`) and produces zero false positives against every real PR I sampled.

## Safety of `pull_request_target`

The job never checks out or executes the PR head's code. It checks out the workflow + script from the base branch (so a PR can't tamper with the guard that's reviewing it) and only calls the GitHub REST API to list changed file paths, post a comment, and apply a label.

## Testing

```
$ python3 -m pytest scripts/test_guard_bounty_pr.py -v
...
13 passed in 0.08s
```

The tests pin `is_protected_path` and `TRUSTED_ASSOCIATIONS` against the real PR shapes above (#14981 fires, #14990/#14546 don't, #12741/#2093/#2094/#2095/#173-style paths don't), plus a hypothetical ledger-tamper case, so a future edit to the lists can't silently reopen either kind of false result. Also did an end-to-end dry run of `main()` with a mocked GitHub API reproducing #14981's exact file set (comment posted, label created + applied, exits non-zero) and a second dry run for a trusted OWNER author (zero API calls, returns cleanly).

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/guard-bounty-pr.yml')); print('OK')"
OK
```

Not merging — for review.