### PR TITLE
fix: fail closed on payout delivery state

### DIFF
--- a/.github/workflows/confirm-pending.yml
+++ b/.github/workflows/confirm-pending.yml
@@ -35,10 +35,12 @@ jobs:
           RTC_VPS_HOST: ${{ secrets.RTC_VPS_HOST }}
           RTC_ADMIN_KEY: ${{ secrets.RTC_ADMIN_KEY }}
         run: |
+          set -euo pipefail
           if [ -z "$RTC_VPS_HOST" ] || [ -z "$RTC_ADMIN_KEY" ]; then
             echo "::error::RTC_VPS_HOST / RTC_ADMIN_KEY not configured"; exit 1
           fi
           total=0
+          stale=0
           # Safety cap: 60 iterations * 500 = up to 30,000 transfers/run.
           for i in $(seq 1 60); do
             code=$(curl -sk -o resp.json -w '%{http_code}' --max-time 60 \
@@ -49,7 +51,15 @@ jobs:
             read confirmed stale < <(python3 - <<'PY'
           import json
           d = json.load(open('resp.json'))
-          print(d.get('confirmed_count', 0), d.get('stale_pending_count', 0))
+          if d.get('ok') is not True:
+              raise SystemExit(f"confirm refused: {d.get('error', 'ok != true')}")
+          confirmed = d.get('confirmed_count')
+          stale = d.get('stale_pending_count')
+          if not isinstance(confirmed, int) or confirmed < 0:
+              raise SystemExit("invalid confirmed_count")
+          if not isinstance(stale, int) or stale < 0:
+              raise SystemExit("invalid stale_pending_count")
+          print(confirmed, stale)
           PY
           )
             total=$((total + confirmed))
@@ -59,4 +69,9 @@ jobs:
             [ "${stale:-0}" -eq 0 ] && { echo "queue drained"; break; }
             [ "${confirmed:-0}" -eq 0 ] && { echo "no progress this iter; stopping"; break; }
           done
+          if [ "${stale:-0}" -gt 0 ]; then
+            echo "::error::confirmation stopped with $stale stale transfer(s) undelivered"
+            cat resp.json
+            exit 1
+          fi
           echo "confirmed $total transfer(s) this run"

--- a/scripts/auto-pay.py
+++ b/scripts/auto-pay.py
@@ -44,9 +44,16 @@ PAYMENT_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Duplicate-detection: if this string appears in any comment, payment was
-# already processed for this PR.
+# Duplicate-detection uses an exact structured marker written by trusted
+# automation (or the repository owner). Public PR comments are untrusted: a
+# contributor must not be able to suppress their own or somebody else's payout
+# by copying this string into a comment.
 ALREADY_PAID_MARKER = "RTC-AutoPay-Confirmed"
+FAILED_MARKER = "RTC-AutoPay-Failed"
+PAID_MARKER_RE = re.compile(
+    r"<!--\s*RTC-AutoPay-Confirmed\s+kind=(?:directive|auto-tier)\s+"
+    r"pending_id=[^\s>]+\s*-->"
+)
 
 # ---------------------------------------------------------------------------
 # Conservative auto-tier (folded in from the former sophia-auto-approve.yml,
@@ -136,6 +143,14 @@ def post_comment(repo: str, pr_number: str, body: str) -> None:
     resp = requests.post(url, headers=gh_headers(), json={"body": body})
     resp.raise_for_status()
     print(f"Posted confirmation comment on PR #{pr_number}")
+
+
+def has_trusted_paid_marker(comment: dict, repo_owner: str) -> bool:
+    """True only for an exact paid marker from trusted automation/owner."""
+    user = comment.get("user") or comment.get("author") or {}
+    login = (user.get("login") or "").lower() if isinstance(user, dict) else ""
+    trusted = {repo_owner.lower(), "github-actions", "github-actions[bot]"}
+    return login in trusted and bool(PAID_MARKER_RE.search(comment.get("body") or ""))
 
 
 def transfer_rtc(vps_host: str, admin_key: str, to_wallet: str,
@@ -231,7 +246,7 @@ def main() -> None:
 
     # --- Check for duplicate run ------------------------------------------
     for c in comments:
-        if ALREADY_PAID_MARKER in (c.get("body") or ""):
+        if has_trusted_paid_marker(c, repo_owner):
             print(f"Payment already processed (found {ALREADY_PAID_MARKER}). Skipping.")
             return
 
@@ -356,7 +371,7 @@ def main() -> None:
             f"but the transfer was rejected:\n\n"
             f"```\n{error}\n```\n\n"
             f"Please process this payment manually.\n\n"
-            f"<!-- {ALREADY_PAID_MARKER}:FAILED -->"
+            f"<!-- {FAILED_MARKER} -->"
         )
         post_comment(repo, pr_number, fail_body)
         sys.exit(1)

--- a/scripts/bounty_payout.py
+++ b/scripts/bounty_payout.py
@@ -21,7 +21,8 @@ SAFETY:
 Env: GITHUB_TOKEN, RTC_ADMIN_KEY, RTC_VPS_HOST, GH_REPO, RATE_RTC(3), MAX_PER_RUN(40).
 
 RTC_VPS_HOST must name the host covered by the node's TLS certificate. The
-payer intentionally has no plaintext or certificate-verification fallback.
+legacy production IP is translated to its certificate hostname so existing
+workflow secrets keep working without a plaintext or verification fallback.
 """
 import os, re, json, time, subprocess, ssl, urllib.request, urllib.error, importlib.util
 
@@ -42,7 +43,24 @@ def _load_second_act():
 
 _second_act = _load_second_act()
 TOKEN=os.environ["GITHUB_TOKEN"]; ADMIN=os.environ["RTC_ADMIN_KEY"]
-HOST=os.environ.get("RTC_VPS_HOST","50.28.86.131"); REPO=os.environ.get("GH_REPO","Scottcjn/rustchain-bounties")
+LEGACY_NODE_IP="50.28.86.131"
+NODE_TLS_HOST="bulbous-bouffant.metalseed.net"
+
+
+def _certificate_host(configured=None):
+    """Return a hostname that can pass TLS verification.
+
+    The workflow historically stored the production node's raw IP in
+    RTC_VPS_HOST. Its public certificate covers NODE_TLS_HOST, not that IP, so
+    enabling hostname verification without this exact compatibility mapping
+    would make the security fix stop every payout until a secret was edited.
+    Only the known production IP is translated; custom hosts are untouched.
+    """
+    host = configured if configured is not None else os.environ.get("RTC_VPS_HOST", NODE_TLS_HOST)
+    return NODE_TLS_HOST if host == LEGACY_NODE_IP else host
+
+
+HOST=_certificate_host(); REPO=os.environ.get("GH_REPO","Scottcjn/rustchain-bounties")
 RATE=float(os.environ.get("RATE_RTC","3"))
 # Hard ceiling re-enforced at payout time, independent of any gate.
 MAX_CLAIM_RTC=float(os.environ.get("MAX_CLAIM_RTC","25")); MAXRUN=int(os.environ.get("MAX_PER_RUN","40"))

--- a/scripts/bounty_payout.py
+++ b/scripts/bounty_payout.py
@@ -19,6 +19,9 @@ SAFETY:
   - idempotency_key=bounty73-claim-<n> + 'RTC-AutoPay-Confirmed' marker => never double-pays
   - MAX_PER_RUN aggregate cap (default 40) — hard stop per run, surfaced in log
 Env: GITHUB_TOKEN, RTC_ADMIN_KEY, RTC_VPS_HOST, GH_REPO, RATE_RTC(3), MAX_PER_RUN(40).
+
+RTC_VPS_HOST must name the host covered by the node's TLS certificate. The
+payer intentionally has no plaintext or certificate-verification fallback.
 """
 import os, re, json, time, subprocess, ssl, urllib.request, urllib.error, importlib.util
 
@@ -43,7 +46,7 @@ HOST=os.environ.get("RTC_VPS_HOST","50.28.86.131"); REPO=os.environ.get("GH_REPO
 RATE=float(os.environ.get("RATE_RTC","3"))
 # Hard ceiling re-enforced at payout time, independent of any gate.
 MAX_CLAIM_RTC=float(os.environ.get("MAX_CLAIM_RTC","25")); MAXRUN=int(os.environ.get("MAX_PER_RUN","40"))
-FROM="founder_community"; PORT="8099"
+FROM="founder_community"
 REPO_OWNER=REPO.split("/",1)[0]
 WALLET_RE=re.compile(r'\bRTC[0-9a-fA-F]{40}\b')
 PAID_COMMENT_RE=re.compile(r'\*\*RTC-AutoPay-Confirmed\*\*\s+—\s+payout\b')
@@ -158,7 +161,9 @@ def gh(args, _check=True):
         raise GhError(f"gh {' '.join(args[:3])} exited {p.returncode}: {(p.stderr or '').strip()[:200]}")
     return p.stdout
 def _post(url, body):
-    ctx=ssl.create_default_context(); ctx.check_hostname=False; ctx.verify_mode=ssl.CERT_NONE
+    # The response is the payer's success oracle, so it must be authenticated.
+    # create_default_context() verifies both the certificate chain and hostname.
+    ctx=ssl.create_default_context()
     req=urllib.request.Request(url,data=body,method="POST",
         headers={"Content-Type":"application/json","X-Admin-Key":ADMIN})
     with urllib.request.urlopen(req,timeout=30,context=ctx) as r: return json.loads(r.read())
@@ -177,20 +182,16 @@ def transfer(to,memo,idem,amount=None):
     debit under a different URL.
     """
     body=json.dumps({"from_miner":FROM,"to_miner":to,"amount_rtc":(RATE if amount is None else amount),"memo":memo,"idempotency_key":idem}).encode()
-    # node gunicorn is bound to 127.0.0.1:8099 (nginx-only) — reach it via the
-    # nginx HTTPS endpoint (the working path); fall back to the internal port.
-    last="no_endpoint_attempted"
-    for url in (f"https://{HOST}/wallet/transfer", f"http://{HOST}:{PORT}/wallet/transfer"):
-        try:
-            resp=_post(url,body)
-        except Exception as e:
-            last=str(e)[:160]
-            continue
-        if not isinstance(resp,dict) or not resp.get("ok"):
-            # Server answered and refused. Do not try the other endpoint.
-            return False,f"server_declined:{str(resp)[:180]}"
-        return True,resp
-    return False,last
+    # Reach the node only through its authenticated nginx HTTPS endpoint.
+    # Falling back to http://HOST:8099 would expose X-Admin-Key and would turn a
+    # certificate failure into a silent security downgrade.
+    try:
+        resp=_post(f"https://{HOST}/wallet/transfer",body)
+    except Exception as e:
+        return False,str(e)[:160]
+    if not isinstance(resp,dict) or not resp.get("ok"):
+        return False,f"server_declined:{str(resp)[:180]}"
+    return True,resp
 def _is_bot_login(login, user_obj):
     """Return True if the comment/author appears to be a bot.
 

--- a/scripts/bounty_payout.py
+++ b/scripts/bounty_payout.py
@@ -44,7 +44,9 @@ RATE=float(os.environ.get("RATE_RTC","3"))
 # Hard ceiling re-enforced at payout time, independent of any gate.
 MAX_CLAIM_RTC=float(os.environ.get("MAX_CLAIM_RTC","25")); MAXRUN=int(os.environ.get("MAX_PER_RUN","40"))
 FROM="founder_community"; PORT="8099"
+REPO_OWNER=REPO.split("/",1)[0]
 WALLET_RE=re.compile(r'\bRTC[0-9a-fA-F]{40}\b')
+PAID_COMMENT_RE=re.compile(r'\*\*RTC-AutoPay-Confirmed\*\*\s+—\s+payout\b')
 # Matches `Wallet: <handle-or-address>` (case-insensitive, Markdown-tolerant).
 # Tolerates:
 #   - leading Markdown headers (`## Wallet: handle`)
@@ -240,6 +242,16 @@ def _comment_author_login(c):
     if isinstance(u, dict):
         return u.get("login"), u
     return None, None
+
+
+def is_trusted_paid_comment(c):
+    """Accept the paid sentinel only from trusted automation/repo owner."""
+    login, _ = _comment_author_login(c)
+    trusted = {REPO_OWNER.lower(), "github-actions", "github-actions[bot]"}
+    return bool(login and login.lower() in trusted and
+                PAID_COMMENT_RE.search(c.get("body") or ""))
+
+
 def _looks_like_handle(token):
     if not token:
         return False
@@ -345,7 +357,7 @@ for i in issues:
         and _is_trusted(_comment_author_login(c)[0])
         for c in coms)
     if not eligible: continue
-    if any("RTC-AutoPay-Confirmed" in (c.get("body") or "") for c in coms): continue
+    if any(is_trusted_paid_comment(c) for c in coms): continue
     wallet, source = resolve_wallet(d.get("body"), coms, claimant_login=claimant)
     if not wallet: continue
     # Review claims are a flat RATE. Docstring claims are worth whatever the

--- a/scripts/test_auto_pay.py
+++ b/scripts/test_auto_pay.py
@@ -156,8 +156,7 @@ class TransferRetry(unittest.TestCase):
     @patch("time.sleep", return_value=None)
     @patch("requests.post")
     def test_single_attempt_never_double_calls(self, mock_post, _sleep):
-        """Baseline: the common case (VPS reachable) makes exactly one
-        HTTP call — the retry loop must not add extra calls on success."""
+        """Baseline: the common case makes exactly one HTTP call."""
         ok_resp = MagicMock()
         ok_resp.raise_for_status.return_value = None
         ok_resp.json.return_value = {"ok": True}
@@ -167,6 +166,32 @@ class TransferRetry(unittest.TestCase):
 
         self.assertEqual(mock_post.call_count, 1)
 
+
+class PaidMarkerGuard(unittest.TestCase):
+    def _comment(self, login, body):
+        return {"user": {"login": login}, "body": body}
+
+    def test_untrusted_comment_cannot_suppress_payment(self):
+        c = self._comment(
+            "mallory",
+            "<!-- RTC-AutoPay-Confirmed kind=directive pending_id=p1 -->",
+        )
+        self.assertFalse(auto_pay.has_trusted_paid_marker(c, "Scottcjn"))
+
+    def test_failure_marker_is_not_a_paid_marker(self):
+        c = self._comment("github-actions[bot]", "<!-- RTC-AutoPay-Failed -->")
+        self.assertFalse(auto_pay.has_trusted_paid_marker(c, "Scottcjn"))
+
+    def test_trusted_exact_marker_suppresses_duplicate(self):
+        c = self._comment(
+            "github-actions[bot]",
+            "<!-- RTC-AutoPay-Confirmed kind=auto-tier pending_id=p1 -->",
+        )
+        self.assertTrue(auto_pay.has_trusted_paid_marker(c, "Scottcjn"))
+
+    def test_trusted_but_malformed_marker_does_not_suppress(self):
+        c = self._comment("github-actions[bot]", "RTC-AutoPay-Confirmed")
+        self.assertFalse(auto_pay.has_trusted_paid_marker(c, "Scottcjn"))
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_bounty_payout_declined_transfer.py
+++ b/tests/test_bounty_payout_declined_transfer.py
@@ -11,17 +11,20 @@ publicly confirmed with no RTC actually sent.
 Validates:
   - `{"ok": true}`   -> (True, response)
   - `{"ok": false}`  -> (False, "server_declined:...")
-  - a declining server is NOT retried against the fallback endpoint
-    (re-posting a request the server already processed risks a double debit)
-  - a raising endpoint DOES fall through to the fallback endpoint
-  - both endpoints raising -> (False, last error)
+  - certificate and hostname verification remain enabled
+  - the admin-authenticated request is HTTPS-only with no plaintext fallback
+  - a transport exception fails closed after one request
   - a non-dict body (e.g. an HTML error page) is not treated as success
 """
 import importlib.util
+import io
+import json
 import os
+import ssl
 import subprocess
 import unittest
 from pathlib import Path
+from unittest import mock
 
 os.environ.setdefault("GITHUB_TOKEN", "dummy")
 os.environ.setdefault("RTC_ADMIN_KEY", "dummy")
@@ -86,7 +89,7 @@ class TransferResultTests(unittest.TestCase):
         self.assertIn("server_declined", resp)
         self.assertIn("Insufficient balance", resp)
 
-    def test_declining_server_is_not_retried_on_fallback(self):
+    def test_declining_server_is_not_retried(self):
         """A server that processed and refused must not be re-posted to."""
         self._install([
             lambda u: {"ok": False, "error": "rejected"},
@@ -96,24 +99,17 @@ class TransferResultTests(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(len(self.calls), 1, "fallback endpoint must not be tried")
 
-    def test_raising_endpoint_falls_through_to_fallback(self):
+    def test_raising_endpoint_fails_closed_without_plaintext_fallback(self):
         def boom(_u):
             raise OSError("connection refused")
 
-        self._install([boom, lambda u: {"ok": True, "tx_hash": "z"}])
-        ok, resp = bp.transfer("alice", "memo", "idem-4")
-        self.assertTrue(ok)
-        self.assertEqual(resp["tx_hash"], "z")
-        self.assertEqual(len(self.calls), 2)
-
-    def test_all_endpoints_raise_is_failure(self):
-        def boom(_u):
-            raise OSError("403 Forbidden")
-
-        self._install([boom, boom])
+        self._install([boom])
         ok, resp = bp.transfer("alice", "memo", "idem-5")
         self.assertFalse(ok)
-        self.assertIn("403", resp)
+        self.assertIn("connection refused", resp)
+        self.assertEqual(len(self.calls), 1)
+        self.assertTrue(self.calls[0].startswith("https://"))
+        self.assertNotIn(":8099/", self.calls[0])
 
     def test_non_dict_body_is_not_success(self):
         """An HTML error page must not read as a completed payment."""
@@ -121,6 +117,32 @@ class TransferResultTests(unittest.TestCase):
         ok, resp = bp.transfer("alice", "memo", "idem-6")
         self.assertFalse(ok)
         self.assertIn("server_declined", resp)
+
+
+class VerifiedTransportTests(unittest.TestCase):
+    class _Response(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.close()
+
+    def test_post_keeps_default_certificate_and_hostname_verification(self):
+        captured = {}
+
+        def fake_urlopen(request, *, timeout, context):
+            captured.update(request=request, timeout=timeout, context=context)
+            return self._Response(json.dumps({"ok": True}).encode())
+
+        with mock.patch.object(bp.urllib.request, "urlopen", side_effect=fake_urlopen):
+            response = bp._post("https://node.example/wallet/transfer", b"{}")
+
+        self.assertEqual(response, {"ok": True})
+        self.assertTrue(captured["context"].check_hostname)
+        self.assertEqual(captured["context"].verify_mode, ssl.CERT_REQUIRED)
+        self.assertEqual(captured["request"].full_url,
+                         "https://node.example/wallet/transfer")
+        self.assertEqual(captured["request"].get_header("X-admin-key"), "dummy")
 
 
 if __name__ == "__main__":

--- a/tests/test_bounty_payout_declined_transfer.py
+++ b/tests/test_bounty_payout_declined_transfer.py
@@ -145,5 +145,25 @@ class VerifiedTransportTests(unittest.TestCase):
         self.assertEqual(captured["request"].get_header("X-admin-key"), "dummy")
 
 
+class EndpointCompatibilityTests(unittest.TestCase):
+    def test_legacy_production_ip_uses_certificate_hostname(self):
+        self.assertEqual(
+            bp._certificate_host("50.28.86.131"),
+            "bulbous-bouffant.metalseed.net",
+        )
+
+    def test_custom_hostname_is_preserved(self):
+        self.assertEqual(
+            bp._certificate_host("node.internal.example"),
+            "node.internal.example",
+        )
+
+    def test_ip_prefix_is_not_broadly_rewritten(self):
+        self.assertEqual(
+            bp._certificate_host("50.28.86.131.attacker.example"),
+            "50.28.86.131.attacker.example",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_bounty_payout_handle_fallback.py
+++ b/tests/test_bounty_payout_handle_fallback.py
@@ -300,6 +300,23 @@ class GraphQLAuthorShapeTests(unittest.TestCase):
         self.assertEqual(bp._comment_author_login("string"), (None, None))
 
 
+class PaidMarkerTrustTests(unittest.TestCase):
+    MARKER = "💸 **RTC-AutoPay-Confirmed** — payout **settled** — 3 RTC"
+
+    def test_untrusted_paid_marker_is_ignored(self):
+        c = {"author": {"login": "mallory"}, "body": self.MARKER}
+        self.assertFalse(bp.is_trusted_paid_comment(c))
+
+    def test_actions_paid_marker_is_accepted(self):
+        c = {"author": {"login": "github-actions"}, "body": self.MARKER}
+        self.assertTrue(bp.is_trusted_paid_comment(c))
+
+    def test_plain_marker_text_is_not_accepted(self):
+        c = {"author": {"login": "github-actions"},
+             "body": "RTC-AutoPay-Confirmed"}
+        self.assertFalse(bp.is_trusted_paid_comment(c))
+
+
 class BotDetectionTests(unittest.TestCase):
     def test_bot_via_type(self):
         self.assertTrue(bp._is_bot_login("anything", {"type": "Bot"}))

--- a/tests/test_confirm_pending_workflow.py
+++ b/tests/test_confirm_pending_workflow.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
-"""Static regression guard for confirm-pending's delivery postcondition."""
+"""Regression tests for confirm-pending's delivery postcondition."""
+import json
+import os
 from pathlib import Path
+import subprocess
+import tempfile
 import unittest
 
 
@@ -13,6 +17,37 @@ class ConfirmPendingWorkflowTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.text = WORKFLOW.read_text()
+        lines = cls.text.splitlines()
+        start = lines.index("        run: |") + 1
+        body = []
+        for line in lines[start:]:
+            if line and not line.startswith("          "):
+                break
+            body.append(line[10:] if line else "")
+        cls.script = "\n".join(body) + "\n"
+
+    def run_response(self, payload):
+        fake_curl = """
+curl() {
+  printf '%s' "$RESPONSE_JSON" > resp.json
+  printf '200'
+}
+"""
+        env = os.environ.copy()
+        env.update({
+            "RTC_VPS_HOST": "node.invalid",
+            "RTC_ADMIN_KEY": "test-key",
+            "RESPONSE_JSON": json.dumps(payload),
+        })
+        with tempfile.TemporaryDirectory() as workdir:
+            return subprocess.run(
+                ["bash", "-c", fake_curl + self.script],
+                cwd=workdir,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
 
     def test_application_refusal_fails(self):
         self.assertIn("if d.get('ok') is not True:", self.text)
@@ -25,6 +60,38 @@ class ConfirmPendingWorkflowTests(unittest.TestCase):
         self.assertIn('if [ "${stale:-0}" -gt 0 ]; then', self.text)
         self.assertIn('stale transfer(s) undelivered', self.text)
         self.assertIn('exit 1', self.text)
+
+    def test_drained_response_exits_successfully(self):
+        result = self.run_response({
+            "ok": True,
+            "confirmed_count": 2,
+            "stale_pending_count": 0,
+        })
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("queue drained", result.stdout)
+        self.assertIn("confirmed 2 transfer(s) this run", result.stdout)
+
+    def test_application_refusal_exits_nonzero(self):
+        result = self.run_response({
+            "ok": False,
+            "error": "delivery unavailable",
+            "confirmed_count": 0,
+            "stale_pending_count": 7,
+        })
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("confirm refused: delivery unavailable", result.stderr)
+
+    def test_stale_no_progress_response_exits_nonzero(self):
+        result = self.run_response({
+            "ok": True,
+            "confirmed_count": 0,
+            "stale_pending_count": 7,
+            "errors": ["row 42 locked"],
+        })
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no progress this iter; stopping", result.stdout)
+        self.assertIn("7 stale transfer(s) undelivered", result.stdout)
+        self.assertIn("row 42 locked", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_confirm_pending_workflow.py
+++ b/tests/test_confirm_pending_workflow.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Static regression guard for confirm-pending's delivery postcondition."""
+from pathlib import Path
+import unittest
+
+
+WORKFLOW = (Path(__file__).resolve().parents[1] /
+            ".github/workflows/confirm-pending.yml")
+
+
+class ConfirmPendingWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = WORKFLOW.read_text()
+
+    def test_application_refusal_fails(self):
+        self.assertIn("if d.get('ok') is not True:", self.text)
+
+    def test_counts_are_required_integers(self):
+        self.assertIn('invalid confirmed_count', self.text)
+        self.assertIn('invalid stale_pending_count', self.text)
+
+    def test_stale_backlog_after_loop_fails(self):
+        self.assertIn('if [ "${stale:-0}" -gt 0 ]; then', self.text)
+        self.assertIn('stale transfer(s) undelivered', self.text)
+        self.assertIn('exit 1', self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses four payout silent-success/wrong-effect defects reported in #16471:

- a rejected `auto-pay.py` transfer wrote `RTC-AutoPay-Confirmed:FAILED`, so the next run treated the failed attempt as paid and exited 0;
- `confirm-pending.yml` exited 0 when stale transfers remained after a no-progress iteration or the iteration cap;
- both payout scripts accepted a paid sentinel copied into a comment by any public user;
- `bounty_payout.py` disabled certificate and hostname verification, then used
  an unauthenticated `{"ok": true}` response to confirm and close a payout.

## Changes

- write a distinct `RTC-AutoPay-Failed` marker for rejected transfers;
- accept only exact paid-marker formats authored by the repository owner or GitHub Actions;
- require `/wallet/confirm-pending` to return `ok: true` and non-negative integer counts;
- fail the confirmation job if any stale transfers remain when the loop stops;
- retain the default verified TLS context and remove the plaintext
  `http://HOST:8099` fallback carrying `X-Admin-Key`;
- translate only the known legacy production IP to the certificate-covered DNS
  hostname, so existing `RTC_VPS_HOST` secrets remain deployable with verified TLS;
- add regression coverage for forged markers, failure-marker collisions, pending-delivery postconditions, and endpoint compatibility.

## Verification

```text
python3 scripts/test_auto_pay.py                         # 12 passed
python3 tests/test_bounty_payout_handle_fallback.py     # 47 passed
python3 tests/test_bounty_payout_declined_transfer.py   # 9 passed
python3 tests/test_confirm_pending_workflow.py           # 6 passed
python3 tests/test_payout_authorization.py               # 12 passed
python3 tests/test_docstring_gate.py                     # 17 passed
python3 -m py_compile scripts/auto-pay.py scripts/bounty_payout.py scripts/docstring_gate.py scripts/pr_review_gate_backfill.py tests/test_confirm_pending_workflow.py
git diff --check
```

Current-upstream compatibility: the branch is rebased onto `44f52a3`, which
already contains the later trusted-authorization, payout-cap, docstring-gate,
and backfill fixes that overlap the older #16473 patch. Those landed changes
are preserved, and the expanded focused suite passes **103/103**. PR #16473 is
now itself stale/conflicting against main, so the prior merge-order statement
no longer describes the repository state and should not be used for landing.

Deployment note: the existing legacy value `RTC_VPS_HOST=50.28.86.131` is
translated in-process to `bulbous-bouffant.metalseed.net`, which currently
resolves to the same IP and passes a normal verified HTTPS health check. This
keeps current secrets deployable without disabling verification or exposing
the admin key over HTTP. Any custom `RTC_VPS_HOST` remains unchanged and must
be covered by its own certificate.

Audit evidence:

- [failed-marker collision](https://github.com/Scottcjn/rustchain-bounties/issues/16471#issuecomment-5252241406)
- [stale pending queue exits green](https://github.com/Scottcjn/rustchain-bounties/issues/16471#issuecomment-5254138653)
- [untrusted paid-marker forgery](https://github.com/Scottcjn/rustchain-bounties/issues/16471#issuecomment-5259803872)
- [unauthenticated payout transport](https://github.com/Scottcjn/rustchain-bounties/issues/16471#issuecomment-5277643639)

Payout destination: `RTCc35559a7c3921c1a4a18ddfb40f0e38e810eaa4b`
