### PR TITLE
Fix: add required BoTTube /health, /api/videos, /api/feed calls and doc links to example

### DIFF
--- a/crewai-template/examples/basic_api_demo.py
+++ b/crewai-template/examples/basic_api_demo.py
@@ -47,11 +47,17 @@ def main():
     print(f"   Wallet: aric-saxp-alpha")
     print(f"   Balance: {balance}")
     
-    # 5. BoTTube Stats
-    print("\n5. Getting BoTTube stats...")
+    # 5. BoTTube Integration
+    print("\n5. BoTTube API integration...")
+    print("   Docs: https://bottube.ai/api/docs")
+    print("   Developers: https://bottube.ai/developers")
     try:
-        stats = bt.get_stats()
-        print(f"   Stats: {stats}")
+        health = bt.health()
+        print(f"   Health: {health}")
+        videos = bt.videos(limit=3)
+        print(f"   Videos (sample): {videos[:1] if isinstance(videos, list) else videos}")
+        feed = bt.feed(limit=3)
+        print(f"   Feed (sample): {feed[:1] if isinstance(feed, list) else feed}")
     except Exception as e:
         print(f"   (BoTTube API not available: {e})")
     


### PR DESCRIPTION
## Summary
The BoTTube integration example (basic_api_demo.py) only calls get_stats() and lacks required endpoints (/health, /api/videos or /api/feed or /api/upload) and setup/doc links. We add a proper BoTTube section with health, videos, and feed calls plus developer links.

**Fixes:** https://github.com/Scottcjn/rustchain-bounties/issues/303

---

### Changes Made
- `crewai-template/examples/basic_api_demo.py`

---

> **Bounty Claim:** If this PR resolves the issue and is eligible for the bounty, please send the payout via PayPal: https://www.paypal.com/paypalme/plutoxvii
