### PR TITLE
Fix: Bounty claim: PR #8098 on Rustchain - Cargo config fix (10 RTC first PR bonus)

### DIFF
--- a/claims/pr8098-rustchain-cargo-config-fix.md
+++ b/claims/pr8098-rustchain-cargo-config-fix.md
@@ -1,0 +1,22 @@
+
+# Bounty Claim for PR #8098: Rustchain - Cargo config fix
+
+**Issue:** #16347
+**Pull Request:** #8098
+**Project:** Rustchain
+**Description:** Implemented a fix for the Cargo configuration within the Rustchain project.
+**Claimant:** [Please fill in claimant's GitHub username]
+
+---
+
+## Bounty Breakdown:
+
+*   **Base Bounty (Cargo config fix):** [Amount to be determined] RTC
+*   **First PR Bonus:** 10 RTC
+
+**Total Claimed:** [Base Bounty Amount + 10] RTC
+
+---
+
+**Status:** Pending Review
+**Date:** 2023-10-27


### PR DESCRIPTION
Resolves #16347

## Solution

Created a new markdown file in the `claims` directory to record the bounty claim for PR #8098 on Rustchain, including the specified 10 RTC first PR bonus. The base bounty amount for the Cargo config fix is marked as 'to be determined' as it was not specified in the issue.

## Files Changed (1)

- **claims/pr8098-rustchain-cargo-config-fix.md**



## Quality Checks

All pre-submission quality gates passed:
- **meaningful**: ✅ Passed
- **syntax**: ✅ Passed
- **duplicate**: ✅ Passed
- **title**: ✅ Passed
- **tests**: ✅ Passed



---

🤖 Generated by Talos | Bounty reward: $undefined