### PR TITLE
fix(ci): restore the required check context name for the tier gate

### DIFF
--- a/.github/workflows/bcos-tier-gate.yml
+++ b/.github/workflows/bcos-tier-gate.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-name: BCOS Review Tier
+name: BCOS Checks
 
 # Assigns / checks the review tier label on non-doc pull requests.
 #


### PR DESCRIPTION
## The bug

Branch protection on `main` requires these contexts:

```
BCOS Checks / Review Tier Label Gate
BCOS Checks / SPDX + SBOM Artifacts
```

A GitHub check context is `"<workflow display name> / <job name>"`.

When `label-gate` was moved out of `bcos.yml` into `bcos-tier-gate.yml`, that file was given `name: BCOS Review Tier`. So the gate now reports as **`BCOS Review Tier / Review Tier Label Gate`**, and the required **`BCOS Checks / Review Tier Label Gate`** is produced by nothing at all.

A required status check that is never reported stays *"Expected — waiting for status"* indefinitely, which blocks the merge permanently. **68 open PRs are affected.** It has been invisible because `enforce_admins: false`, so maintainer merges still work — only external contributions are stuck.

The header comment in this very file says the previous arrangement left *"five external PRs stuck"*. The extraction fixed the labelling logic and made the blocking permanent and universal, because the branch-protection config was never updated alongside it.

## The fix

Restore `name: BCOS Checks` so the context string matches what protection requires.

The workflows **stay separate** — this one needs `pull_request_target` with `pull-requests: write` to label fork PRs, while `bcos.yml` uses `pull_request` with read-only permissions. Only the display name changes; triggers, permissions, and logic are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)