### PR TITLE
fix: three money paths that report success while doing nothing

### DIFF
--- a/scripts/auto-pay.py
+++ b/scripts/auto-pay.py
@@ -48,6 +48,38 @@ PAYMENT_RE = re.compile(
 # already processed for this PR.
 ALREADY_PAID_MARKER = "RTC-AutoPay-Confirmed"
 
+# Marker for a payout that was ATTEMPTED AND REJECTED. It must not contain
+# ALREADY_PAID_MARKER as a substring.
+#
+# It used to: the failure notice embedded `<!-- RTC-AutoPay-Confirmed:FAILED -->`,
+# which the substring dedup below matched on every later run. One failed
+# payout therefore poisoned the PR permanently — every re-run printed
+# "Payment already processed. Skipping.", exited 0 green, and the only record
+# of the money was a comment saying the transfer had been REJECTED. The PR
+# could never be auto-paid again and the log asserted that it had been.
+#
+# (The AUTO_TIER_MARKER overlap further down is deliberate and stays: the
+# auto-tier is a real payment and SHOULD dedup as one.)
+FAILED_PAYMENT_MARKER = "RTC-AutoPay-Rejected"
+
+# Failure marker emitted before the fix above. Existing PRs still carry it,
+# so it is stripped before the dedup check — otherwise this fix would leave
+# every already-poisoned PR poisoned.
+LEGACY_FAILED_MARKER = f"{ALREADY_PAID_MARKER}:FAILED"
+
+
+def is_already_paid_comment(body: str) -> bool:
+    """True if `body` records a COMPLETED payment for this PR.
+
+    Substring matching is required (the live marker carries `kind=` and
+    `pending_id=` suffixes), so legacy failure notices are removed from the
+    text first rather than matched by accident.
+    """
+    b = body or ""
+    if ALREADY_PAID_MARKER not in b:
+        return False
+    return ALREADY_PAID_MARKER in b.replace(LEGACY_FAILED_MARKER, "")
+
 # ---------------------------------------------------------------------------
 # Conservative auto-tier (folded in from the former sophia-auto-approve.yml,
 # PR #11536). When a merged PR has NO human `Payment:` directive, this single
@@ -231,7 +263,7 @@ def main() -> None:
 
     # --- Check for duplicate run ------------------------------------------
     for c in comments:
-        if ALREADY_PAID_MARKER in (c.get("body") or ""):
+        if is_already_paid_comment(c.get("body") or ""):
             print(f"Payment already processed (found {ALREADY_PAID_MARKER}). Skipping.")
             return
 
@@ -356,7 +388,7 @@ def main() -> None:
             f"but the transfer was rejected:\n\n"
             f"```\n{error}\n```\n\n"
             f"Please process this payment manually.\n\n"
-            f"<!-- {ALREADY_PAID_MARKER}:FAILED -->"
+            f"<!-- {FAILED_PAYMENT_MARKER} -->"
         )
         post_comment(repo, pr_number, fail_body)
         sys.exit(1)
@@ -371,8 +403,19 @@ def main() -> None:
             f"not auto-awarded; they need a maintainer `Payment: N RTC` directive."
         )
     else:
-        title = "**RTC Payment Sent**"
-        tail = "Transfer confirmed on RustChain."
+        # The POST returns a pending_id, nothing more. RustChain transfers
+        # are two-phase with a ~24h void window; the balance moves only when
+        # the confirmer settles them. This path used to say "Transfer
+        # confirmed on RustChain" off that POST alone — a confirmation the
+        # script had no way to know about, on the very comment recipients
+        # read as proof of payment. The auto-tier path below already worded
+        # this correctly; the wording now matches.
+        title = "**RTC Payment Submitted** (pending confirmation)"
+        tail = (
+            f"The transfer is in the pending ledger with a ~24h void window — the balance "
+            f"moves only once the confirmer settles it. @{repo.split('/')[0]} — void "
+            f"`pending_id {pending_id}` before it confirms if this is wrong."
+        )
 
     confirm_body = (
         f"{title}\n\n"
@@ -388,8 +431,9 @@ def main() -> None:
     )
     post_comment(repo, pr_number, confirm_body)
 
-    print(f"Payment complete ({pay_kind}): {payment_amount} RTC to {to_wallet} "
-          f"(pending_id={pending_id})")
+    # "submitted", not "complete" — see the confirmation wording above.
+    print(f"Payment submitted to pending ledger ({pay_kind}): {payment_amount} RTC to "
+          f"{to_wallet} (pending_id={pending_id}, awaits confirmer)")
 
 
 if __name__ == "__main__":

--- a/scripts/pr_review_gate.py
+++ b/scripts/pr_review_gate.py
@@ -22,7 +22,29 @@ TARGET=os.environ.get("TARGET_REPO","Scottcjn/Rustchain")
 NUM=os.environ.get("ISSUE_NUMBER","")
 CAP=int(os.environ.get("CAP","15")); RATE=os.environ.get("RATE_RTC","3")
 API="https://api.github.com"
-def api(path, method="GET", data=None):
+
+
+class ApiError(RuntimeError):
+    """A GitHub API call failed. Must never be mistaken for an empty result."""
+
+
+def api(path, method="GET", data=None, strict=False):
+    """Call the GitHub API and parse JSON.
+
+    A failed GET normally returns None so callers can treat "not found" and
+    "could not read" the same way — fine for lookups where the fallback is
+    `needs-human`.
+
+    `strict=True` raises `ApiError` instead, and that matters wherever the
+    result feeds a MONEY decision. The per-contributor cap counted eligible
+    claims with `api("/search/issues?...") or {}`, so ANY failure — most
+    routinely a 403 secondary rate-limit, since /search/issues carries its
+    own 30 req/min budget separate from the REST quota — read back as
+    total_count 0, i.e. "this author has claimed nothing yet". The cap then
+    failed OPEN and approved past it at 3 RTC/claim, with no ceiling on how
+    many times that could repeat. A failed lookup is not an authoritative
+    zero. (Same defect and same remedy as `docstring_gate.gh(strict=True)`.)
+    """
     req=urllib.request.Request(f"{API}{path}", method=method,
         headers={"Authorization":f"Bearer {TOKEN}","Accept":"application/vnd.github+json",
                  "X-GitHub-Api-Version":"2022-11-28","User-Agent":"pr-review-gate"})
@@ -31,7 +53,14 @@ def api(path, method="GET", data=None):
     try:
         with urllib.request.urlopen(req,timeout=30) as r: return json.loads(r.read() or "null")
     except urllib.error.HTTPError as e:
+        if strict: raise ApiError(f"{method} {path} -> HTTP {e.code}") from e
         if method=="GET": return None
+        raise
+    except Exception as e:
+        # Transport/timeout/JSON failures. Non-strict callers keep the old
+        # behaviour (propagate to main's catch-all); strict callers get a
+        # typed error they can fail closed on.
+        if strict: raise ApiError(f"{method} {path} failed: {e.__class__.__name__}: {e}") from e
         raise
 
 def is_review_claim(title):
@@ -364,7 +393,31 @@ def main():
     # cap check: count author's existing bounty-eligible issues ORG-WIDE
     # (user:Scottcjn spans every repo, so the per-contributor cap stays global
     # even though the gate now runs in both rustchain-bounties and Rustchain).
-    elig=api(f"/search/issues?q=user:Scottcjn+label:bounty-eligible+author:{author}+type:issue") or {}
+    #
+    # This lookup is STRICT: if it cannot be completed the cap cannot be
+    # honoured, so the claim is held for a human rather than approved. See
+    # api(strict=True) for why a swallowed failure here reads as "zero
+    # claims so far" and lets the cap fail open.
+    try:
+        elig=api(f"/search/issues?q=user:Scottcjn+label:bounty-eligible+author:{author}+type:issue",
+                 strict=True) or {}
+    except ApiError as e:
+        print(f"gate: cap lookup failed, refusing to approve: {e}", file=sys.stderr)
+        _unresolved(
+            f"🤖 Gate: your review of {target}#{pr} checks out, but the lookup that counts your "
+            f"existing eligible claims failed, so the **{CAP} eligible reviews/contributor** cap "
+            f"(Bounty #73) cannot be checked right now.\n\nHolding for a human rather than "
+            f"approving — a failed lookup is not proof that you are under the cap. Nothing is "
+            f"needed from you.", quiet)
+        return
+    if not isinstance(elig, dict) or "total_count" not in elig:
+        # A 200 with an unexpected shape is also not an authoritative zero.
+        print("gate: cap lookup returned unexpected shape, refusing to approve", file=sys.stderr)
+        _unresolved(
+            f"🤖 Gate: your review of {target}#{pr} checks out, but the cap lookup returned an "
+            f"unreadable response, so the **{CAP} eligible reviews/contributor** cap (Bounty #73) "
+            f"cannot be checked right now. Holding for a human.", quiet)
+        return
     if elig.get("total_count",0)>=CAP:
         close(NUM,f"🤖 Gate: @{author} has reached the **{CAP} eligible reviews/contributor** cap (Bounty #73). Quality over volume — thanks!"); return
     add_label(NUM,"bounty-eligible")

--- a/scripts/verify_bounties.py
+++ b/scripts/verify_bounties.py
@@ -114,8 +114,30 @@ def gh_get(url: str, params: dict | None = None) -> requests.Response:
     return r
 
 
+class IncompleteSweep(RuntimeError):
+    """A paginated sweep could not be completed.
+
+    Must never be mistaken for "the complete set, which happens to be small".
+    """
+
+
 def paginate_all(url: str, params: dict | None = None) -> list:
-    """Paginate through all results for a GitHub API endpoint."""
+    """Paginate through ALL results for a GitHub API endpoint, or raise.
+
+    Raises `IncompleteSweep` on any non-200 page instead of returning what it
+    managed to collect.
+
+    Why this is not defensive over-engineering: this used to `break` on a
+    non-200 and return the partial list with the same type and shape as a
+    complete one, so the caller could not tell the difference. `Rustchain`
+    alone is ~6,800 stars (~69 pages at per_page=100); one 403 secondary
+    rate-limit on page 3 returned ~300 logins as if that were everybody. The
+    star verifier then PUBLICLY posted, on the claimants' own issues, that
+    real contributors had not starred — an accusation manufactured entirely
+    by a swallowed HTTP error.
+
+    A sweep that cannot complete must render no verdict about anyone.
+    """
     results = []
     params = dict(params or {})
     params.setdefault("per_page", 100)
@@ -124,8 +146,9 @@ def paginate_all(url: str, params: dict | None = None) -> list:
         params["page"] = page
         r = gh_get(url, params)
         if r.status_code != 200:
-            log.warning("API %s returned %d: %s", url, r.status_code, r.text[:200])
-            break
+            raise IncompleteSweep(
+                f"{url} page {page} returned HTTP {r.status_code}: {r.text[:200]}"
+            )
         data = r.json()
         if not data:
             break
@@ -141,13 +164,26 @@ def paginate_all(url: str, params: dict | None = None) -> list:
 # ---------------------------------------------------------------------------
 
 def get_stargazers(repo: str) -> set[str]:
-    """Return set of usernames who starred OWNER/repo."""
-    users = paginate_all(f"https://api.github.com/repos/{OWNER}/{repo}/stargazers")
+    """Return set of usernames who starred OWNER/repo.
+
+    Raises `IncompleteSweep` if the stargazer list could not be read in full
+    (including a 404, which would otherwise silently turn a renamed or moved
+    repo into "nobody starred it").
+    """
+    try:
+        users = paginate_all(f"https://api.github.com/repos/{OWNER}/{repo}/stargazers")
+    except IncompleteSweep as e:
+        raise IncompleteSweep(f"stargazers for {OWNER}/{repo}: {e}") from e
     return {u["login"] for u in users if isinstance(u, dict) and "login" in u}
 
 
 def get_all_stargazers() -> dict[str, set[str]]:
-    """Return {repo: set(usernames)} for all tracked repos."""
+    """Return {repo: set(usernames)} for all tracked repos.
+
+    All-or-nothing on purpose. A partial map here becomes a public "you did
+    not star this" verdict on someone's claim, so if any repo cannot be read
+    in full the whole star phase is abandoned rather than reported.
+    """
     result = {}
     for repo in STAR_REPOS:
         log.info("Fetching stargazers for %s/%s ...", OWNER, repo)
@@ -156,20 +192,24 @@ def get_all_stargazers() -> dict[str, set[str]]:
     return result
 
 
-def check_profile_badge(username: str) -> tuple[bool, str]:
+def check_profile_badge(username: str) -> tuple[Optional[bool], str]:
     """Check if user's profile README mentions RustChain/Elyan.
-    Returns (found, detail_string).
+
+    Returns (found, detail_string), where `found` is None when the check
+    could NOT be performed. Distinguishing "no badge" from "could not look"
+    matters: both used to render as a public NOT FOUND verdict, so a 403
+    rate-limit read to the claimant as an accusation.
     """
     r = gh_get(f"https://api.github.com/repos/{username}/{username}/contents/README.md")
     if r.status_code == 404:
         return False, "No profile README found"
     if r.status_code != 200:
-        return False, f"Could not fetch profile README (HTTP {r.status_code})"
+        return None, f"Could not fetch profile README (HTTP {r.status_code}) — not checked"
 
     try:
         content = base64.b64decode(r.json()["content"]).decode("utf-8", errors="ignore")
     except Exception as e:
-        return False, f"Could not decode README: {e}"
+        return None, f"Could not decode README ({e}) — not checked"
 
     content_lower = content.lower()
     found_keywords = [kw for kw in BADGE_KEYWORDS if kw in content_lower]
@@ -178,10 +218,20 @@ def check_profile_badge(username: str) -> tuple[bool, str]:
     return False, "No RustChain/Elyan keywords found in profile README"
 
 
-def check_follows_owner(username: str) -> bool:
-    """Check if username follows OWNER."""
+def check_follows_owner(username: str) -> Optional[bool]:
+    """Check if username follows OWNER.
+
+    204 = follows, 404 = does not follow (an authoritative answer from
+    GitHub). Anything else means the check did not happen — return None
+    rather than reporting the claimant as NOT FOLLOWING off a rate-limit.
+    """
     r = gh_get(f"https://api.github.com/users/{username}/following/{OWNER}")
-    return r.status_code == 204
+    if r.status_code == 204:
+        return True
+    if r.status_code == 404:
+        return False
+    log.warning("Follow check for %s inconclusive: HTTP %d", username, r.status_code)
+    return None
 
 
 def get_issue_reactions(issue_number: int) -> dict[str, set[str]]:
@@ -389,8 +439,14 @@ def verify_badge_claims(issue_number: int) -> None:
     for cl in claimants:
         username = cl["username"]
         found, detail = check_profile_badge(username)
-        status = "VERIFIED" if found else "NOT FOUND"
-        lines.append(f"| @{username} | {'Yes' if found else 'No'} | {detail} | {status} |")
+        if found is None:
+            # Could not look. Say so; do not report it as a missing badge.
+            status, cell = "NOT CHECKED (retrying next run)", "?"
+        elif found:
+            status, cell = "VERIFIED", "Yes"
+        else:
+            status, cell = "NOT FOUND", "No"
+        lines.append(f"| @{username} | {cell} | {detail} | {status} |")
 
     lines.extend([
         "",
@@ -433,8 +489,13 @@ def verify_follow_claims(issue_number: int) -> None:
     for cl in claimants:
         username = cl["username"]
         follows = check_follows_owner(username)
-        status = "VERIFIED" if follows else "NOT FOLLOWING"
-        lines.append(f"| @{username} | {'Yes' if follows else 'No'} | {status} |")
+        if follows is None:
+            status, cell = "NOT CHECKED (retrying next run)", "?"
+        elif follows:
+            status, cell = "VERIFIED", "Yes"
+        else:
+            status, cell = "NOT FOLLOWING", "No"
+        lines.append(f"| @{username} | {cell} | {status} |")
 
     lines.extend([
         "",
@@ -549,54 +610,78 @@ def is_issue_open(issue_number: int) -> bool:
 # Main
 # ---------------------------------------------------------------------------
 
-def main():
+def run_phase(name: str, issues: list[int], runner) -> list[str]:
+    """Run one verification phase, per issue, never on incomplete data.
+
+    Every verify_* function does all of its fetching BEFORE it posts, so an
+    `IncompleteSweep` raised mid-fetch means no comment was written for that
+    issue. Returns a list of failure descriptions (empty == clean).
+    """
+    failures: list[str] = []
+    log.info("--- %s ---", name)
+    for issue in issues:
+        if not is_issue_open(issue):
+            log.info("Issue #%d is closed, skipping", issue)
+            continue
+        try:
+            runner(issue)
+        except IncompleteSweep as e:
+            # No verdict is better than a verdict built on a truncated read.
+            log.error("SKIPPED #%d — could not read all data: %s", issue, e)
+            failures.append(f"{name} #{issue}: {e}")
+    return failures
+
+
+def main() -> int:
     log.info("=" * 60)
     log.info("RustChain Bounty Verification Bot starting")
     log.info("Owner: %s | Bounty repo: %s", OWNER, BOUNTY_REPO)
     log.info("=" * 60)
 
-    # Pre-fetch all stargazers once (most expensive operation)
+    failures: list[str] = []
+
+    # Pre-fetch all stargazers once (most expensive operation).
+    #
+    # If this cannot complete, the ENTIRE star phase is skipped. Running it
+    # on a partial map is how honest contributors got publicly told they had
+    # not starred; a missing report is recoverable, a false accusation is not.
     log.info("--- Phase 1: Fetching stargazers ---")
-    all_stars = get_all_stargazers()
-    total_unique = len(set().union(*all_stars.values()))
-    log.info("Total unique stargazers across %d repos: %d", len(STAR_REPOS), total_unique)
+    all_stars: dict[str, set[str]] | None = None
+    try:
+        all_stars = get_all_stargazers()
+    except IncompleteSweep as e:
+        log.error("Stargazer sweep INCOMPLETE — skipping all star bounties: %s", e)
+        failures.append(f"stargazer sweep: {e}")
+    else:
+        total_unique = len(set().union(*all_stars.values())) if all_stars else 0
+        log.info("Total unique stargazers across %d repos: %d", len(STAR_REPOS), total_unique)
 
-    # Star verification
-    log.info("--- Phase 2: Star bounties ---")
-    for issue in STAR_BOUNTY_ISSUES:
-        if is_issue_open(issue):
-            verify_star_claims(issue, all_stars)
-        else:
-            log.info("Issue #%d is closed, skipping", issue)
+    if all_stars is not None:
+        failures += run_phase(
+            "Phase 2: Star bounties", STAR_BOUNTY_ISSUES,
+            lambda issue: verify_star_claims(issue, all_stars),
+        )
+    else:
+        log.warning("Phase 2: Star bounties SKIPPED (no trustworthy stargazer data)")
 
-    # Badge verification
-    log.info("--- Phase 3: Badge bounties ---")
-    for issue in BADGE_BOUNTY_ISSUES:
-        if is_issue_open(issue):
-            verify_badge_claims(issue)
-        else:
-            log.info("Issue #%d is closed, skipping", issue)
-
-    # Follow verification
-    log.info("--- Phase 4: Follow bounties ---")
-    for issue in FOLLOW_BOUNTY_ISSUES:
-        if is_issue_open(issue):
-            verify_follow_claims(issue)
-        else:
-            log.info("Issue #%d is closed, skipping", issue)
-
-    # Emoji verification
-    log.info("--- Phase 5: Emoji bounties ---")
-    for issue in EMOJI_BOUNTY_ISSUES:
-        if is_issue_open(issue):
-            verify_emoji_claims(issue)
-        else:
-            log.info("Issue #%d is closed, skipping", issue)
+    failures += run_phase("Phase 3: Badge bounties", BADGE_BOUNTY_ISSUES, verify_badge_claims)
+    failures += run_phase("Phase 4: Follow bounties", FOLLOW_BOUNTY_ISSUES, verify_follow_claims)
+    failures += run_phase("Phase 5: Emoji bounties", EMOJI_BOUNTY_ISSUES, verify_emoji_claims)
 
     log.info("=" * 60)
+    if failures:
+        # Exit non-zero so the run shows RED. A sweep that skipped work is
+        # not a successful sweep, and a green check here previously meant
+        # nothing at all.
+        log.error("Bounty verification INCOMPLETE — %d check(s) skipped:", len(failures))
+        for f in failures:
+            log.error("  - %s", f)
+        log.info("=" * 60)
+        return 1
     log.info("Bounty verification complete")
     log.info("=" * 60)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_auto_pay_failure_marker.py
+++ b/tests/test_auto_pay_failure_marker.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""A failed payout must not poison the PR, and a POST is not a confirmation.
+
+Two defects, one file:
+
+1. The failure comment embedded `<!-- RTC-AutoPay-Confirmed:FAILED -->`, which
+   CONTAINS `ALREADY_PAID_MARKER` as a substring. After any failed payout the
+   dedup check matched on every later run, printed "Payment already processed.
+   Skipping." and exited 0 green. The PR could never be auto-paid again, and
+   the log asserted that it already had been.
+
+2. The human-directive path posted "Transfer confirmed on RustChain" off a POST
+   that only returns a `pending_id`. RustChain transfers are two-phase with a
+   ~24h void window; the balance moves only when the confirmer runs. The
+   auto-tier path already worded this correctly.
+
+The `AUTO_TIER_MARKER` substring overlap is DELIBERATE (an auto-tier award is a
+real payment and should dedup as one) and is pinned here so it is not "fixed"
+by mistake.
+"""
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def load_auto_pay():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "auto-pay.py"
+    spec = importlib.util.spec_from_file_location("auto_pay_markers", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+auto_pay = load_auto_pay()
+
+OWNER = "Scottcjn"
+ENV = {
+    "GITHUB_TOKEN": "t",
+    "REPO": f"{OWNER}/rustchain-bounties",
+    "PR_NUMBER": "1234",
+    "PR_AUTHOR": "alice",
+    "RTC_VPS_HOST": "203.0.113.1",
+    "RTC_ADMIN_KEY": "k",
+    "REPO_OWNER": OWNER,
+}
+
+DIRECTIVE_COMMENT = [{
+    "id": 1,
+    "user": {"login": OWNER},
+    "body": "Nice work. **Payment: 75 RTC**",
+}]
+
+
+class FailureMarkerDoesNotCollide(unittest.TestCase):
+    def test_failure_marker_is_not_a_substring_of_the_paid_marker(self):
+        self.assertNotIn(auto_pay.ALREADY_PAID_MARKER, auto_pay.FAILED_PAYMENT_MARKER)
+
+    def test_auto_tier_overlap_is_preserved_on_purpose(self):
+        # Deliberate and documented: an auto-tier award IS a payment.
+        self.assertIn(auto_pay.ALREADY_PAID_MARKER, auto_pay.AUTO_TIER_MARKER)
+
+    def test_success_comment_dedupes(self):
+        body = f"<!-- {auto_pay.ALREADY_PAID_MARKER} kind=directive pending_id=p1 -->"
+        self.assertTrue(auto_pay.is_already_paid_comment(body))
+
+    def test_new_failure_comment_does_not_dedupe(self):
+        body = f"**RTC Auto-Pay Failed**\n<!-- {auto_pay.FAILED_PAYMENT_MARKER} -->"
+        self.assertFalse(auto_pay.is_already_paid_comment(body))
+
+    def test_legacy_failure_comment_no_longer_poisons_the_pr(self):
+        """PRs already carrying the old marker must become payable again."""
+        body = f"**RTC Auto-Pay Failed**\n<!-- {auto_pay.LEGACY_FAILED_MARKER} -->"
+        self.assertFalse(auto_pay.is_already_paid_comment(body))
+
+    def test_legacy_failure_plus_real_payment_still_dedupes(self):
+        body = (f"<!-- {auto_pay.LEGACY_FAILED_MARKER} -->\n"
+                f"<!-- {auto_pay.ALREADY_PAID_MARKER} kind=directive pending_id=p9 -->")
+        self.assertTrue(auto_pay.is_already_paid_comment(body))
+
+
+class EndToEndPaths(unittest.TestCase):
+    def _run(self, transfer_result):
+        posted = []
+        with patch.dict(os.environ, ENV, clear=False), \
+             patch.object(auto_pay, "fetch_pr_comments", return_value=list(DIRECTIVE_COMMENT)), \
+             patch.object(auto_pay, "transfer_rtc", return_value=transfer_result), \
+             patch.object(auto_pay, "post_comment",
+                          side_effect=lambda repo, pr, body: posted.append(body)):
+            try:
+                auto_pay.main()
+                exit_code = 0
+            except SystemExit as e:
+                exit_code = e.code
+        return posted, exit_code
+
+    def test_failed_transfer_leaves_the_pr_payable(self):
+        posted, exit_code = self._run({"ok": False, "error": "insufficient_balance"})
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(len(posted), 1)
+        self.assertIn("Failed", posted[0])
+        # THE regression: re-running must not see this as an already-paid PR.
+        self.assertFalse(auto_pay.is_already_paid_comment(posted[0]))
+
+    def test_directive_path_does_not_claim_confirmation(self):
+        posted, exit_code = self._run({"ok": True, "pending_id": "p42"})
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(len(posted), 1)
+        body = posted[0]
+        self.assertNotIn("Transfer confirmed on RustChain", body)
+        self.assertIn("pending", body.lower())
+        self.assertIn("void", body.lower())
+        # A real payment still dedupes.
+        self.assertTrue(auto_pay.is_already_paid_comment(body))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_pr_review_gate_cap_fails_closed.py
+++ b/tests/test_pr_review_gate_cap_fails_closed.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: MIT
+"""The Bounty #73 per-contributor cap must fail CLOSED.
+
+The cap counted an author's existing `bounty-eligible` claims with
+`api("/search/issues?...") or {}`. `api()` returned None on any HTTPError, so
+a 403 secondary rate-limit — routine, because /search/issues has its own
+30 req/min budget — became `{}`, became `total_count = 0`, became "this
+author has claimed nothing yet". The claim was then approved past the cap, at
+3 RTC each, with nothing bounding how often that could recur.
+
+These tests pin the two halves of the fix:
+  1. `api(strict=True)` raises `ApiError` instead of returning None.
+  2. A cap lookup that cannot complete holds the claim for a human and does
+     NOT apply `bounty-eligible`.
+"""
+import importlib.util
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+
+def load_gate():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "pr_review_gate.py"
+    spec = importlib.util.spec_from_file_location("pr_review_gate_capfix", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SUBSTANTIVE_BODY = (
+    "The retry loop in `scripts/auto-pay.py` swallows the HTTPError on line 88 and "
+    "reports success; that is a real bug and it needs a guard before merge."
+)
+
+
+class FakeApi:
+    """Stand-in for `api()`, with a scripted failure for the cap lookup."""
+
+    def __init__(self, cap_lookup_result, author="alice", pr="1396"):
+        self.cap_lookup_result = cap_lookup_result
+        self.author = author
+        self.pr = pr
+        self.labels = []
+        self.comments = []
+        self.patches = []
+
+    def __call__(self, path, method="GET", data=None, strict=False):
+        if method == "POST" and path.endswith("/labels"):
+            self.labels.extend(data["labels"])
+            return {}
+        if method == "POST" and path.endswith("/comments"):
+            self.comments.append(data["body"])
+            return {}
+        if method == "PATCH":
+            self.patches.append(data)
+            return {}
+        if path.startswith("/search/issues"):
+            if isinstance(self.cap_lookup_result, Exception):
+                raise self.cap_lookup_result
+            return self.cap_lookup_result
+        if "/pulls/" in path and path.endswith("/reviews"):
+            return [{
+                "user": {"login": self.author},
+                "body": SUBSTANTIVE_BODY,
+                "submitted_at": "2026-08-01T00:00:00Z",
+            }]
+        if "/pulls/" in path and "/comments" in path:
+            return []
+        if path.endswith("/issues/42"):
+            return {
+                "state": "open",
+                "labels": [],
+                "title": f"Bounty #73 claim: review of PR #{self.pr}",
+                "body": "wallet RTC" + "a" * 40,
+                "user": {"login": self.author},
+            }
+        raise AssertionError(f"unexpected API call: {method} {path}")
+
+
+# Sentinel: the cap lookup should raise the loaded module's OWN ApiError.
+RAISE_API_ERROR = object()
+
+
+def run_gate(cap_lookup_result):
+    mod = load_gate()
+    mod.NUM = "42"
+    mod.REPO = "Scottcjn/rustchain-bounties"
+    mod.TARGET = "Scottcjn/Rustchain"
+    if cap_lookup_result is RAISE_API_ERROR:
+        cap_lookup_result = mod.ApiError("GET /search/issues -> HTTP 403")
+    fake = FakeApi(cap_lookup_result)
+    mod.api = fake
+    mod.main()
+    return mod, fake
+
+
+def test_cap_lookup_failure_does_not_approve():
+    """A 403 on the cap lookup must not read as 'zero claims so far'."""
+    _, fake = run_gate(RAISE_API_ERROR)
+
+    assert "bounty-eligible" not in fake.labels, (
+        "cap lookup failed, so the cap is unknown — the claim must not be approved"
+    )
+    assert "needs-human" in fake.labels
+    assert not fake.patches, "an undecidable claim must not be closed either"
+    assert any("cap" in c.lower() for c in fake.comments)
+
+
+def test_cap_lookup_unreadable_shape_does_not_approve():
+    """A 200 whose body has no total_count is also not an authoritative zero."""
+    _, fake = run_gate({"unexpected": "shape"})
+
+    assert "bounty-eligible" not in fake.labels
+    assert "needs-human" in fake.labels
+
+
+def test_under_cap_still_approves():
+    """The fix must not break the normal path."""
+    _, fake = run_gate({"total_count": 2})
+
+    assert "bounty-eligible" in fake.labels
+    assert "needs-human" not in fake.labels
+
+
+def test_over_cap_still_closes():
+    _, fake = run_gate({"total_count": 15})
+
+    assert "bounty-eligible" not in fake.labels
+    assert fake.patches == [{"state": "closed", "state_reason": "not_planned"}]
+
+
+def test_api_strict_raises_instead_of_returning_none(monkeypatch):
+    """The seam itself: strict=True converts a swallowed None into ApiError."""
+    mod = load_gate()
+
+    def boom(req, timeout=30):
+        raise urllib.error.HTTPError(req.full_url, 403, "rate limited", {}, None)
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", boom)
+
+    # Legacy behaviour, still used by lookups whose fallback is needs-human.
+    assert mod.api("/search/issues?q=x") is None
+
+    # Money path.
+    with pytest.raises(mod.ApiError):
+        mod.api("/search/issues?q=x", strict=True)

--- a/tests/test_verify_bounties_incomplete_sweep.py
+++ b/tests/test_verify_bounties_incomplete_sweep.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: MIT
+"""A sweep that cannot complete must render no verdict about anyone.
+
+`paginate_all()` used to `break` on any non-200 and return the PARTIAL list
+with the same type and shape as a complete one. `Rustchain` alone is ~6,800
+stars (~69 pages at per_page=100), so a single 403 on page 3 returned ~300
+logins as if that were everybody — and the bot then posted PUBLICLY, on the
+claimants' own issues, that real contributors had not starred. Failure and
+success were indistinguishable to every caller.
+
+These tests pin: failures propagate, partial data never reaches a report, and
+an inconclusive per-user check reports "not checked" rather than an accusation.
+"""
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def load_verify_bounties():
+    os.environ.setdefault("GITHUB_TOKEN", "dummy-token-for-tests")
+    requests_stub = types.SimpleNamespace(
+        Session=lambda: types.SimpleNamespace(headers={}, get=None, post=None, patch=None)
+    )
+    sys.modules.setdefault("requests", requests_stub)
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "verify_bounties.py"
+    spec = importlib.util.spec_from_file_location("verify_bounties_sweep", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else []
+        self.text = text
+        self.headers = {"X-RateLimit-Remaining": "5000"}
+
+    def json(self):
+        return self._payload
+
+
+def install_pages(mod, pages):
+    """Make gh_get walk `pages` (a list of FakeResponse) in order."""
+    calls = {"n": 0}
+
+    def fake_get(url, params=None):
+        i = calls["n"]
+        calls["n"] += 1
+        return pages[i] if i < len(pages) else FakeResponse(200, [])
+
+    mod.gh_get = fake_get
+    return calls
+
+
+def full_page(prefix, n=100):
+    return [{"login": f"{prefix}{i}"} for i in range(n)]
+
+
+class PaginateAllPropagatesFailure(unittest.TestCase):
+    def test_mid_sweep_403_raises_instead_of_returning_partial(self):
+        mod = load_verify_bounties()
+        install_pages(mod, [
+            FakeResponse(200, full_page("p1_")),
+            FakeResponse(200, full_page("p2_")),
+            FakeResponse(403, text="secondary rate limit"),
+        ])
+
+        with self.assertRaises(mod.IncompleteSweep):
+            mod.paginate_all("https://api.github.com/repos/Scottcjn/Rustchain/stargazers")
+
+    def test_404_also_raises(self):
+        """A renamed/moved repo must not silently become 'nobody starred it'."""
+        mod = load_verify_bounties()
+        install_pages(mod, [FakeResponse(404, text="Not Found")])
+
+        with self.assertRaises(mod.IncompleteSweep):
+            mod.paginate_all("https://api.github.com/repos/Scottcjn/Rustchain/stargazers")
+
+    def test_complete_sweep_still_returns_everything(self):
+        mod = load_verify_bounties()
+        install_pages(mod, [
+            FakeResponse(200, full_page("p1_")),
+            FakeResponse(200, full_page("p2_", n=7)),   # short page ends the sweep
+        ])
+
+        got = mod.paginate_all("https://api.github.com/x")
+        self.assertEqual(len(got), 107)
+
+
+class StargazerSweepIsAllOrNothing(unittest.TestCase):
+    def test_one_bad_repo_aborts_the_whole_map(self):
+        mod = load_verify_bounties()
+        install_pages(mod, [
+            FakeResponse(200, full_page("a_", n=3)),   # first repo OK
+            FakeResponse(403, text="secondary rate limit"),
+        ])
+
+        with self.assertRaises(mod.IncompleteSweep) as ctx:
+            mod.get_all_stargazers()
+
+        # The message must name the repo that failed, or the log is useless.
+        self.assertIn("stargazers for", str(ctx.exception))
+
+
+class NoVerdictOnIncompleteData(unittest.TestCase):
+    def test_star_report_is_not_posted_when_comments_cannot_be_read(self):
+        mod = load_verify_bounties()
+        install_pages(mod, [FakeResponse(403, text="secondary rate limit")])
+
+        with patch.object(mod, "post_comment") as post, \
+             patch.object(mod, "update_comment") as update:
+            with self.assertRaises(mod.IncompleteSweep):
+                mod.verify_star_claims(2175, {"Rustchain": {"alice"}})
+
+        post.assert_not_called()
+        update.assert_not_called()
+
+    def test_run_phase_skips_the_issue_and_reports_the_failure(self):
+        mod = load_verify_bounties()
+
+        def boom(issue):
+            raise mod.IncompleteSweep("page 3 returned HTTP 403")
+
+        with patch.object(mod, "is_issue_open", return_value=True):
+            failures = mod.run_phase("Phase X", [1, 2], boom)
+
+        self.assertEqual(len(failures), 2)
+        self.assertIn("403", failures[0])
+
+
+class InconclusiveChecksAreNotAccusations(unittest.TestCase):
+    def test_follow_check_returns_none_on_rate_limit(self):
+        mod = load_verify_bounties()
+        mod.gh_get = lambda url, params=None: FakeResponse(403)
+        self.assertIsNone(mod.check_follows_owner("alice"))
+
+    def test_follow_check_still_answers_204_and_404(self):
+        mod = load_verify_bounties()
+        mod.gh_get = lambda url, params=None: FakeResponse(204)
+        self.assertIs(mod.check_follows_owner("alice"), True)
+        mod.gh_get = lambda url, params=None: FakeResponse(404)
+        self.assertIs(mod.check_follows_owner("alice"), False)
+
+    def test_badge_check_distinguishes_missing_from_unreadable(self):
+        mod = load_verify_bounties()
+
+        mod.gh_get = lambda url, params=None: FakeResponse(404)
+        found, detail = mod.check_profile_badge("alice")
+        self.assertIs(found, False)          # authoritative: no README
+
+        mod.gh_get = lambda url, params=None: FakeResponse(403)
+        found, detail = mod.check_profile_badge("alice")
+        self.assertIsNone(found)             # inconclusive: did not look
+        self.assertIn("not checked", detail.lower())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Three defects in this repo where a money path reports success while doing nothing. Each was confirmed by reading the call path on `origin/main` (74a67c1) before editing, not from memory.

---

## 1. `scripts/pr_review_gate.py` — the per-contributor payout cap failed OPEN

```python
elig = api("/search/issues?q=user:Scottcjn+label:bounty-eligible+author:{author}+type:issue") or {}
if elig.get("total_count", 0) >= CAP:
```

`api()` returns `None` on any `HTTPError`. `None or {}` is `{}`, `{}.get("total_count", 0)` is `0`, and the 15-claim cap reads that as "this author has claimed nothing yet" and approves past itself at 3 RTC/claim. Nothing bounds how often it repeats.

Not a rare path: `/search/issues` carries its own 30 req/min secondary rate-limit budget, separate from the REST quota, and answers 403 when it is exceeded.

**The fix already existed two files over.** `scripts/docstring_gate.py:78-105` was written for this exact defect and names it: *"A failed lookup is not an authoritative zero."* The same pattern is applied here — `api(..., strict=True)` raises `ApiError`, and a cap lookup that cannot complete labels the claim `needs-human` and holds it. A 200 with no `total_count` is treated the same way.

## 2. `scripts/verify_bounties.py` — a truncated sweep publicly accused honest claimants

`paginate_all()` broke the loop on any non-200 and returned the **partial** list with the same type and shape as a complete one. No caller could distinguish "that is everybody" from "that is where the API stopped answering".

`get_all_stargazers()` walks 13 repos. Rustchain alone is ~6,800 stars — about 69 pages at `per_page=100`. One 403 on page 3 returned ~300 logins as the whole set, and the bot then posted, publicly, on the claimants' own bounty issues, that real contributors had not starred. The accusation was manufactured entirely by a swallowed HTTP error.

- `paginate_all()` raises `IncompleteSweep` rather than returning a partial list. 404 included — a renamed repo must not silently become "nobody starred it".
- `get_all_stargazers()` is all-or-nothing; if it cannot complete, the entire star phase is skipped rather than reported.
- Phases run per issue through `run_phase()`. Every `verify_*` function does all of its fetching before it posts, so a raised `IncompleteSweep` means no comment was written for that issue.
- `main()` returns 1 when any check was skipped. A sweep that skipped work is not a successful sweep, and the green check previously meant nothing at all.

Same defect shape, same file, fixed alongside: `check_follows_owner()` reported **NOT FOLLOWING** and `check_profile_badge()` reported **NOT FOUND** off a rate-limit. Both are now tri-state and render "NOT CHECKED" when the lookup did not happen. 404 stays authoritative in both — it is GitHub's real answer for "does not follow" / "no profile README".

## 3. `scripts/auto-pay.py` — a failed payout poisoned the PR permanently

```python
ALREADY_PAID_MARKER = "RTC-AutoPay-Confirmed"
...
f"<!-- {ALREADY_PAID_MARKER}:FAILED -->"     # the FAILURE comment
```

The failure marker **contains the success marker as a substring**, so the `in` dedup check matched it on every later run: "Payment already processed. Skipping.", exit 0, green. The PR could never be auto-paid again, and the only record of the money was a comment saying the transfer had been REJECTED while the log asserted it had been paid.

- Distinct `FAILED_PAYMENT_MARKER = "RTC-AutoPay-Rejected"`, no overlap.
- `is_already_paid_comment()` strips the legacy `:FAILED` marker before matching, so PRs already carrying it become payable again. Without that, this fix would leave every existing victim poisoned.
- The `AUTO_TIER_MARKER` overlap is **deliberate and documented** — an auto-tier award is a real payment and should dedup as one. Unchanged, and now pinned by a test so it is not "fixed" by mistake.

**Also in the same file:** the human-directive path posted *"Transfer confirmed on RustChain"* off a POST that only returns a `pending_id`. Transfers here are two-phase with a ~24h void window; the balance moves only when the confirmer runs. The script had no way to know about confirmation, and said so on the very comment recipients read as proof of payment. The auto-tier path already worded this correctly; the directive path now matches it.

---

## Verified

Ran locally, Python 3.13.7, pytest 9.0.2:

- **New tests, 22 passing** — `tests/test_pr_review_gate_cap_fails_closed.py` (5), `tests/test_verify_bounties_incomplete_sweep.py` (9), `tests/test_auto_pay_failure_marker.py` (8).
- **Full suite: `542 passed, 16 failed`.** All 16 failures are **pre-existing on `origin/main`** — confirmed by `git stash` and re-running the same two files at the unmodified tree, which fails identically (`ModuleNotFoundError` for `github` / `clawrtc`). None touch the changed code.
- 4 further test modules cannot be collected at all on `origin/main` (`prometheus_client` not installed) and were excluded from the run; also pre-existing.
- `ruff check` on the three changed scripts: **32 findings before, 33 after**. The delta is +2 `E701` (one-line `if strict: raise ...`, matching the terse house style of `pr_review_gate.py`) and −1 `F841` (a pre-existing unused `except ... as e` now used). No new rule classes.
- `python3 -m py_compile` clean on all three.

## NOT verified

- **Nothing was run against production.** No node, no VPS, no live GitHub API call. Every test uses stubs.
- The `run_phase` / `main()` restructure in `verify_bounties.py` is exercised by unit tests, **not** by a real 6-hourly Actions run. First live run will now **exit non-zero and show red** if any check is skipped — that is the intended signal, but it is a behaviour change to a scheduled workflow and worth watching once.
- `is_issue_open()` still returns `False` on a non-200, so a rate-limited issue is skipped silently rather than reported as a failure. Fail-closed (no verdict is posted), but it is not covered by the new exit-code signal. Left as-is; flagging it.
- The end-to-end auto-pay tests stub `transfer_rtc`, so the node's actual response shape for a rejected transfer is assumed, not observed.
- No audit of how many claims were historically approved past the cap, or how many PRs currently carry the legacy `:FAILED` marker. The legacy-stripping in `is_already_paid_comment()` un-poisons them on the next run without needing that count, but the ledger impact of the cap failing open is unquantified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
