### PR TITLE
fix(rtc-reward): parse markdown-wrapped wallets in claim issues (#16327)

### DIFF
--- a/actions/rtc-reward/README.md
+++ b/actions/rtc-reward/README.md
@@ -43,7 +43,7 @@ Or the repo maintainer places a `.rtc-wallet` file in the repo root.
 | `wallet-from` | Yes | — | Source wallet for rewards |
 | `admin-key` | Yes | — | Admin key for signing |
 | `dry-run` | No | `false` | Log actions without sending transactions |
-| `wallet-pattern` | No | `RTC[0-9a-fA-F]{36,44}` | Regex to find wallet in PR body |
+| `wallet-pattern` | No | `RTC[0-9a-fA-F]{40}(?![0-9a-fA-F])` | Regex to find an exact RTC wallet in PR body |
 | `comment-template` | No | Built-in | Template for reward comment |
 
 ## Outputs

--- a/actions/rtc-reward/action.yml
+++ b/actions/rtc-reward/action.yml
@@ -27,7 +27,7 @@ inputs:
   wallet-pattern:
     description: 'Regex pattern to extract RTC wallet from PR body'
     required: false
-    default: 'RTC[0-9a-fA-F]{36,44}'
+    default: 'RTC[0-9a-fA-F]{40}(?![0-9a-fA-F])'
   comment-template:
     description: 'Template for the reward comment. Use {{amount}} and {{wallet}}'
     required: false

--- a/actions/rtc-reward/dist/index.js
+++ b/actions/rtc-reward/dist/index.js
@@ -1,236 +1,114 @@
-// RTC Reward Action — standalone (no external npm deps)
-// Uses only Node.js 20 built-ins. Compatible with GitHub Actions node20 runtime.
+// Built from community/github-actions/rtc-reward/src/main.js - keep in sync.
+'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const crypto = require('crypto');
+// rtc-reward: parses bounty claim issues and exports payout details.
+//
+// Fixes #16327 (Claim #696): claimants wrap their wallet in markdown code
+// quotes, e.g.
+//   **Wallet:** `7doPxSPt1pmbHcUcVzK22FVECDhv8kV6nnd2XMKaFiRd`
+// The previous parser expected a bare address and rejected these claims.
 
-// ---- helpers ----
+const core = require('@actions/core');
+const github = require('@actions/github');
 
-function getInput(name, opts = {}) {
-  const key = `INPUT_${name.replace(/ /g, '_').toUpperCase()}`;
-  const val = process.env[key];
-  if (opts.required && (val === undefined || val === '')) {
-    throw new Error(`Input required and not supplied: ${name}`);
+// Wallet label followed by an optional code quote and a base58 address.
+// Tolerates bold markers: **Wallet:**, Wallet:, wallet :
+const WALLET_RE = /wallet\s*\*{0,2}\s*:\s*\*{0,2}\s*`?([1-9A-HJ-NP-Za-km-z]{32,44})`?/i;
+const WALLET_VALID_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+// "(2 RTC)" anywhere in the title or body.
+const AMOUNT_RE = /\(\s*(\d+(?:\.\d+)?)\s*RTC\s*\)/i;
+
+function extractWallet(body) {
+  if (!body) {
+    return null;
   }
-  return val !== undefined ? val : (opts.default || '');
-}
-
-function setOutput(name, value) {
-  // Write to GITHUB_OUTPUT file if available (actions/core compatible)
-  const outFile = process.env.GITHUB_OUTPUT;
-  if (outFile) {
-    fs.appendFileSync(outFile, `${name}=${value}\n`);
+  const match = body.match(WALLET_RE);
+  if (!match) {
+    return null;
   }
-  // Also print for workflow command compatibility
-  process.stdout.write(`::set-output name=${name}::${value}\n`);
+  const candidate = match[1].trim();
+  return WALLET_VALID_RE.test(candidate) ? candidate : null;
 }
 
-function setFailed(msg) {
-  process.stderr.write(`::error::${msg}\n`);
-  process.exit(1);
-}
-
-function info(msg) {
-  process.stdout.write(`${msg}\n`);
-}
-
-function warning(msg) {
-  process.stdout.write(`::warning::${msg}\n`);
-}
-
-async function octokitRequest(token, method, url, body) {
-  const resp = await fetch(url, {
-    method,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28',
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  const data = resp.headers.get('content-type')?.includes('json')
-    ? await resp.json()
-    : await resp.text();
-  if (!resp.ok) {
-    throw new Error(`GitHub API ${method} ${url} → ${resp.status}: ${JSON.stringify(data)}`);
+function extractAmount(title, body, fallbackAmount) {
+  const fromTitle = title && title.match(AMOUNT_RE);
+  if (fromTitle) {
+    return Number(fromTitle[1]);
   }
-  return data;
+  const fromBody = body && body.match(AMOUNT_RE);
+  if (fromBody) {
+    return Number(fromBody[1]);
+  }
+  return fallbackAmount;
 }
-
-// ---- main ----
 
 async function run() {
-  const nodeUrl = getInput('node-url', { required: true });
-  const amount = parseInt(getInput('amount', { required: true }), 10);
-  if (isNaN(amount) || amount <= 0) throw new Error(`Invalid amount: ${getInput('amount')}`);
-  const walletFrom = getInput('wallet-from', { required: true });
-  const adminKey = getInput('admin-key', { required: true });
-  const dryRun = getInput('dry-run') === 'true';
-  const walletPattern = getInput('wallet-pattern') || 'RTC[0-9a-fA-F]{36,44}';
-  const commentTemplate = getInput('comment-template') || [
-    '## RTC Reward',
-    '',
-    'This merged PR earned **{{amount}} RTC** — sent to `{{wallet}}`.',
-    '',
-    '[RustChain Bounty Program](https://github.com/Scottcjn/rustchain-bounties)',
-  ].join('\n');
+  try {
+    const token = core.getInput('github-token') || process.env.GITHUB_TOKEN || '';
+    const fallbackAmount = Number(core.getInput('default-amount') || '0');
+    const dryRun = String(core.getInput('dry-run') || '').toLowerCase() === 'true';
 
-  const token = process.env.GITHUB_TOKEN;
-  if (!token) throw new Error('GITHUB_TOKEN not set');
+    const ctx = github.context;
+    const issue = ctx.payload.issue;
+    const issueNumber = (issue && issue.number) || Number(core.getInput('issue-number') || '0');
 
-  // Read event payload
-  const eventPath = process.env.GITHUB_EVENT_PATH;
-  if (!eventPath) throw new Error('GITHUB_EVENT_PATH not set');
-  const event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
-  const repoFull = (process.env.GITHUB_REPOSITORY || '').split('/');
-  const owner = repoFull[0];
-  const repo = repoFull[1];
-
-  const apiBase = 'https://api.github.com';
-
-  // Determine PR number
-  let prNumber;
-  if (event.pull_request) {
-    prNumber = event.pull_request.number;
-  } else if (event.after) {
-    // Push event — find associated merged PR
-    const prs = await octokitRequest(
-      token, 'GET',
-      `${apiBase}/repos/${owner}/${repo}/commits/${event.after}/pulls`
-    );
-    const merged = prs.filter(p => p.merged_at);
-    if (merged.length > 0) prNumber = merged[0].number;
-  }
-
-  if (!prNumber) {
-    info('No merged PR found for this event. Skipping.');
-    return;
-  }
-
-  // Fetch PR
-  const pr = await octokitRequest(
-    token, 'GET',
-    `${apiBase}/repos/${owner}/${repo}/pulls/${prNumber}`
-  );
-
-  if (!pr.merged) {
-    info(`PR #${prNumber} is not merged. Skipping.`);
-    return;
-  }
-
-  // Extract wallet
-  let wallet = extractWallet(pr.body || '', walletPattern);
-  if (!wallet) {
-    wallet = await findWalletInRepo(token, apiBase, owner, repo, pr.head.sha, walletPattern);
-  }
-  let walletSource = 'pr-body-or-repo';
-  if (!wallet) {
-    // Handle fallback: RustChain treats a contributor's GitHub handle as a valid
-    // wallet identifier (see rustchain-bounties/GIG_APPLICANTS.md), so a PR with
-    // no explicit RTC address still earns — the author can later bind that handle
-    // to an RTC address. Bots are excluded so automation cannot farm rewards.
-    const login = (pr.user && pr.user.login) || '';
-    const isBot = (pr.user && pr.user.type === 'Bot') || /\[bot\]$/i.test(login);
-    if (login && !isBot) {
-      wallet = login;
-      walletSource = 'github-handle-fallback';
-      info(`No RTC wallet in PR #${prNumber}; falling back to GitHub handle wallet: ${wallet}`);
+    if (!issueNumber) {
+      core.setFailed('rtc-reward: no issue number available');
+      return;
     }
+
+    const title = (issue && issue.title) || '';
+    const body = (issue && issue.body) || '';
+
+    const wallet = extractWallet(body);
+    const amount = extractAmount(title, body, fallbackAmount);
+    const valid = Boolean(wallet) && amount > 0;
+
+    core.setOutput('issue-number', String(issueNumber));
+    core.setOutput('wallet', wallet || '');
+    core.setOutput('amount', String(amount));
+    core.setOutput('valid', String(valid));
+
+    if (!wallet) {
+      core.warning('rtc-reward: no valid base58 wallet found in claim #' + issueNumber);
+    }
+    if (!(amount > 0)) {
+      core.warning('rtc-reward: no positive RTC amount found in claim #' + issueNumber);
+    }
+
+    if (!token || dryRun || !issue) {
+      core.info('rtc-reward: dry run - outputs exported, no comment posted');
+      return;
+    }
+
+    const octokit = github.getOctokit(token);
+    const repo = ctx.repo;
+
+    let comment;
+    if (valid) {
+      comment =
+        '✅ Claim #' + issueNumber + ' validated by rtc-reward.\n\n' +
+        '- Wallet: `' + wallet + '`\n' +
+        '- Amount: ' + amount + ' RTC\n\n' +
+        'Payout queued by the rewards bot.';
+    } else {
+      comment =
+        '⚠️ Claim #' + issueNumber + ' could not be validated.\n\n' +
+        (wallet ? '' : '- Add a wallet line: Wallet: <your-base58-address>\n') +
+        (amount > 0 ? '' : '- Include the amount in the title, e.g. (2 RTC).\n');
+    }
+
+    await octokit.rest.issues.createComment({
+      owner: repo.owner,
+      repo: repo.repo,
+      issue_number: issueNumber,
+      body: comment,
+    });
+    core.info('rtc-reward: commented on #' + issueNumber + ' (valid=' + valid + ')');
+  } catch (err) {
+    core.setFailed('rtc-reward: ' + (err && err.message ? err.message : String(err)));
   }
-  if (!wallet) {
-    info(`No wallet and no eligible handle for PR #${prNumber} (bot author?). Skipping reward.`);
-    setOutput('wallet-found', 'false');
-    return;
-  }
-
-  info(`Found wallet: ${wallet} (source: ${walletSource})`);
-  info(`Awarding ${amount} RTC to @${pr.user.login} for PR #${prNumber}`);
-
-  if (dryRun) {
-    info('[DRY RUN] Would call RTC transfer:');
-    info(`  From: ${walletFrom}  →  To: ${wallet}`);
-    info(`  Amount: ${amount} RTC`);
-    info(`  Node: ${nodeUrl}`);
-  } else {
-    const tx = await sendRTC(nodeUrl, walletFrom, wallet, amount, adminKey, pr.html_url);
-    info(`Transfer result: ${JSON.stringify(tx)}`);
-  }
-
-  // Post comment
-  const comment = commentTemplate
-    .replace(/\{\{amount\}\}/g, String(amount))
-    .replace(/\{\{wallet\}\}/g, wallet)
-    .replace(/\{\{pr_number\}\}/g, String(prNumber))
-    .replace(/\{\{author\}\}/g, pr.user.login);
-
-  if (!dryRun) {
-    await octokitRequest(token, 'POST',
-      `${apiBase}/repos/${owner}/${repo}/issues/${prNumber}/comments`,
-      { body: comment }
-    );
-    info('Reward comment posted.');
-  } else {
-    info(`[DRY RUN] Would post comment:\n${comment}`);
-  }
-
-  setOutput('wallet-found', 'true');
-  setOutput('wallet', wallet);
-  setOutput('amount', String(amount));
-  setOutput('pr-number', String(prNumber));
-}
-
-function extractWallet(text, pattern) {
-  const re = new RegExp(pattern, 'g');
-  const matches = text.match(re);
-  return matches ? matches[matches.length - 1] : null;
-}
-
-async function findWalletInRepo(token, apiBase, owner, repo, ref, pattern) {
-  const paths = ['.rtc-wallet', '.github/rtc-wallet', 'RTC_WALLET', '.rtcwallet'];
-  for (const p of paths) {
-    try {
-      const data = await octokitRequest(
-        token, 'GET',
-        `${apiBase}/repos/${owner}/${repo}/contents/${p}?ref=${ref}`
-      );
-      const content = Buffer.from(data.content, 'base64').toString('utf-8').trim();
-      const wallet = extractWallet(content, pattern);
-      if (wallet) { info(`Found wallet in ${p}: ${wallet}`); return wallet; }
-    } catch { /* file not found */ }
-  }
-  return null;
-}
-
-function buildIdempotencyKey(from, to, amount, memo) {
-  const raw = `${from}:${to}:${amount}:${memo}`;
-  return crypto.createHash('sha256').update(raw).digest('hex').slice(0, 24);
-}
-
-async function sendRTC(nodeUrl, from, to, amount, adminKey, memo) {
-  // RustChain node contract: POST /wallet/transfer with {from_miner,to_miner,
-  // amount_rtc}, admin auth via the X-Admin-Key header (NOT the body). The old
-  // /api/v1/transfer path 404s and body admin_key is ignored. Use a compact
-  // stable hex idempotency key because the node rejects URL-shaped keys.
-  const idempotencyKey = buildIdempotencyKey(from, to, amount, memo);
-  const payload = {
-    from_miner: from,
-    to_miner: to,
-    amount_rtc: amount,
-    memo,
-    idempotency_key: idempotencyKey,
-  };
-  const resp = await fetch(`${nodeUrl.replace(/\/$/, '')}/wallet/transfer`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'X-Admin-Key': adminKey },
-    body: JSON.stringify(payload),
-  });
-  if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`RTC transfer failed (${resp.status}): ${text}`);
-  }
-  return resp.json();
 }
 
 run();

--- a/actions/rtc-reward/dist/index.js
+++ b/actions/rtc-reward/dist/index.js
@@ -1,114 +1,242 @@
-// Built from community/github-actions/rtc-reward/src/main.js - keep in sync.
-'use strict';
+// RTC Reward Action — standalone (no external npm deps)
+// Uses only Node.js 20 built-ins. Compatible with GitHub Actions node20 runtime.
 
-// rtc-reward: parses bounty claim issues and exports payout details.
-//
-// Fixes #16327 (Claim #696): claimants wrap their wallet in markdown code
-// quotes, e.g.
-//   **Wallet:** `7doPxSPt1pmbHcUcVzK22FVECDhv8kV6nnd2XMKaFiRd`
-// The previous parser expected a bare address and rejected these claims.
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
 
-const core = require('@actions/core');
-const github = require('@actions/github');
+const DEFAULT_WALLET_PATTERN = 'RTC[0-9a-fA-F]{40}(?![0-9a-fA-F])';
 
-// Wallet label followed by an optional code quote and a base58 address.
-// Tolerates bold markers: **Wallet:**, Wallet:, wallet :
-const WALLET_RE = /wallet\s*\*{0,2}\s*:\s*\*{0,2}\s*`?([1-9A-HJ-NP-Za-km-z]{32,44})`?/i;
-const WALLET_VALID_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+// ---- helpers ----
 
-// "(2 RTC)" anywhere in the title or body.
-const AMOUNT_RE = /\(\s*(\d+(?:\.\d+)?)\s*RTC\s*\)/i;
-
-function extractWallet(body) {
-  if (!body) {
-    return null;
+function getInput(name, opts = {}) {
+  const key = `INPUT_${name.replace(/ /g, '_').toUpperCase()}`;
+  const val = process.env[key];
+  if (opts.required && (val === undefined || val === '')) {
+    throw new Error(`Input required and not supplied: ${name}`);
   }
-  const match = body.match(WALLET_RE);
-  if (!match) {
-    return null;
-  }
-  const candidate = match[1].trim();
-  return WALLET_VALID_RE.test(candidate) ? candidate : null;
+  return val !== undefined ? val : (opts.default || '');
 }
 
-function extractAmount(title, body, fallbackAmount) {
-  const fromTitle = title && title.match(AMOUNT_RE);
-  if (fromTitle) {
-    return Number(fromTitle[1]);
+function setOutput(name, value) {
+  // Write to GITHUB_OUTPUT file if available (actions/core compatible)
+  const outFile = process.env.GITHUB_OUTPUT;
+  if (outFile) {
+    fs.appendFileSync(outFile, `${name}=${value}\n`);
   }
-  const fromBody = body && body.match(AMOUNT_RE);
-  if (fromBody) {
-    return Number(fromBody[1]);
-  }
-  return fallbackAmount;
+  // Also print for workflow command compatibility
+  process.stdout.write(`::set-output name=${name}::${value}\n`);
 }
+
+function setFailed(msg) {
+  process.stderr.write(`::error::${msg}\n`);
+  process.exit(1);
+}
+
+function info(msg) {
+  process.stdout.write(`${msg}\n`);
+}
+
+function warning(msg) {
+  process.stdout.write(`::warning::${msg}\n`);
+}
+
+async function octokitRequest(token, method, url, body) {
+  const resp = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = resp.headers.get('content-type')?.includes('json')
+    ? await resp.json()
+    : await resp.text();
+  if (!resp.ok) {
+    throw new Error(`GitHub API ${method} ${url} → ${resp.status}: ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+// ---- main ----
 
 async function run() {
-  try {
-    const token = core.getInput('github-token') || process.env.GITHUB_TOKEN || '';
-    const fallbackAmount = Number(core.getInput('default-amount') || '0');
-    const dryRun = String(core.getInput('dry-run') || '').toLowerCase() === 'true';
+  const nodeUrl = getInput('node-url', { required: true });
+  const amount = parseInt(getInput('amount', { required: true }), 10);
+  if (isNaN(amount) || amount <= 0) throw new Error(`Invalid amount: ${getInput('amount')}`);
+  const walletFrom = getInput('wallet-from', { required: true });
+  const adminKey = getInput('admin-key', { required: true });
+  const dryRun = getInput('dry-run') === 'true';
+  const walletPattern = getInput('wallet-pattern') || DEFAULT_WALLET_PATTERN;
+  const commentTemplate = getInput('comment-template') || [
+    '## RTC Reward',
+    '',
+    'This merged PR earned **{{amount}} RTC** — sent to `{{wallet}}`.',
+    '',
+    '[RustChain Bounty Program](https://github.com/Scottcjn/rustchain-bounties)',
+  ].join('\n');
 
-    const ctx = github.context;
-    const issue = ctx.payload.issue;
-    const issueNumber = (issue && issue.number) || Number(core.getInput('issue-number') || '0');
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN not set');
 
-    if (!issueNumber) {
-      core.setFailed('rtc-reward: no issue number available');
-      return;
-    }
+  // Read event payload
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) throw new Error('GITHUB_EVENT_PATH not set');
+  const event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
+  const repoFull = (process.env.GITHUB_REPOSITORY || '').split('/');
+  const owner = repoFull[0];
+  const repo = repoFull[1];
 
-    const title = (issue && issue.title) || '';
-    const body = (issue && issue.body) || '';
+  const apiBase = 'https://api.github.com';
 
-    const wallet = extractWallet(body);
-    const amount = extractAmount(title, body, fallbackAmount);
-    const valid = Boolean(wallet) && amount > 0;
-
-    core.setOutput('issue-number', String(issueNumber));
-    core.setOutput('wallet', wallet || '');
-    core.setOutput('amount', String(amount));
-    core.setOutput('valid', String(valid));
-
-    if (!wallet) {
-      core.warning('rtc-reward: no valid base58 wallet found in claim #' + issueNumber);
-    }
-    if (!(amount > 0)) {
-      core.warning('rtc-reward: no positive RTC amount found in claim #' + issueNumber);
-    }
-
-    if (!token || dryRun || !issue) {
-      core.info('rtc-reward: dry run - outputs exported, no comment posted');
-      return;
-    }
-
-    const octokit = github.getOctokit(token);
-    const repo = ctx.repo;
-
-    let comment;
-    if (valid) {
-      comment =
-        '✅ Claim #' + issueNumber + ' validated by rtc-reward.\n\n' +
-        '- Wallet: `' + wallet + '`\n' +
-        '- Amount: ' + amount + ' RTC\n\n' +
-        'Payout queued by the rewards bot.';
-    } else {
-      comment =
-        '⚠️ Claim #' + issueNumber + ' could not be validated.\n\n' +
-        (wallet ? '' : '- Add a wallet line: Wallet: <your-base58-address>\n') +
-        (amount > 0 ? '' : '- Include the amount in the title, e.g. (2 RTC).\n');
-    }
-
-    await octokit.rest.issues.createComment({
-      owner: repo.owner,
-      repo: repo.repo,
-      issue_number: issueNumber,
-      body: comment,
-    });
-    core.info('rtc-reward: commented on #' + issueNumber + ' (valid=' + valid + ')');
-  } catch (err) {
-    core.setFailed('rtc-reward: ' + (err && err.message ? err.message : String(err)));
+  // Determine PR number
+  let prNumber;
+  if (event.pull_request) {
+    prNumber = event.pull_request.number;
+  } else if (event.after) {
+    // Push event — find associated merged PR
+    const prs = await octokitRequest(
+      token, 'GET',
+      `${apiBase}/repos/${owner}/${repo}/commits/${event.after}/pulls`
+    );
+    const merged = prs.filter(p => p.merged_at);
+    if (merged.length > 0) prNumber = merged[0].number;
   }
+
+  if (!prNumber) {
+    info('No merged PR found for this event. Skipping.');
+    return;
+  }
+
+  // Fetch PR
+  const pr = await octokitRequest(
+    token, 'GET',
+    `${apiBase}/repos/${owner}/${repo}/pulls/${prNumber}`
+  );
+
+  if (!pr.merged) {
+    info(`PR #${prNumber} is not merged. Skipping.`);
+    return;
+  }
+
+  // Extract wallet
+  let wallet = extractWallet(pr.body || '', walletPattern);
+  if (!wallet) {
+    wallet = await findWalletInRepo(token, apiBase, owner, repo, pr.head.sha, walletPattern);
+  }
+  let walletSource = 'pr-body-or-repo';
+  if (!wallet) {
+    // Handle fallback: RustChain treats a contributor's GitHub handle as a valid
+    // wallet identifier (see rustchain-bounties/GIG_APPLICANTS.md), so a PR with
+    // no explicit RTC address still earns — the author can later bind that handle
+    // to an RTC address. Bots are excluded so automation cannot farm rewards.
+    const login = (pr.user && pr.user.login) || '';
+    const isBot = (pr.user && pr.user.type === 'Bot') || /\[bot\]$/i.test(login);
+    if (login && !isBot) {
+      wallet = login;
+      walletSource = 'github-handle-fallback';
+      info(`No RTC wallet in PR #${prNumber}; falling back to GitHub handle wallet: ${wallet}`);
+    }
+  }
+  if (!wallet) {
+    info(`No wallet and no eligible handle for PR #${prNumber} (bot author?). Skipping reward.`);
+    setOutput('wallet-found', 'false');
+    return;
+  }
+
+  info(`Found wallet: ${wallet} (source: ${walletSource})`);
+  info(`Awarding ${amount} RTC to @${pr.user.login} for PR #${prNumber}`);
+
+  if (dryRun) {
+    info('[DRY RUN] Would call RTC transfer:');
+    info(`  From: ${walletFrom}  →  To: ${wallet}`);
+    info(`  Amount: ${amount} RTC`);
+    info(`  Node: ${nodeUrl}`);
+  } else {
+    const tx = await sendRTC(nodeUrl, walletFrom, wallet, amount, adminKey, pr.html_url);
+    info(`Transfer result: ${JSON.stringify(tx)}`);
+  }
+
+  // Post comment
+  const comment = commentTemplate
+    .replace(/\{\{amount\}\}/g, String(amount))
+    .replace(/\{\{wallet\}\}/g, wallet)
+    .replace(/\{\{pr_number\}\}/g, String(prNumber))
+    .replace(/\{\{author\}\}/g, pr.user.login);
+
+  if (!dryRun) {
+    await octokitRequest(token, 'POST',
+      `${apiBase}/repos/${owner}/${repo}/issues/${prNumber}/comments`,
+      { body: comment }
+    );
+    info('Reward comment posted.');
+  } else {
+    info(`[DRY RUN] Would post comment:\n${comment}`);
+  }
+
+  setOutput('wallet-found', 'true');
+  setOutput('wallet', wallet);
+  setOutput('amount', String(amount));
+  setOutput('pr-number', String(prNumber));
 }
 
-run();
+function extractWallet(text, pattern) {
+  const re = new RegExp(pattern, 'g');
+  const matches = text.match(re);
+  return matches ? matches[matches.length - 1] : null;
+}
+
+async function findWalletInRepo(token, apiBase, owner, repo, ref, pattern) {
+  const paths = ['.rtc-wallet', '.github/rtc-wallet', 'RTC_WALLET', '.rtcwallet'];
+  for (const p of paths) {
+    try {
+      const data = await octokitRequest(
+        token, 'GET',
+        `${apiBase}/repos/${owner}/${repo}/contents/${p}?ref=${ref}`
+      );
+      const content = Buffer.from(data.content, 'base64').toString('utf-8').trim();
+      const wallet = extractWallet(content, pattern);
+      if (wallet) { info(`Found wallet in ${p}: ${wallet}`); return wallet; }
+    } catch { /* file not found */ }
+  }
+  return null;
+}
+
+function buildIdempotencyKey(from, to, amount, memo) {
+  const raw = `${from}:${to}:${amount}:${memo}`;
+  return crypto.createHash('sha256').update(raw).digest('hex').slice(0, 24);
+}
+
+async function sendRTC(nodeUrl, from, to, amount, adminKey, memo) {
+  // RustChain node contract: POST /wallet/transfer with {from_miner,to_miner,
+  // amount_rtc}, admin auth via the X-Admin-Key header (NOT the body). The old
+  // /api/v1/transfer path 404s and body admin_key is ignored. Use a compact
+  // stable hex idempotency key because the node rejects URL-shaped keys.
+  const idempotencyKey = buildIdempotencyKey(from, to, amount, memo);
+  const payload = {
+    from_miner: from,
+    to_miner: to,
+    amount_rtc: amount,
+    memo,
+    idempotency_key: idempotencyKey,
+  };
+  const resp = await fetch(`${nodeUrl.replace(/\/$/, '')}/wallet/transfer`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Admin-Key': adminKey },
+    body: JSON.stringify(payload),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`RTC transfer failed (${resp.status}): ${text}`);
+  }
+  return resp.json();
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = { DEFAULT_WALLET_PATTERN, extractWallet };

--- a/actions/rtc-reward/test/wallet.test.js
+++ b/actions/rtc-reward/test/wallet.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  DEFAULT_WALLET_PATTERN,
+  extractWallet,
+} = require('../dist/index.js');
+
+const ISSUE_16327_BODY = `## Claim #696: RustChain Memes (2 RTC)
+
+I created memes about RustChain and posted them on social media.
+
+### Meme 1:
+**Concept:** "When your 2012 Xeon earns more RTC than someone's $5000 cloud server"
+**Format:** Text meme — the punchline is that vintage hardware out-earns modern infrastructure under Proof of Antiquity.
+
+### Meme 2:
+**Concept:** "Proof of Antiquity: the only blockchain that rewards you for NOT upgrading your hardware"
+**Format:** Comparison image — "Other chains: buy the latest GPU → RustChain: keep your old PC running"
+
+### Where Posted:
+- Reddit: r/cryptocurrency and r/rust
+- Hacker News: Posted as a show HN item about Proof of Antiquity
+
+### Links:
+- Reddit post: (link would be provided with actual URL)
+- HN post: (link would be provided with actual URL)
+
+**Wallet:** \`7doPxSPt1pmbHcUcVzK22FVECDhv8kV6nnd2XMKaFiRd\`
+
+---
+Claiming meme bounty #696. Memes posted with honest humor about RustChain's unique consensus design.
+`;
+
+const VALID_RTC_WALLET = `RTC${'a1'.repeat(20)}`;
+
+test('rejects the non-RTC wallet in the exact body of issue #16327', () => {
+  assert.equal(extractWallet(ISSUE_16327_BODY, DEFAULT_WALLET_PATTERN), null);
+});
+
+test('accepts an exact RTC wallet inside issue #16327 Markdown', () => {
+  const body = ISSUE_16327_BODY.replace(
+    '7doPxSPt1pmbHcUcVzK22FVECDhv8kV6nnd2XMKaFiRd',
+    VALID_RTC_WALLET
+  );
+
+  assert.equal(extractWallet(body, DEFAULT_WALLET_PATTERN), VALID_RTC_WALLET);
+});
+
+test('rejects RTC wallets with non-exact length or non-hex content', () => {
+  assert.equal(extractWallet(`Wallet: RTC${'a'.repeat(39)}`, DEFAULT_WALLET_PATTERN), null);
+  assert.equal(extractWallet(`Wallet: RTC${'a'.repeat(41)}`, DEFAULT_WALLET_PATTERN), null);
+  assert.equal(extractWallet(`Wallet: RTC${'g'.repeat(40)}`, DEFAULT_WALLET_PATTERN), null);
+});

--- a/community/github-actions/rtc-reward/src/main.js
+++ b/community/github-actions/rtc-reward/src/main.js
@@ -1,113 +1,110 @@
-'use strict';
-
-// rtc-reward: parses bounty claim issues and exports payout details.
-//
-// Fixes #16327 (Claim #696): claimants wrap their wallet in markdown code
-// quotes, e.g.
-//   **Wallet:** `7doPxSPt1pmbHcUcVzK22FVECDhv8kV6nnd2XMKaFiRd`
-// The previous parser expected a bare address and rejected these claims.
-
 const core = require('@actions/core');
 const github = require('@actions/github');
+const fetch = require('node-fetch');
+const { extractRtcWallet } = require('./wallet');
 
-// Wallet label followed by an optional code quote and a base58 address.
-// Tolerates bold markers: **Wallet:**, Wallet:, wallet :
-const WALLET_RE = /wallet\s*\*{0,2}\s*:\s*\*{0,2}\s*`?([1-9A-HJ-NP-Za-km-z]{32,44})`?/i;
-const WALLET_VALID_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
-
-// "(2 RTC)" anywhere in the title or body.
-const AMOUNT_RE = /\(\s*(\d+(?:\.\d+)?)\s*RTC\s*\)/i;
-
-function extractWallet(body) {
-  if (!body) {
-    return null;
-  }
-  const match = body.match(WALLET_RE);
-  if (!match) {
-    return null;
-  }
-  const candidate = match[1].trim();
-  return WALLET_VALID_RE.test(candidate) ? candidate : null;
-}
-
-function extractAmount(title, body, fallbackAmount) {
-  const fromTitle = title && title.match(AMOUNT_RE);
-  if (fromTitle) {
-    return Number(fromTitle[1]);
-  }
-  const fromBody = body && body.match(AMOUNT_RE);
-  if (fromBody) {
-    return Number(fromBody[1]);
-  }
-  return fallbackAmount;
-}
-
-async function run() {
+async function getContributorWallet() {
+  const walletFile = core.getInput('wallet-file');
+  const prBody = github.context.payload.pull_request?.body || '';
+  
+  // Try to extract wallet from PR body
+  const prWallet = extractRtcWallet(prBody);
+  if (prWallet) return prWallet;
+  
+  // Try to get wallet from file in repo
   try {
-    const token = core.getInput('github-token') || process.env.GITHUB_TOKEN || '';
-    const fallbackAmount = Number(core.getInput('default-amount') || '0');
-    const dryRun = String(core.getInput('dry-run') || '').toLowerCase() === 'true';
-
-    const ctx = github.context;
-    const issue = ctx.payload.issue;
-    const issueNumber = (issue && issue.number) || Number(core.getInput('issue-number') || '0');
-
-    if (!issueNumber) {
-      core.setFailed('rtc-reward: no issue number available');
-      return;
+    const response = await fetch(
+      `https://api.github.com/repos/${github.context.repo.owner}/${github.context.repo.repo}/contents/${walletFile}`,
+      {
+        headers: {
+          'Authorization': `token ${process.env.GITHUB_TOKEN}`,
+          'Accept': 'application/vnd.github.v3+json'
+        }
+      }
+    );
+    
+    if (response.ok) {
+      const data = await response.json();
+      const wallet = extractRtcWallet(
+        Buffer.from(data.content, 'base64').toString().trim()
+      );
+      if (wallet) return wallet;
     }
+  } catch (error) {
+    core.info(`Could not read wallet file: ${error.message}`);
+  }
+  
+  // Fallback to PR author
+  return github.context.payload.pull_request?.user?.login || 'unknown';
+}
 
-    const title = (issue && issue.title) || '';
-    const body = (issue && issue.body) || '';
-
-    const wallet = extractWallet(body);
-    const amount = extractAmount(title, body, fallbackAmount);
-    const valid = Boolean(wallet) && amount > 0;
-
-    core.setOutput('issue-number', String(issueNumber));
-    core.setOutput('wallet', wallet || '');
-    core.setOutput('amount', String(amount));
-    core.setOutput('valid', String(valid));
-
-    if (!wallet) {
-      core.warning('rtc-reward: no valid base58 wallet found in claim #' + issueNumber);
-    }
-    if (!(amount > 0)) {
-      core.warning('rtc-reward: no positive RTC amount found in claim #' + issueNumber);
-    }
-
-    if (!token || dryRun || !issue) {
-      core.info('rtc-reward: dry run - outputs exported, no comment posted');
-      return;
-    }
-
-    const octokit = github.getOctokit(token);
-    const repo = ctx.repo;
-
-    let comment;
-    if (valid) {
-      comment =
-        '✅ Claim #' + issueNumber + ' validated by rtc-reward.\n\n' +
-        '- Wallet: `' + wallet + '`\n' +
-        '- Amount: ' + amount + ' RTC\n\n' +
-        'Payout queued by the rewards bot.';
-    } else {
-      comment =
-        '⚠️ Claim #' + issueNumber + ' could not be validated.\n\n' +
-        (wallet ? '' : '- Add a wallet line: Wallet: <your-base58-address>\n') +
-        (amount > 0 ? '' : '- Include the amount in the title, e.g. (2 RTC).\n');
-    }
-
-    await octokit.rest.issues.createComment({
-      owner: repo.owner,
-      repo: repo.repo,
-      issue_number: issueNumber,
-      body: comment,
+async function awardRTC(contributorWallet, amount, nodeUrl, adminKey, dryRun) {
+  if (dryRun === 'true') {
+    core.info(`DRY RUN: Would award ${amount} RTC to ${contributorWallet}`);
+    return { success: true, message: 'Dry run completed' };
+  }
+  
+  try {
+    const response = await fetch(`${nodeUrl}/admin/transfer`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Admin-Key': adminKey
+      },
+      body: JSON.stringify({
+        from_wallet: core.getInput('wallet-from'),
+        to_wallet: contributorWallet,
+        amount_rtc: parseFloat(amount)
+      })
     });
-    core.info('rtc-reward: commented on #' + issueNumber + ' (valid=' + valid + ')');
-  } catch (err) {
-    core.setFailed('rtc-reward: ' + (err && err.message ? err.message : String(err)));
+    
+    const result = await response.json();
+    return { success: response.ok, message: result.message || 'Transfer completed' };
+  } catch (error) {
+    return { success: false, message: error.message };
   }
 }
 
-run();
+async function main() {
+  try {
+    // Verify this is a merged PR
+    if (!github.context.payload.pull_request?.merged) {
+      core.info('PR not merged, skipping reward');
+      return;
+    }
+    
+    const amount = core.getInput('amount');
+    const nodeUrl = core.getInput('node-url');
+    const adminKey = core.getInput('admin-key');
+    const dryRun = core.getInput('dry-run');
+    
+    const contributorWallet = await getContributorWallet();
+    core.info(`Awarding ${amount} RTC to contributor: ${contributorWallet}`);
+    
+    const result = await awardRTC(contributorWallet, amount, nodeUrl, adminKey, dryRun);
+    
+    if (result.success) {
+      core.info(`Successfully awarded ${amount} RTC to ${contributorWallet}`);
+      await core.setOutput('success', 'true');
+    } else {
+      core.setFailed(`Failed to award RTC: ${result.message}`);
+      await core.setOutput('success', 'false');
+    }
+    
+    // Post comment on PR
+    const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+    await octokit.rest.issues.createComment({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      issue_number: github.context.issue.number,
+      body: result.success 
+        ? `✅ **RTC Reward Awarded**\n\n${amount} RTC has been transferred to wallet \`${contributorWallet}\`.\n\nThank you for your contribution! 🌾`
+        : `❌ **RTC Reward Failed**\n\nFailed to transfer ${amount} RTC: ${result.message}`
+    });
+    
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}
+
+main();

--- a/community/github-actions/rtc-reward/src/main.js
+++ b/community/github-actions/rtc-reward/src/main.js
@@ -1,109 +1,113 @@
+'use strict';
+
+// rtc-reward: parses bounty claim issues and exports payout details.
+//
+// Fixes #16327 (Claim #696): claimants wrap their wallet in markdown code
+// quotes, e.g.
+//   **Wallet:** `7doPxSPt1pmbHcUcVzK22FVECDhv8kV6nnd2XMKaFiRd`
+// The previous parser expected a bare address and rejected these claims.
+
 const core = require('@actions/core');
 const github = require('@actions/github');
-const fetch = require('node-fetch');
 
-async function getContributorWallet() {
-  const walletFile = core.getInput('wallet-file');
-  const prBody = github.context.payload.pull_request?.body || '';
-  
-  // Try to extract wallet from PR body
-  const walletMatch = prBody.match(/(?:wallet|rtc)[\s:]*`?([a-zA-Z0-9_]+)`?/i);
-  if (walletMatch) {
-    return walletMatch[1];
+// Wallet label followed by an optional code quote and a base58 address.
+// Tolerates bold markers: **Wallet:**, Wallet:, wallet :
+const WALLET_RE = /wallet\s*\*{0,2}\s*:\s*\*{0,2}\s*`?([1-9A-HJ-NP-Za-km-z]{32,44})`?/i;
+const WALLET_VALID_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+// "(2 RTC)" anywhere in the title or body.
+const AMOUNT_RE = /\(\s*(\d+(?:\.\d+)?)\s*RTC\s*\)/i;
+
+function extractWallet(body) {
+  if (!body) {
+    return null;
   }
-  
-  // Try to get wallet from file in repo
-  try {
-    const response = await fetch(
-      `https://api.github.com/repos/${github.context.repo.owner}/${github.context.repo.repo}/contents/${walletFile}`,
-      {
-        headers: {
-          'Authorization': `token ${process.env.GITHUB_TOKEN}`,
-          'Accept': 'application/vnd.github.v3+json'
-        }
-      }
-    );
-    
-    if (response.ok) {
-      const data = await response.json();
-      const wallet = Buffer.from(data.content, 'base64').toString().trim();
-      if (wallet) return wallet;
-    }
-  } catch (error) {
-    core.info(`Could not read wallet file: ${error.message}`);
+  const match = body.match(WALLET_RE);
+  if (!match) {
+    return null;
   }
-  
-  // Fallback to PR author
-  return github.context.payload.pull_request?.user?.login || 'unknown';
+  const candidate = match[1].trim();
+  return WALLET_VALID_RE.test(candidate) ? candidate : null;
 }
 
-async function awardRTC(contributorWallet, amount, nodeUrl, adminKey, dryRun) {
-  if (dryRun === 'true') {
-    core.info(`DRY RUN: Would award ${amount} RTC to ${contributorWallet}`);
-    return { success: true, message: 'Dry run completed' };
+function extractAmount(title, body, fallbackAmount) {
+  const fromTitle = title && title.match(AMOUNT_RE);
+  if (fromTitle) {
+    return Number(fromTitle[1]);
   }
-  
-  try {
-    const response = await fetch(`${nodeUrl}/admin/transfer`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Admin-Key': adminKey
-      },
-      body: JSON.stringify({
-        from_wallet: core.getInput('wallet-from'),
-        to_wallet: contributorWallet,
-        amount_rtc: parseFloat(amount)
-      })
-    });
-    
-    const result = await response.json();
-    return { success: response.ok, message: result.message || 'Transfer completed' };
-  } catch (error) {
-    return { success: false, message: error.message };
+  const fromBody = body && body.match(AMOUNT_RE);
+  if (fromBody) {
+    return Number(fromBody[1]);
   }
+  return fallbackAmount;
 }
 
-async function main() {
+async function run() {
   try {
-    // Verify this is a merged PR
-    if (!github.context.payload.pull_request?.merged) {
-      core.info('PR not merged, skipping reward');
+    const token = core.getInput('github-token') || process.env.GITHUB_TOKEN || '';
+    const fallbackAmount = Number(core.getInput('default-amount') || '0');
+    const dryRun = String(core.getInput('dry-run') || '').toLowerCase() === 'true';
+
+    const ctx = github.context;
+    const issue = ctx.payload.issue;
+    const issueNumber = (issue && issue.number) || Number(core.getInput('issue-number') || '0');
+
+    if (!issueNumber) {
+      core.setFailed('rtc-reward: no issue number available');
       return;
     }
-    
-    const amount = core.getInput('amount');
-    const nodeUrl = core.getInput('node-url');
-    const adminKey = core.getInput('admin-key');
-    const dryRun = core.getInput('dry-run');
-    
-    const contributorWallet = await getContributorWallet();
-    core.info(`Awarding ${amount} RTC to contributor: ${contributorWallet}`);
-    
-    const result = await awardRTC(contributorWallet, amount, nodeUrl, adminKey, dryRun);
-    
-    if (result.success) {
-      core.info(`Successfully awarded ${amount} RTC to ${contributorWallet}`);
-      await core.setOutput('success', 'true');
-    } else {
-      core.setFailed(`Failed to award RTC: ${result.message}`);
-      await core.setOutput('success', 'false');
+
+    const title = (issue && issue.title) || '';
+    const body = (issue && issue.body) || '';
+
+    const wallet = extractWallet(body);
+    const amount = extractAmount(title, body, fallbackAmount);
+    const valid = Boolean(wallet) && amount > 0;
+
+    core.setOutput('issue-number', String(issueNumber));
+    core.setOutput('wallet', wallet || '');
+    core.setOutput('amount', String(amount));
+    core.setOutput('valid', String(valid));
+
+    if (!wallet) {
+      core.warning('rtc-reward: no valid base58 wallet found in claim #' + issueNumber);
     }
-    
-    // Post comment on PR
-    const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+    if (!(amount > 0)) {
+      core.warning('rtc-reward: no positive RTC amount found in claim #' + issueNumber);
+    }
+
+    if (!token || dryRun || !issue) {
+      core.info('rtc-reward: dry run - outputs exported, no comment posted');
+      return;
+    }
+
+    const octokit = github.getOctokit(token);
+    const repo = ctx.repo;
+
+    let comment;
+    if (valid) {
+      comment =
+        '✅ Claim #' + issueNumber + ' validated by rtc-reward.\n\n' +
+        '- Wallet: `' + wallet + '`\n' +
+        '- Amount: ' + amount + ' RTC\n\n' +
+        'Payout queued by the rewards bot.';
+    } else {
+      comment =
+        '⚠️ Claim #' + issueNumber + ' could not be validated.\n\n' +
+        (wallet ? '' : '- Add a wallet line: Wallet: <your-base58-address>\n') +
+        (amount > 0 ? '' : '- Include the amount in the title, e.g. (2 RTC).\n');
+    }
+
     await octokit.rest.issues.createComment({
-      owner: github.context.repo.owner,
-      repo: github.context.repo.repo,
-      issue_number: github.context.issue.number,
-      body: result.success 
-        ? `✅ **RTC Reward Awarded**\n\n${amount} RTC has been transferred to wallet \`${contributorWallet}\`.\n\nThank you for your contribution! 🌾`
-        : `❌ **RTC Reward Failed**\n\nFailed to transfer ${amount} RTC: ${result.message}`
+      owner: repo.owner,
+      repo: repo.repo,
+      issue_number: issueNumber,
+      body: comment,
     });
-    
-  } catch (error) {
-    core.setFailed(error.message);
+    core.info('rtc-reward: commented on #' + issueNumber + ' (valid=' + valid + ')');
+  } catch (err) {
+    core.setFailed('rtc-reward: ' + (err && err.message ? err.message : String(err)));
   }
 }
 
-main();
+run();

--- a/community/github-actions/rtc-reward/src/wallet.js
+++ b/community/github-actions/rtc-reward/src/wallet.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// RustChain wallets are the literal RTC prefix followed by exactly 40 hex
+// characters. The surrounding character is consumed (but not captured) so a
+// wallet embedded in Markdown such as **Wallet:** `RTC...` is accepted without
+// accepting a longer or unrelated identifier.
+const RTC_WALLET_RE = /(?:^|[^0-9A-Za-z])(RTC[0-9a-fA-F]{40})(?![0-9a-fA-F])/;
+
+function extractRtcWallet(text) {
+  if (typeof text !== 'string') return null;
+  const match = RTC_WALLET_RE.exec(text);
+  return match ? match[1] : null;
+}
+
+module.exports = { extractRtcWallet, RTC_WALLET_RE };

--- a/community/github-actions/rtc-reward/test/wallet.test.js
+++ b/community/github-actions/rtc-reward/test/wallet.test.js
@@ -1,0 +1,48 @@
+const { extractRtcWallet } = require('../src/wallet');
+
+const ISSUE_16327_BODY = `## Claim #696: RustChain Memes (2 RTC)
+
+I created memes about RustChain and posted them on social media.
+
+### Meme 1:
+**Concept:** "When your 2012 Xeon earns more RTC than someone's $5000 cloud server"
+**Format:** Text meme — the punchline is that vintage hardware out-earns modern infrastructure under Proof of Antiquity.
+
+### Meme 2:
+**Concept:** "Proof of Antiquity: the only blockchain that rewards you for NOT upgrading your hardware"
+**Format:** Comparison image — "Other chains: buy the latest GPU → RustChain: keep your old PC running"
+
+### Where Posted:
+- Reddit: r/cryptocurrency and r/rust
+- Hacker News: Posted as a show HN item about Proof of Antiquity
+
+### Links:
+- Reddit post: (link would be provided with actual URL)
+- HN post: (link would be provided with actual URL)
+
+**Wallet:** \`7doPxSPt1pmbHcUcVzK22FVECDhv8kV6nnd2XMKaFiRd\`
+
+---
+Claiming meme bounty #696. Memes posted with honest humor about RustChain's unique consensus design.
+`;
+
+const VALID_RTC_WALLET = `RTC${'a1'.repeat(20)}`;
+
+test('rejects the non-RTC wallet in the exact body of issue #16327', () => {
+  expect(extractRtcWallet(ISSUE_16327_BODY)).toBeNull();
+});
+
+test('accepts an exact RTC wallet in issue #16327 Markdown', () => {
+  const body = ISSUE_16327_BODY.replace(
+    '7doPxSPt1pmbHcUcVzK22FVECDhv8kV6nnd2XMKaFiRd',
+    VALID_RTC_WALLET
+  );
+
+  expect(extractRtcWallet(body)).toBe(VALID_RTC_WALLET);
+});
+
+test('requires exactly 40 hexadecimal characters after RTC', () => {
+  expect(extractRtcWallet(`Wallet: RTC${'a'.repeat(39)}`)).toBeNull();
+  expect(extractRtcWallet(`Wallet: RTC${'a'.repeat(41)}`)).toBeNull();
+  expect(extractRtcWallet(`Wallet: RTC${'g'.repeat(40)}`)).toBeNull();
+});


### PR DESCRIPTION
## Summary

Fixes RTC wallet extraction in both reward-action implementations while preserving the existing payout inputs and transfer flow.

### Behavior

- accepts the canonical wallet format: literal `RTC` plus exactly 40 hexadecimal characters
- accepts that wallet inside normal Markdown wrappers such as `**Wallet:** \`RTC...\``
- rejects shorter, longer, non-hex, and unrelated Base58 identifiers
- keeps custom `wallet-pattern`, dry-run, wallet-file fallback, transfer request, and reward-comment behavior intact

### Regression coverage

The exact body of issue #16327 is included as a regression fixture. Its Base58 value is rejected; replacing it with a canonical Markdown-wrapped RTC wallet is accepted.

### Verification

- Node built-in test suite: 3 passed
- Jest suite: 3 passed
- npm build: passed
- all GitHub checks: passed

This is intentionally a minimal parser correction; it does not attempt to pay the invalid wallet from #16327 and does not change the payout contract.
