### PR TITLE
fix(ci): gates that reported success without adjudicating anything

### DIFF
--- a/.github/workflows/confirm-pending.yml
+++ b/.github/workflows/confirm-pending.yml
@@ -46,14 +46,30 @@ jobs:
               -H "X-Admin-Key: ${RTC_ADMIN_KEY}" \
               -H "Content-Type: application/json" -d '{"limit": 500}')
             if [ "$code" != "200" ]; then echo "::error::confirm HTTP $code"; cat resp.json; exit 1; fi
+            # `stale` is emitted as the literal string UNKNOWN when the node
+            # could not measure the queue (locked pending_ledger / schema drift).
+            # It used to come back as 0 in that case, which is this loop's stop
+            # condition — so a stuck queue printed "queue drained" and the job
+            # went green while RTC delivery was halted. Fail closed instead.
             read confirmed stale < <(python3 - <<'PY'
           import json
           d = json.load(open('resp.json'))
-          print(d.get('confirmed_count', 0), d.get('stale_pending_count', 0))
+          measured = d.get('overdue_stats_measured')
+          stale = d.get('stale_pending_count')
+          # measured is absent on older node builds; treat a present integer as
+          # measured so this workflow keeps working across the deploy window.
+          if measured is False or stale is None:
+              stale = 'UNKNOWN'
+          print(d.get('confirmed_count', 0), stale)
           PY
           )
             total=$((total + confirmed))
             echo "iter $i: confirmed=$confirmed total=$total stale_remaining=$stale"
+            if [ "$stale" = "UNKNOWN" ]; then
+              echo "::error title=Pending queue not measurable::The node could not count overdue pending transfers, so the queue state is UNKNOWN. This is NOT a drained queue — RTC delivery may be halted."
+              cat resp.json
+              exit 1
+            fi
             # Stop when the queue is drained, or a run makes no progress (e.g. all
             # remaining rows error individually) to avoid spinning.
             [ "${stale:-0}" -eq 0 ] && { echo "queue drained"; break; }

--- a/.github/workflows/docstring-gate.yml
+++ b/.github/workflows/docstring-gate.yml
@@ -45,12 +45,22 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RATE_PER_FUNC: "0.5"
           MAX_RTC: "25"
+        # `set -e` is deliberately NOT used: the sweep must keep going past one
+        # bad claim. Every exit status is therefore captured and acted on
+        # explicitly — which is what was missing before.
         run: |
           set -uo pipefail
           single="${{ github.event.inputs.issue || github.event.issue.number }}"
           if [ -n "$single" ]; then
-            ISSUE_NUMBER="$single" python3 scripts/docstring_gate.py
-            exit 0
+            # This used to be followed by an unconditional `exit 0`. Without
+            # `set -e`, a failing gate run reached it and the step went green
+            # having adjudicated nothing. The step's status is now the gate's
+            # status.
+            ISSUE_NUMBER="$single" python3 scripts/docstring_gate.py && rc=0 || rc=$?
+            if [ "$rc" -ne 0 ]; then
+              echo "::error title=Docstring gate failed::claim #${single} exited ${rc}; it was NOT adjudicated"
+            fi
+            exit "$rc"
           fi
 
           # Scheduled sweep: anything held awaiting-merge, plus recent claims
@@ -62,11 +72,30 @@ jobs:
                   -f q="repo:${GH_REPO} is:issue is:open -label:bounty-eligible -label:awaiting-merge -label:needs-human docstring" \
                   -f per_page=60 --jq '.items[].number' 2>/dev/null || true)
 
-          n=0
+          # Three separate counters. The old loop kept one, incremented it once
+          # per ITERATION after `|| true`, and printed it as "adjudicated N" —
+          # so 60 consecutive crashes reported "adjudicated 60 claim(s)" and the
+          # run was green. A count of attempts is not a count of adjudications.
+          attempted=0
+          adjudicated=0
+          failed=0
+          failed_list=""
           for i in $(printf '%s\n%s\n' "$held" "$fresh" | sort -un); do
             [ -z "$i" ] && continue
-            ISSUE_NUMBER="$i" python3 scripts/docstring_gate.py || true
-            n=$((n+1))
-            [ "$n" -ge 60 ] && echo "::notice::stopped at 60 claims this run; the rest process next sweep" && break
+            attempted=$((attempted+1))
+            ISSUE_NUMBER="$i" python3 scripts/docstring_gate.py && rc=0 || rc=$?
+            if [ "$rc" -eq 0 ]; then
+              adjudicated=$((adjudicated+1))
+            else
+              failed=$((failed+1))
+              failed_list="${failed_list} #${i}(exit ${rc})"
+              echo "::warning title=Docstring claim not adjudicated::#${i} exited ${rc}"
+            fi
+            [ "$attempted" -ge 60 ] && echo "::notice::stopped at 60 claims this run; the rest process next sweep" && break
           done
-          echo "adjudicated $n claim(s)"
+          echo "attempted ${attempted} claim(s): adjudicated ${adjudicated}, failed ${failed}"
+
+          if [ "$failed" -gt 0 ]; then
+            echo "::error title=Docstring gate failures::${failed} of ${attempted} claim(s) were NOT adjudicated:${failed_list}"
+            exit 1
+          fi

--- a/scripts/pr_review_gate.py
+++ b/scripts/pr_review_gate.py
@@ -371,6 +371,22 @@ def main():
     comment(NUM,f"✅ 🤖 Gate: **verified eligible** — @{author} is the first substantive reviewer of {target}#{pr}. **{RATE} RTC** pending payout (native `RTC…` wallet if not on file).")
 
 if __name__=="__main__":
-    try: main()
+    try:
+        main()
     except Exception as e:
-        print(f"gate error: {e}", file=sys.stderr)  # never fail the workflow
+        # Exit non-zero so the run is visibly red and can be retried.
+        #
+        # This used to swallow every exception ("never fail the workflow").
+        # add_label() re-raises on a failed POST, so when the label write at the
+        # eligible branch failed, it threw straight past the follow-up comment:
+        # the claim went unlabelled, the contributor was never told, and the run
+        # was green. That is the reported "gate green without applying payout
+        # labels" bug.
+        #
+        # A silent pass is the worst outcome for a payout gate — nothing
+        # downstream can tell a claim that was skipped from one that was
+        # adjudicated. Fail loudly instead.
+        import traceback
+        print(f"gate error: {type(e).__name__}: {e}", file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
Three gates on the payout path could not report a failure. Confirmed by reading `origin/main` today, and each was reproduced locally before and after the change.

---

## 1. Docstring sweep: an unconditional `exit 0` and a fabricated count

`.github/workflows/docstring-gate.yml`

### a) The single-claim branch always exited 0

```bash
set -uo pipefail          # note: no -e
...
ISSUE_NUMBER="$single" python3 scripts/docstring_gate.py
exit 0
```

Without `-e`, a failing gate run reached that `exit 0` and the step went green having adjudicated nothing. The step's status is now the gate's status.

### b) The sweep counted iterations and called them adjudications

```bash
ISSUE_NUMBER="$i" python3 scripts/docstring_gate.py || true
n=$((n+1))
...
echo "adjudicated $n claim(s)"
```

`|| true` discarded the outcome, then `n` was incremented unconditionally. `n` counted **loop iterations**, not adjudications — so sixty consecutive crashes reported `adjudicated 60 claim(s)` and the run was green. For a gate whose whole job is to tell you which claims got adjudicated, that number was worse than absent: it was confidently wrong.

There are now three counters — `attempted`, `adjudicated`, `failed`. Only a zero exit increments `adjudicated`. Each failure is annotated with its issue number and exit code, and the step exits 1 if any claim went unadjudicated.

**Verified** by extracting the step's script and running it against a stub gate over 5 claims, 2 of which exit 1:

```
before:  adjudicated 5 claim(s)                                    exit 0
after:   attempted 5 claim(s): adjudicated 3, failed 2             exit 1
         ::error::2 of 5 claim(s) were NOT adjudicated: #102(exit 1) #104(exit 1)
```

Single-claim path: a failing claim now exits 1, a passing one exits 0.

`set -e` is still deliberately absent — the sweep must survive one bad claim — so every exit status is captured and acted on explicitly instead.

---

## 2. `# never fail the workflow`

`scripts/pr_review_gate.py`

```python
if __name__=="__main__":
    try: main()
    except Exception as e:
        print(f"gate error: {e}", file=sys.stderr)  # never fail the workflow
```

`api()` re-raises on a failed non-GET, and `add_label` is a POST. So when the `bounty-eligible` label write failed, the exception jumped **past the follow-up comment on the next line**: the claim went unlabelled, the contributor was never told they were eligible, and the run was green.

That is the reported *"gate green without applying payout labels"* bug, sitting in the larger gate.

It now prints the traceback and exits 1, so the run is visibly red and can be re-run. A silent pass is the worst possible outcome for a payout gate — nothing downstream can distinguish a claim that was skipped from one that was adjudicated. The workflow has no `continue-on-error` or `|| true`, so a non-zero exit does surface.

**Verified** by forcing `main()` to raise the same `HTTPError` that `add_label` would:

| | result |
|---|---|
| `origin/main` | no `SystemExit` — process exits **0** |
| this branch | `SystemExit 1` |

Only the `__main__` block is touched. The adjudication logic above it is unchanged, and `import traceback` is local to the handler to keep the diff off any shared line.

---

## 3. A locked DB reported "0 overdue" — this loop's stop condition

`.github/workflows/confirm-pending.yml`

The node's `_pending_overdue_stats` returned zeros on a DB error, so a locked `pending_ledger` produced `stale_pending_count = 0`. This loop reads that field, concludes **"queue drained"**, breaks, and the job goes green — while RTC delivery is actually halted. The function carried a comment explicitly warning against exactly this, immediately above the line that did it.

The node side is fixed in the companion PR on `Scottcjn/Rustchain` (**Scottcjn/Rustchain#8233**), where the counts become `null` alongside `overdue_stats_measured: false` and an explicit `overdue_stats_error`.

This loop now maps an unmeasurable queue to the literal `UNKNOWN` and fails the job with an explicit error rather than treating it as drained.

**Verified** against four synthetic node responses:

| response | outcome |
|---|---|
| locked DB (`null` + `measured: false`) | `::error::queue state UNKNOWN`, **exit 1** |
| genuinely drained (`0` + `measured: true`) | `queue drained`, break, exit 0 |
| backlog remaining (`1200`) | continue looping |
| **old node build** (integer `0`, no `measured` field) | unchanged — `queue drained` |

That last row matters: the workflow keeps working against a node that has not yet taken the companion change, so the two PRs can merge in either order without a window where the hourly job breaks.

---

## What I verified, and what I did not

**Verified by running it:**
- Both workflow steps' shell extracted from the YAML and executed against stubs, with the before/after results shown above.
- `pr_review_gate.py`'s `__main__` guard, old vs new, under a forced `HTTPError`.
- Both workflow files parse under `yaml.safe_load`.
- `pytest tests/test_docstring_gate.py tests/test_pr_review_gate_prose_repo.py tests/test_pr_review_gate_rubber_stamp.py` — 48 passed.
- Full suite: 520 passed. The 16 failures (`test_ai_agent.py`, `test_clawrtc_integration.py`) and 4 collection errors (missing `prometheus_client`) are **pre-existing on `origin/main`** — confirmed by stashing my changes and re-running.

**NOT verified:**
- **No GitHub Actions run was executed.** I ran the step scripts directly against stubs, which exercises the control flow, but **that is not the same as watching the workflow go red**. The `::error` / `::warning` annotations, the `${{ github.event.inputs.issue || github.event.issue.number }}` expression (stubbed out during testing), and the self-hosted-runner path in `confirm-pending.yml` are unproven until a real run exists.
- No production host was contacted, so `confirm-pending.yml` was tested only against synthetic JSON, never against a live `/pending/confirm`.
- I did not re-audit whether `docstring_gate.py`'s own return codes correctly distinguish "adjudicated" from "failed" in every branch — I read them (`0` for all adjudicated and deliberately-skipped outcomes, `1` for real failures) and relied on that contract. If a branch returns 0 where it should fail, this workflow will now faithfully report that as a success.
