### PR TITLE
Refresh frozen README stats, fix halving claim, verify API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 [![Open Bounties](https://img.shields.io/github/issues/Scottcjn/rustchain-bounties/bounty?label=open%20bounties&color=brightgreen)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
 [![Stars](https://img.shields.io/github/stars/Scottcjn/rustchain-bounties?style=social)](https://github.com/Scottcjn/rustchain-bounties/stargazers)
-[![RTC Pool](https://img.shields.io/badge/RTC%20Pool-5%2C900%2B%20RTC-gold)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
+[![Open Bounties](https://img.shields.io/github/issues/Scottcjn/rustchain-bounties/bounty?label=Open%20Bounties&color=gold)](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty)
 [![BCOS](https://img.shields.io/badge/BCOS-L1%20Certified-blue)](https://github.com/Scottcjn/RustChain)
 
-**131 open bounties · 5,900+ RTC available · No experience required for many tasks**
+**200+ open bounties · 72,499+ RTC already paid to 1,124 contributors · No experience required for many tasks**
 
 [![Total Paid](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Frustchain.org%2Fpayouts.json&query=%24.total_paid_rtc&label=Total%20Paid&suffix=%20RTC&color=gold)](BOUNTY_LEDGER.md)
 
@@ -88,11 +88,13 @@ Once verified, RTC is sent to your wallet. First time? We will help you set one 
 
 ## Stats
 
-- **Total bounties created**: 500+
-- **Open bounties**: 131
-- **RTC available**: 5,900+
-- **Contributors paid**: 14
-- **Reference rate**: 1 RTC = $0.15 USD
+Live payout figures are published at [rustchain.org/payouts.json](https://rustchain.org/payouts.json). Snapshot as of 2026-07-25:
+
+- **Open bounties**: 228 ([live count](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aissue+is%3Aopen+label%3Abounty))
+- **RTC paid out**: 72,499+
+- **Contributors paid**: 1,124 unique recipients
+- **Payout transactions**: 3,634
+- **Reference rate**: 1 RTC = $0.15 USD ([live rate](https://rustchain.org/api/tokenomics))
 
 ---
 

--- a/articles/rustchain-vs-ethereum-pos.md
+++ b/articles/rustchain-vs-ethereum-pos.md
@@ -149,7 +149,7 @@ The hard cap at 8,388,608 is notably smaller than Bitcoin's 21 million, making R
 | Metric | ETH | RTC |
 |--------|-----|-----|
 | Max supply | Unlimited | 8,388,608 (hard cap) |
-| Current inflation | ~0.3%/year | Decreasing (halving schedule) |
+| Current inflation | ~0.3%/year | Fixed 1.5 RTC per epoch, no halving (tapers to zero at the hard cap) |
 | Staking model | Liquid staking common | Hardware-bonded |
 | Monetary policy | Social consensus | Code-enforced cap |
 | Scarcity narrative | "Ultrasound money" | "Digital antiquity" |

--- a/docs/api-reference/README.md
+++ b/docs/api-reference/README.md
@@ -2,6 +2,8 @@
 
 **Bounty: 20 RTC** | 所有接口附带中文说明 + Python SDK 示例
 
+> **状态说明 (verified 2026-07-25):** 本文档由社区赏金提交，部分接口在当前生产节点 (`https://rustchain.org`) 上并未部署。实测可用的接口包括 `/health`、`/epoch`、`/api/miners`、`/api/fee_pool`、`/wallet/balance?miner_id=<id>`、`/api/badge/<miner_id>`、`/api/tokenomics` 以及 `/explorer`。治理、提现、P2P、锁定等章节描述的接口在当前节点返回 404，属于历史设计或未部署功能，使用前请先用 `curl` 验证。
+
 ---
 
 ## 目录 / Table of Contents
@@ -184,15 +186,6 @@ curl -k https://rustchain.org/api/bounty-multiplier
 
 ---
 
-### `GET /api/balances`
-全网余额汇总
-
-```bash
-curl -k https://rustchain.org/api/balances
-```
-
----
-
 ### `GET /api/metrics`
 Prometheus 兼容的监控指标
 
@@ -307,15 +300,16 @@ curl -k https://rustchain.org/hall-of-fame
 查询矿工余额（RTC）
 
 ```bash
-curl -k https://rustchain.org/balance/0xPUBLIC_KEY_HERE
+curl -k "https://rustchain.org/wallet/balance?miner_id=<miner_id>"
 ```
 
-**响应示例:** `{"balance_rtc": 150.5, "locked_rtc": 10.0}`
+**响应示例:** `{"amount_i64": 124951060000, "amount_rtc": 124951.06, "miner_id": "founder_dev_fund"}`
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `balance_rtc` | float | 可用余额（RTC） |
-| `locked_rtc` | float | 锁定余额（质押中） |
+| `amount_i64` | int | 余额（最小单位整数） |
+| `amount_rtc` | float | 余额（RTC） |
+| `miner_id` | string | 查询的钱包 / 矿工 ID |
 
 ---
 
@@ -324,11 +318,11 @@ curl -k https://rustchain.org/balance/0xPUBLIC_KEY_HERE
 
 ---
 
-### `GET /api/balances`
-全网余额分布
+### 全网余额分布
+当前节点没有一次性返回全网余额的公开接口。全网余额可通过区块浏览器查看：
 
-```bash
-curl -k https://rustchain.org/api/balances
+```
+https://rustchain.org/explorer
 ```
 
 ---


### PR DESCRIPTION
Facts and URLs checked against the live node and payouts feed on 2026-07-25.

README:
- Stats were frozen at "131 open bounties, 5,900+ RTC, 14 contributors paid". Live figures: https://rustchain.org/payouts.json reports 72,499+ RTC paid to 1,124 unique recipients over 3,634 transactions, and the bounty label search shows 228 open issues. The stats block now links the live sources and datestamps the snapshot, and the static RTC Pool badge is now a dynamic open-bounties badge so it cannot freeze again.

articles/rustchain-vs-ethereum-pos.md:
- The tokenomics table claimed a "halving schedule". RIP-0004 and the node code specify a fixed 1.5 RTC per-epoch emission with no halving; the row now says that.

docs/api-reference/README.md (zh-CN):
- `GET /api/balances` was documented twice and returns 404; there is no live network-wide balances endpoint, so those entries now point at the explorer instead.
- The `/wallet/balance` example used a URL shape (`/balance/0xKEY`) that 404s and a response shape the node does not return. Now shows the real call and the real response fields (`amount_i64`, `amount_rtc`, `miner_id`), verified live.
- Added a datestamped notice at the top: many documented endpoints (governance, withdraw, p2p, locks, rewards, `/api/metrics`, `/api/stats`, etc.) return 404 on the current production node. I verified each with curl but did not rewrite the whole document; the notice tells readers to verify before relying on an entry. Flagging the full rewrite as follow-up work for a human.