### PR TITLE
fix: check response payload in transfer() — soft failure recorded as paid (fixes #16390)

### DIFF
--- a/scripts/bounty_payout.py
+++ b/scripts/bounty_payout.py
@@ -119,9 +119,15 @@ def transfer(to,memo,idem):
     body=json.dumps({"from_miner":FROM,"to_miner":to,"amount_rtc":RATE,"memo":memo,"idempotency_key":idem}).encode()
     # node gunicorn is bound to 127.0.0.1:8099 (nginx-only) — reach it via the
     # nginx HTTPS endpoint (the working path); fall back to the internal port.
+    last="no endpoint attempted"
     for url in (f"https://{HOST}/wallet/transfer", f"http://{HOST}:{PORT}/wallet/transfer"):
-        try: return True,_post(url,body)
-        except Exception as e: last=str(e)[:160]
+        try:
+            resp=_post(url,body)
+        except Exception as e:
+            last=str(e)[:160]; continue
+        if isinstance(resp,dict) and resp.get("ok") is True:
+            return True,resp
+        return False,resp          # node answered and declined — do not retry the fallback
     return False,last
 def _is_bot_login(login, user_obj):
     """Return True if the comment/author appears to be a bot.


### PR DESCRIPTION
## Fixes #16390

### Bug
`transfer()` in `scripts/bounty_payout.py` treated every non-exception HTTP response as a successful payment. A node response of `200 OK` carrying `{"ok": false, ...}` (insufficient balance, unknown wallet, rejected idempotency key, etc.) was recorded as a successful payout: the claim was commented as `RTC-AutoPay-Confirmed`, closed as `completed`, and counted in the run total — while no RTC moved.

### Fix
- Parse the response body and check `resp.get("ok") is True` before returning success
- On an explicit 2xx refusal (falsy `ok`), return `False` immediately without retrying the fallback endpoint (avoiding double-send risk if the two endpoints ever diverge)
- Initialize `last` to `"no endpoint attempted"` for clearer error messages on network failure

### Wallet
FaaFyfxR9WAQrL7F98QMMqJmWQmQqTqFkTqKkqKkqKkqKkqKkqK