### PR TITLE
fix(docstring-gate): fail closed on diff read errors

### DIFF
--- a/.github/workflows/docstring-gate.yml
+++ b/.github/workflows/docstring-gate.yml
@@ -46,27 +46,34 @@ jobs:
           RATE_PER_FUNC: "0.5"
           MAX_RTC: "25"
         run: |
-          set -uo pipefail
+          set -euo pipefail
           single="${{ github.event.inputs.issue || github.event.issue.number }}"
           if [ -n "$single" ]; then
             ISSUE_NUMBER="$single" python3 scripts/docstring_gate.py
-            exit 0
+            exit
           fi
 
           # Scheduled sweep: anything held awaiting-merge, plus recent claims
           # that have not been adjudicated yet.
           held=$(gh api -X GET search/issues \
                   -f q="repo:${GH_REPO} is:issue is:open label:awaiting-merge" \
-                  -f per_page=60 --jq '.items[].number' 2>/dev/null || true)
+                  -f per_page=60 --jq '.items[].number')
           fresh=$(gh api -X GET search/issues \
                   -f q="repo:${GH_REPO} is:issue is:open -label:bounty-eligible -label:awaiting-merge -label:needs-human docstring" \
-                  -f per_page=60 --jq '.items[].number' 2>/dev/null || true)
+                  -f per_page=60 --jq '.items[].number')
 
           n=0
+          failed=0
           for i in $(printf '%s\n%s\n' "$held" "$fresh" | sort -un); do
             [ -z "$i" ] && continue
-            ISSUE_NUMBER="$i" python3 scripts/docstring_gate.py || true
+            if ! ISSUE_NUMBER="$i" python3 scripts/docstring_gate.py; then
+              echo "::error::docstring gate failed for issue #$i"
+              failed=$((failed+1))
+            fi
             n=$((n+1))
             [ "$n" -ge 60 ] && echo "::notice::stopped at 60 claims this run; the rest process next sweep" && break
           done
-          echo "adjudicated $n claim(s)"
+          echo "adjudicated $n claim(s); $failed failed"
+          if [ "$failed" -gt 0 ]; then
+            exit 1
+          fi

--- a/scripts/docstring_gate.py
+++ b/scripts/docstring_gate.py
@@ -106,10 +106,15 @@ def gh(args, default=None, strict=False):
 
 
 def gh_raw(args):
+    """Run `gh` and return stdout, raising when the read is not authoritative."""
     try:
-        return subprocess.run(["gh"] + args, capture_output=True, text=True, timeout=120).stdout
-    except Exception:
-        return ""
+        p = subprocess.run(["gh"] + args, capture_output=True, text=True, timeout=120)
+    except Exception as e:
+        raise GhError(f"gh {' '.join(args[:3])} failed: {e}") from e
+    if p.returncode != 0:
+        raise GhError(f"gh {' '.join(args[:3])} exited {p.returncode}: "
+                      f"{(p.stderr or '').strip()[:200]}")
+    return p.stdout
 
 
 
@@ -246,7 +251,14 @@ def main():
         print(f"{pr_repo}#{pr_num} not merged ({pr.get('state')}); waiting")
         return 0
 
-    diff = gh_raw(["pr", "diff", pr_num, "-R", pr_repo])
+    try:
+        diff = gh_raw(["pr", "diff", pr_num, "-R", pr_repo])
+    except GhError as e:
+        # A failed diff read is not evidence that the merged PR contains zero
+        # docstrings. Leave the claim untouched so the workflow exposes the
+        # infrastructure failure and a later run can retry safely.
+        print(f"::error::could not read merged PR diff: {e}", file=sys.stderr)
+        return 1
     doc_count, total_added, files = count_added_docstrings(diff)
     claimed = None
     cm = COUNT_RE.search(body) or COUNT_RE.search(title)

--- a/tests/test_docstring_gate.py
+++ b/tests/test_docstring_gate.py
@@ -10,6 +10,7 @@ import importlib.util
 import os
 import unittest
 from pathlib import Path
+from unittest import mock
 
 os.environ.setdefault("GITHUB_TOKEN", "dummy")
 SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "docstring_gate.py"
@@ -85,6 +86,69 @@ class ClaimParsingTests(unittest.TestCase):
             m = dg.COUNT_RE.search(text)
             self.assertIsNotNone(m, text)
             self.assertEqual(m.group(1), want)
+
+
+class DiffReadFailureTests(unittest.TestCase):
+    def setUp(self):
+        self._num = dg.NUM
+        self._gh = dg.gh
+        self._gh_raw = dg.gh_raw
+        self._add_labels = dg.add_labels
+        dg.NUM = "123"
+        self.comments = []
+        self.labels = []
+
+        def fake_gh(args, default=None, strict=False):
+            if args[:2] == ["issue", "view"]:
+                return {
+                    "title": "Claim: docs batch 1",
+                    "body": "PR: https://github.com/example/project/pull/7\nFunctions documented: 1",
+                    "labels": [],
+                    "author": {"login": "alice"},
+                    "state": "OPEN",
+                }
+            if args[:2] == ["pr", "view"]:
+                return {
+                    "state": "MERGED",
+                    "additions": 1,
+                    "deletions": 0,
+                    "files": [{"path": "x.py"}],
+                    "author": {"login": "alice"},
+                    "mergedAt": "2026-08-14T00:00:00Z",
+                }
+            if args[:2] == ["issue", "comment"]:
+                self.comments.append(args)
+            return default
+
+        dg.gh = fake_gh
+        dg.add_labels = lambda *names: self.labels.extend(names) or True
+
+    def tearDown(self):
+        dg.NUM = self._num
+        dg.gh = self._gh
+        dg.gh_raw = self._gh_raw
+        dg.add_labels = self._add_labels
+
+    def test_nonzero_diff_command_raises(self):
+        result = mock.Mock(returncode=1, stdout="", stderr="API rate limit exceeded")
+        with mock.patch.object(dg.subprocess, "run", return_value=result):
+            with self.assertRaisesRegex(dg.GhError, "API rate limit exceeded"):
+                dg.gh_raw(["pr", "diff", "7", "-R", "example/project"])
+
+    def test_failed_diff_read_does_not_adjudicate_claim(self):
+        dg.gh_raw = lambda _args: (_ for _ in ()).throw(dg.GhError("transient failure"))
+
+        self.assertEqual(dg.main(), 1)
+        self.assertEqual(self.comments, [])
+        self.assertEqual(self.labels, [])
+
+    def test_successful_empty_diff_keeps_zero_docstring_verdict(self):
+        dg.gh_raw = lambda _args: ""
+
+        self.assertEqual(dg.main(), 0)
+        self.assertEqual(self.labels, ["needs-human"])
+        self.assertEqual(len(self.comments), 1)
+        self.assertIn("no added lines", " ".join(self.comments[0]))
 
 
 if __name__ == "__main__":

--- a/tests/test_docstring_gate_workflow.py
+++ b/tests/test_docstring_gate_workflow.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Behavioral tests for the docstring-gate workflow shell step."""
+
+import os
+import re
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = ROOT / ".github" / "workflows" / "docstring-gate.yml"
+
+
+def workflow_script():
+    lines = WORKFLOW.read_text(encoding="utf-8").splitlines()
+    try:
+        start = lines.index("        run: |") + 1
+    except ValueError as exc:
+        raise AssertionError("could not find docstring-gate run block") from exc
+    body = []
+    for line in lines[start:]:
+        if line and not line.startswith("          "):
+            break
+        body.append(line[10:] if line else "")
+    script = "\n".join(body) + "\n"
+    return re.sub(
+        r'^single="\$\{\{.*\}\}"$',
+        'single="${TEST_SINGLE:-}"',
+        script,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+
+class WorkflowFailureTests(unittest.TestCase):
+    def _run(self, *, single="", gh_exit=0, python_exit=0, gh_output="101"):
+        script = workflow_script()
+        with tempfile.TemporaryDirectory() as tmp:
+            bindir = Path(tmp) / "bin"
+            bindir.mkdir()
+            for name, body in {
+                "gh": f"#!/bin/sh\nprintf '%s\\n' {gh_output!r}\nexit {gh_exit}\n",
+                "python3": f"#!/bin/sh\nexit {python_exit}\n",
+            }.items():
+                path = bindir / name
+                path.write_text(body, encoding="utf-8")
+                path.chmod(path.stat().st_mode | stat.S_IXUSR)
+            env = {
+                **os.environ,
+                "PATH": f"{bindir}:{os.environ['PATH']}",
+                "GH_REPO": "owner/repo",
+                "TEST_SINGLE": single,
+            }
+            return subprocess.run(
+                ["bash", "-c", script],
+                cwd=ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+
+    def test_single_issue_failure_is_not_forced_green(self):
+        result = self._run(single="123", python_exit=7)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_scheduled_inventory_failure_is_not_an_empty_success(self):
+        result = self._run(gh_exit=9)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_scheduled_claim_failure_finishes_red(self):
+        result = self._run(python_exit=7)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("docstring gate failed for issue #101", result.stdout)
+
+    def test_successful_scheduled_claim_finishes_green(self):
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("adjudicated 1 claim(s); 0 failed", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make `gh_raw()` raise `GhError` on subprocess exceptions and nonzero exits
- leave the claim untouched and return nonzero when a merged PR diff cannot be read
- preserve the existing zero-docstring verdict for a successfully read, genuinely empty diff
- propagate that failure through both the single-issue and scheduled workflow paths
- let a scheduled sweep continue across claims, but finish red if any adjudication failed

This fixes the silent wrong-effect path reported in audit issue #16471: an API, auth, or rate-limit failure from `gh pr diff` was converted to an empty string, publicly adjudicated as zero docstrings, and labelled `needs-human` while the workflow exited green.

The script-level return code alone was not enough: the workflow forced the single-issue path back to exit 0 and suppressed scheduled inventory/adjudication failures with `|| true`. The workflow now fails closed without abandoning the rest of a scheduled batch.

Finding evidence: https://github.com/Scottcjn/rustchain-bounties/issues/16471#issuecomment-5285711490

## Verification

- `uv run --with pytest pytest -q tests/test_docstring_gate.py tests/test_docstring_gate_workflow.py` — 24 passed
- payout-adjacent targeted suite — 94 passed
- `python3 -m py_compile scripts/docstring_gate.py tests/test_docstring_gate.py tests/test_docstring_gate_workflow.py`
- `git diff --check`

The script regressions distinguish a failed diff read from a successful empty diff and assert that the failure posts no adjudication comment, writes no label, and returns nonzero. The workflow regressions execute the extracted shell block with controlled fake commands and prove that single-issue failure, inventory failure, and scheduled claim failure all finish red while a successful scheduled claim finishes green.

Current-upstream compatibility: rebased onto `44f52a3`.

Payout wallet for the confirmed finding: `RTCc35559a7c3921c1a4a18ddfb40f0e38e810eaa4b`.
