### PR TITLE
fix(auto-pay): stop auto-awarding the repo owner for their own PRs

### DIFF
--- a/scripts/auto-pay.py
+++ b/scripts/auto-pay.py
@@ -279,6 +279,15 @@ def main() -> None:
             print(f"No directive; author {pr_author} is a bot — no auto-award.")
             return
 
+        # The repo owner is the payer, not a bounty recipient. Auto-awarding the
+        # owner for merging their own PRs drains the founder wallet on every
+        # self-merge (observed 2026-07-09: six 5 RTC self-pays in one evening
+        # of routine merges). A human `Payment:` directive is still the way to
+        # pay a genuine owner contribution deliberately.
+        if pr_author.lower() == repo_owner.lower():
+            print(f"No directive; author {pr_author} is the repo owner — no self-award.")
+            return
+
         files = fetch_pr_files(repo, pr_number)
         total_changed = sum(f.get("additions", 0) + f.get("deletions", 0) for f in files)
         paths = [f.get("filename", "") for f in files]


### PR DESCRIPTION
## What

The RTC Auto-Pay on PR Merge workflow's auto-tier path pays a flat low-risk award (5 RTC) to the PR author. It skips bots (dependabot, github-actions) but has no guard for the repo owner, so every time the owner merges one of their own PRs the founder wallet pays the owner.

## Evidence

On 2026-07-09 this fired six times in one evening of routine self-merges (docs pass, a couple of fixes, tooling PRs), queuing 30 RTC of pending self-pay that had to be voided by hand before the 24h auto-confirm. The pending rows all had the default admin_transfer reason and resolved to the owner miner_id.

## Fix

One guard, mirroring the bot check directly above it: skip the auto-award when `pr_author == repo_owner`. A deliberate owner payout is still possible through an explicit `Payment:` directive, which is the intended path for anything above the auto-tier.

## Not touched

The idempotency path is fine and was not the cause here. Each of the six payments was a distinct merged PR, not a double-fire. This only removes the owner from the auto-award recipient set.