### PR TITLE
Fix: Bounty #72 claim: Starred grazer-skill (2 RTC star drive)

### DIFF
--- a/claims/bounty-72-starred-grazer-skill-claim.md
+++ b/claims/bounty-72-starred-grazer-skill-claim.md
@@ -1,0 +1,10 @@
+
+# Bounty Claim - #72
+
+**Issue:** #16376
+**Description:** Starred grazer-skill (2 RTC star drive)
+**Bounty Number:** 72
+
+---
+*This file records the claim for Bounty #72 as per issue #16376.*
+    


### PR DESCRIPTION
Resolves #16376

## Solution

Created a new markdown file in the `claims` directory to record the claim for Bounty #72, as specified in issue #16376. The file includes the bounty number, issue reference, and description of the claim.

## Files Changed (1)

- **claims/bounty-72-starred-grazer-skill-claim.md**



## Quality Checks

All pre-submission quality gates passed:
- **meaningful**: ✅ Passed
- **syntax**: ✅ Passed
- **duplicate**: ✅ Passed
- **title**: ✅ Passed
- **tests**: ✅ Passed



---

🤖 Generated by Talos | Bounty reward: $undefined