### PR TITLE
fix(clients): github-tip-bot + crewai client use the real /wallet/transfer contract

### DIFF
--- a/crewai-template/rustchain_client/__init__.py
+++ b/crewai-template/rustchain_client/__init__.py
@@ -27,10 +27,10 @@ class RustChainClient:
         response.raise_for_status()
         return response.json()
     
-    def _post(self, endpoint: str, data: dict = None) -> dict:
+    def _post(self, endpoint: str, data: dict = None, headers: dict = None) -> dict:
         """Make POST request to RustChain node"""
         url = f"{self.node_url}{endpoint}"
-        response = self.session.post(url, json=data, timeout=30)
+        response = self.session.post(url, json=data, headers=headers or None, timeout=30)
         response.raise_for_status()
         return response.json()
     
@@ -73,8 +73,9 @@ class RustChainClient:
         """
         return self._get("/wallet/balance", params={"miner_id": wallet_name})
     
-    def transfer(self, from_wallet: str, to_wallet: str, amount: float, 
-                 admin_key: str = None) -> Dict[str, Any]:
+    def transfer(self, from_wallet: str, to_wallet: str, amount: float,
+                 admin_key: str = None, reason: str = None,
+                 idempotency_key: str = None) -> Dict[str, Any]:
         """
         Transfer RTC between wallets
         
@@ -89,14 +90,28 @@ class RustChainClient:
         """
         if not admin_key:
             raise ValueError("Admin key required for transfers")
-        
+        if not reason or not str(reason).strip():
+            raise ValueError("reason is required (audit attribution, e.g. 'bounty:123:slug:2026-08-22')")
+        if not idempotency_key:
+            # Stable per (from, to, amount, reason): a retried call replays to
+            # the same pending row on the node instead of paying twice.
+            import hashlib
+            idempotency_key = "crewai:" + hashlib.sha256(
+                f"{from_wallet}:{to_wallet}:{amount}:{reason}".encode()
+            ).hexdigest()[:40]
+
+        # Field names + auth header per the node's POST /wallet/transfer
+        # contract. (The previous from/to/amount/admin_key body never matched
+        # the endpoint.) Response is two-phase: ok + pending_id means QUEUED,
+        # confirming in ~24h — not yet paid.
         data = {
-            "from": from_wallet,
-            "to": to_wallet,
-            "amount": amount,
-            "admin_key": admin_key
+            "from_miner": from_wallet,
+            "to_miner": to_wallet,
+            "amount_rtc": amount,
+            "reason": reason,
+            "idempotency_key": idempotency_key,
         }
-        return self._post("/wallet/transfer", data)
+        return self._post("/wallet/transfer", data, headers={"X-Admin-Key": admin_key})
     
     def register_wallet(self, wallet_name: str) -> Dict[str, Any]:
         """

--- a/github-tip-bot/tip.js
+++ b/github-tip-bot/tip.js
@@ -21,26 +21,45 @@ async function getWalletBalance(walletName) {
   }
 }
 
-async function transferRTC(fromWallet, toWallet, amount, adminKey) {
+// Stable per (from, to, amount, memo, tipCommentId): a re-delivered webhook or
+// a workflow re-run collapses onto the SAME pending row on the node instead of
+// tipping twice. Charset is what the node's /wallet/transfer accepts.
+function buildIdempotencyKey(fromWallet, toWallet, amount, memo, commentId) {
+  const raw = `${fromWallet}:${toWallet}:${amount}:${memo || ''}:${commentId || ''}`;
+  const digest = require('crypto').createHash('sha256').update(raw).digest('hex').slice(0, 32);
+  return `github_tip:${String(commentId || 'manual').replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 32)}:${digest}`;
+}
+
+async function transferRTC(fromWallet, toWallet, amount, adminKey, memo = '', commentId = '') {
   try {
+    // Field names + auth header per the node's POST /wallet/transfer contract:
+    // {from_miner, to_miner, amount_rtc, reason, idempotency_key} with
+    // X-Admin-Key. (The previous body — from/to/amount/admin_key — never
+    // matched the endpoint; every tip would have been rejected.)
+    const reason = `github_tip:${commentId || 'manual'}:${(memo || 'tip').slice(0, 200)}`;
     const response = await fetch(`${RUSTCHAIN_API}/wallet/transfer`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-Admin-Key': adminKey },
       body: JSON.stringify({
-        from: fromWallet,
-        to: toWallet,
-        amount: parseFloat(amount),
-        admin_key: adminKey
+        from_miner: fromWallet,
+        to_miner: toWallet,
+        amount_rtc: parseFloat(amount),
+        reason,
+        idempotency_key: buildIdempotencyKey(fromWallet, toWallet, amount, memo, commentId)
       })
     });
-    
+
     if (!response.ok) {
       const error = await response.text();
       return { success: false, error: error };
     }
-    
+
     const data = await response.json();
-    return { success: true, txId: data.txId || data.ticket_id };
+    if (!data.ok) {
+      return { success: false, error: data.error || JSON.stringify(data) };
+    }
+    // Two-phase: `pending_id`/`tx_hash` mean QUEUED (confirms in ~24h), not paid.
+    return { success: true, txId: data.tx_hash, pendingId: data.pending_id, phase: data.phase };
   } catch (error) {
     return { success: false, error: error.message };
   }
@@ -180,7 +199,7 @@ async function run() {
       }
       
       // Process tip
-      const result = await transferRTC(sender, toUser, amount, adminKey);
+      const result = await transferRTC(sender, toUser, amount, adminKey, memo, context.payload.comment.id);
       
       if (result.success) {
         response = formatResponse('tip_success', {


### PR DESCRIPTION
Part of the /wallet/transfer Phase-2 hardening (node now requires `reason` + `idempotency_key`).

Both clients sent `{from, to, amount, admin_key}` with no `X-Admin-Key` header — a body the node never accepted, so every call would have been rejected. They now send `{from_miner, to_miner, amount_rtc, reason, idempotency_key}` with the header.

- **tip.js**: `idempotency_key = github_tip:<comment_id>:<digest>` — a re-delivered webhook / re-run workflow collapses onto the same pending row instead of tipping twice. Result exposes `pending_id`/`phase` (two-phase: queued, confirms ~24h).
- **crewai client**: `reason` required; key defaults to a deterministic digest of (from,to,amount,reason); `_post` gained a `headers` param.

Verification: `node --check tip.js`, `py_compile` on the client. Neither is a live service; this makes them correct for anyone who deploys them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)