### PR TITLE
Require a maintainer to approve a payout by comment

### DIFF
--- a/scripts/bounty_payout.py
+++ b/scripts/bounty_payout.py
@@ -233,7 +233,28 @@ for i in issues:
     # only `body,comments`, so the fallback was unreachable in production.
     a=d.get("author") or {}
     claimant=a.get("login") if isinstance(a, dict) else None
-    eligible = ("bounty-eligible" in labels) or any("Verified eligible" in (c.get("body") or "") for c in coms)
+    # Only a maintainer may approve a claim by comment. Without this, anyone
+    # could comment "Verified eligible" on their own issue and be paid on the
+    # next cron: the repo is public with issues open, and this runs every six
+    # hours with the admin key.
+    #
+    # Note the comment branch never had a legitimate automated producer. The
+    # PR-review gate emits lowercase "verified eligible", which this
+    # case-sensitive check does not match, so the only thing the branch ever
+    # accepted was a human typing it, or anyone at all. `auto-pay.py` already
+    # does the equivalent author check.
+    _APPROVER_ROLES = {"OWNER", "MEMBER", "COLLABORATOR"}
+
+    def _maintainer_approved(comment):
+        if "Verified eligible" not in (comment.get("body") or ""):
+            return False
+        role = (comment.get("authorAssociation") or "").upper()
+        if role in _APPROVER_ROLES:
+            return True
+        login = ((comment.get("author") or {}).get("login") or "").lower()
+        return login == REPO.split("/")[0].lower()
+
+    eligible = ("bounty-eligible" in labels) or any(_maintainer_approved(c) for c in coms)
     if not eligible: continue
     if any("RTC-AutoPay-Confirmed" in (c.get("body") or "") for c in coms): continue
     wallet, source = resolve_wallet(d.get("body"), coms, claimant_login=claimant)


### PR DESCRIPTION
`scripts/bounty_payout.py:236` decided eligibility like this:

```python
eligible = ("bounty-eligible" in labels) or any("Verified eligible" in (c.get("body") or "") for c in coms)
```

There is no check on who wrote the comment. This repo is public, issues are open, there are around 2,595 of them, and `bounty-payout.yml` runs on `cron: "23 */6 * * *"` with `RTC_ADMIN_KEY` in scope. So the sequence is: open an issue whose title contains "review" and "pr", put an `RTC` address in the body, comment `Verified eligible` on your own issue, and collect 3 RTC within six hours. `MAX_PER_RUN` is 40, so the ceiling is 120 RTC per run.

Two things make this a bug rather than a deliberate honour-system design.

The sibling script does the check. `auto-pay.py:247` has `if author.lower() != repo_owner.lower()`, so the same pipeline already knows this matters.

And the comment branch never had a legitimate automated producer. The review gate that is supposed to approve claims emits **lowercase** `**verified eligible**` at `pr_review_gate.py:286`, which this case-sensitive substring check does not match. So in practice the branch has only ever accepted a maintainer typing the phrase by hand, or anybody at all. The legitimate path has always been the `bounty-eligible` label, which this PR does not touch.

The fix requires the approving comment to come from someone with an `authorAssociation` of OWNER, MEMBER or COLLABORATOR, with a fallback to matching the repo owner's login when the association field is absent. `gh issue view --json comments` does return `authorAssociation`, which I confirmed against the live API before relying on it.

Tested standalone against the real comment shapes, 8 of 8:

| case | result |
|---|---|
| owner approves, as on the real #11561 | eligible |
| collaborator approves | eligible |
| claimant self-approves | rejected |
| first-time contributor approves | rejected |
| owner login present, association field missing | eligible |
| unrelated comment from the owner | rejected |
| the gate's lowercase text | rejected, as it always was |

I checked for exploitation before writing this. Across the issues carrying that phrase, the only account that has actually posted it as a comment is `Scottcjn`, association OWNER. So this looks live but unused, and no payouts need unwinding.

Worth a separate look, not changed here: `:123` returns `True, _post(...)` on any HTTP 200, so a node reply of `{"ok": false, "error": "insufficient balance"}` is recorded as paid, the claim is commented `RTC-AutoPay-Confirmed` and closed. `auto-pay.py` checks `result.get("ok", False)` and this one does not.
