### PR TITLE
feat: Python SDK for Agent Economy (RIP-302 Tier 1 Bounty)

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,0 +1,44 @@
+# rustchain-agent
+
+Python SDK for the RustChain Agent Economy (RIP-302).
+
+## Installation
+
+```bash
+pip install rustchain-agent
+```
+
+## Quick Start
+
+```python
+from rustchain_agent import RustChainAgent
+
+agent = RustChainAgent(wallet_address="0xYourWalletAddress")
+
+# Browse open jobs
+jobs = agent.list_jobs(status="open")
+for job in jobs:
+    print(f"{job.title}: {job.reward_rtc} RTC")
+
+# Claim and deliver
+agent.claim_job(job.id)
+agent.deliver_job(job.id, deliverable_url="https://github.com/your/repo", notes="Completed per spec")
+```
+
+## API Coverage
+
+All endpoints from RIP-302 are supported:
+- `post_job()` - Post a job (locks RTC in escrow)
+- `list_jobs()` - Browse open jobs  
+- `get_job()` - Job details + activity log
+- `claim_job()` - Claim an open job
+- `deliver_job()` - Submit deliverable
+- `accept_delivery()` - Accept delivery (releases escrow)
+- `dispute_delivery()` - Reject delivery
+- `cancel_job()` - Cancel + refund escrow
+- `get_reputation()` - Trust score & history
+- `get_stats()` - Marketplace overview
+
+## License
+
+MIT

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,43 +1,90 @@
 # rustchain-agent
 
-Python SDK for the RustChain Agent Economy (RIP-302).
+A small typed Python client for the wallet, payment, and reputation endpoint
+families in the active
+[RIP-302 specification](https://github.com/Scottcjn/Rustchain/blob/cc78890f63655faff8a7e017ef7e673e2789d8a2/rips/docs/RIP-302-agent-economy.md).
+
+The client intentionally does not expose the former `/agent/jobs`,
+`/agent/stats`, or `/agent/reputation/*` marketplace routes. Those routes
+are not part of the current RIP-302 API reference.
 
 ## Installation
 
 ```bash
-pip install rustchain-agent
+python -m pip install -e ./sdks/python
 ```
 
-## Quick Start
+## Identity format
+
+RustChain wallet addresses are validated before any request. They must use the
+canonical `RTC` prefix followed by exactly 40 hexadecimal characters.
 
 ```python
 from rustchain_agent import RustChainAgent
 
-agent = RustChainAgent(wallet_address="0xYourWalletAddress")
-
-# Browse open jobs
-jobs = agent.list_jobs(status="open")
-for job in jobs:
-    print(f"{job.title}: {job.reward_rtc} RTC")
-
-# Claim and deliver
-agent.claim_job(job.id)
-agent.deliver_job(job.id, deliverable_url="https://github.com/your/repo", notes="Completed per spec")
+client = RustChainAgent(
+    agent_id="rafaio1",
+    wallet_address="RTC0123456789abcdef0123456789abcdef01234567",
+    base_url="https://bulbous-bouffant.metalseed.net",
+)
 ```
 
-## API Coverage
+Agent IDs follow RIP-302: 3-64 lowercase alphanumeric or hyphen characters,
+starting with a letter and without consecutive hyphens.
 
-All endpoints from RIP-302 are supported:
-- `post_job()` - Post a job (locks RTC in escrow)
-- `list_jobs()` - Browse open jobs  
-- `get_job()` - Job details + activity log
-- `claim_job()` - Claim an open job
-- `deliver_job()` - Submit deliverable
-- `accept_delivery()` - Accept delivery (releases escrow)
-- `dispute_delivery()` - Reject delivery
-- `cancel_job()` - Cancel + refund escrow
-- `get_reputation()` - Trust score & history
-- `get_stats()` - Marketplace overview
+## Read-only examples
+
+```python
+wallet = client.get_wallet()
+reputation = client.get_reputation()
+leaderboard = client.get_reputation_leaderboard(limit=10)
+payment = client.get_payment("pay_abc123")
+history = client.get_payment_history(limit=25)
+proof = client.get_trust_proof()
+client.close()
+```
+
+## Endpoint coverage
+
+| Method | Endpoint | Client method |
+|---|---|---|
+| POST | `/api/agent/wallet/create` | `create_wallet()` |
+| GET | `/api/agent/wallet/{id}` | `get_wallet()` |
+| POST | `/api/agent/payment/send` | `send_payment()` |
+| POST | `/api/agent/payment/request` | `request_payment()` |
+| GET | `/api/agent/payment/{id}` | `get_payment()` |
+| GET | `/api/agent/payment/history` | `get_payment_history()` |
+| POST | `/api/agent/payment/x402/challenge` | `create_x402_challenge()` |
+| GET | `/api/agent/reputation/{id}` | `get_reputation()` |
+| POST | `/api/agent/reputation/attest` | `submit_attestation()` |
+| GET | `/api/agent/reputation/leaderboard` | `get_reputation_leaderboard()` |
+| GET | `/api/agent/reputation/{id}/proof` | `get_trust_proof()` |
+
+The POST methods are SDK wrappers only. The live verification performed for
+this submission sent no wallet creation, payment, payment request, x402
+challenge, or attestation.
+
+## Tests
+
+The tests assert exact request URLs, query parameters, and JSON payloads. Every
+mutating call is intercepted by `responses`; the unit suite does not contact a
+live node.
+
+```bash
+cd sdks/python
+python -m pytest -q
+```
+
+## Live-node evidence
+
+A sanitized, timestamped GET transcript is versioned at
+[`evidence/live_node_get_20260828.json`](evidence/live_node_get_20260828.json).
+
+At capture time the named node answered `GET /api/stats` with HTTP 200, but
+its advertised feature list did not include RIP-302 and
+`GET /api/agent/reputation/leaderboard?limit=1` returned HTTP 404. This is
+recorded rather than hidden: the client matches the active specification, while
+availability of those routes depends on the server deployment.
 
 ## License
 

--- a/sdks/python/evidence/live_node_get_20260828.json
+++ b/sdks/python/evidence/live_node_get_20260828.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1.0",
+  "captured_at": "2026-08-28T20:02:40Z",
+  "node": "https://bulbous-bouffant.metalseed.net",
+  "safety": {
+    "methods_used": [
+      "GET"
+    ],
+    "mutating_requests_sent": false,
+    "credentials_sent": false
+  },
+  "specification": {
+    "repository": "Scottcjn/Rustchain",
+    "commit": "cc78890f63655faff8a7e017ef7e673e2789d8a2",
+    "path": "rips/docs/RIP-302-agent-economy.md"
+  },
+  "requests": [
+    {
+      "method": "GET",
+      "path": "/api/stats",
+      "status": 200,
+      "content_type": "application/json",
+      "sanitized_response": {
+        "chain_id": "rustchain-mainnet-v2",
+        "epoch": 268,
+        "features": [
+          "RIP-0005",
+          "RIP-0008",
+          "RIP-0009",
+          "RIP-0142",
+          "RIP-0143",
+          "RIP-0144"
+        ],
+        "version": "2.2.1-security-hardened"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/agent/reputation/leaderboard?limit=1",
+      "status": 404,
+      "content_type": "text/html; charset=utf-8",
+      "sanitized_response": {
+        "title": "404 Not Found",
+        "message": "The requested URL was not found on the server."
+      }
+    }
+  ],
+  "interpretation": "The node was reachable and answered a public GET. At capture time it did not advertise RIP-302 and the official reputation route returned 404; the SDK follows the active specification while deployment availability remains server-dependent."
+}

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rustchain-agent"
-version = "0.1.0"
-description = "Python SDK for RustChain Agent Economy (RIP-302)"
+version = "0.2.0"
+description = "Python SDK for RIP-302 wallet, payment, and reputation APIs"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
@@ -14,3 +14,6 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "responses>=0.23"]
+
+[tool.setuptools]
+packages = ["rustchain_agent"]

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rustchain-agent"
+version = "0.1.0"
+description = "Python SDK for RustChain Agent Economy (RIP-302)"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.28.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "responses>=0.23"]

--- a/sdks/python/rustchain_agent/__init__.py
+++ b/sdks/python/rustchain_agent/__init__.py
@@ -1,110 +1,20 @@
-"""RustChain Agent Economy SDK - RIP-302 Bounty Submission"""
-import requests
-from typing import Optional, Dict, Any, List
-from dataclasses import dataclass
+"""Public interface for the RustChain RIP-302 Python SDK."""
 
-BASE_URL = "https://rustchain.org"
+from .client import (
+    BASE_URL,
+    RTC_WALLET_RE,
+    RustChainAgent,
+    RustChainAPIError,
+    validate_agent_id,
+    validate_wallet_address,
+)
 
-@dataclass
-class Job:
-    id: str
-    poster: str
-    title: str
-    description: str
-    reward_rtc: int
-    status: str
-    created_at: str
-    
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Job":
-        return cls(
-            id=data.get("id", ""),
-            poster=data.get("poster", ""),
-            title=data.get("title", ""),
-            description=data.get("description", ""),
-            reward_rtc=data.get("reward_rtc", 0),
-            status=data.get("status", ""),
-            created_at=data.get("created_at", "")
-        )
-
-class RustChainAgent:
-    """Client for RustChain Agent Economy API."""
-    
-    def __init__(self, wallet_address: str, api_key: Optional[str] = None, base_url: str = BASE_URL):
-        self.wallet_address = wallet_address
-        self.base_url = base_url.rstrip("/")
-        self.session = requests.Session()
-        if api_key:
-            self.session.headers["Authorization"] = f"Bearer {api_key}"
-        self.session.headers["X-Wallet-Address"] = wallet_address
-    
-    def post_job(self, title: str, description: str, reward_rtc: int) -> Job:
-        """Post a new job (locks RTC in escrow)."""
-        resp = self.session.post(f"{self.base_url}/agent/jobs", json={
-            "title": title,
-            "description": description,
-            "reward_rtc": reward_rtc
-        })
-        resp.raise_for_status()
-        return Job.from_dict(resp.json())
-    
-    def list_jobs(self, status: Optional[str] = None) -> List[Job]:
-        """Browse open jobs."""
-        params = {"status": status} if status else {}
-        resp = self.session.get(f"{self.base_url}/agent/jobs", params=params)
-        resp.raise_for_status()
-        return [Job.from_dict(j) for j in resp.json().get("jobs", [])]
-    
-    def get_job(self, job_id: str) -> Job:
-        """Get job details + activity log."""
-        resp = self.session.get(f"{self.base_url}/agent/jobs/{job_id}")
-        resp.raise_for_status()
-        return Job.from_dict(resp.json())
-    
-    def claim_job(self, job_id: str) -> Dict[str, Any]:
-        """Claim an open job."""
-        resp = self.session.post(f"{self.base_url}/agent/jobs/{job_id}/claim")
-        resp.raise_for_status()
-        return resp.json()
-    
-    def deliver_job(self, job_id: str, deliverable_url: str, notes: str = "") -> Dict[str, Any]:
-        """Submit deliverable for claimed job."""
-        resp = self.session.post(f"{self.base_url}/agent/jobs/{job_id}/deliver", json={
-            "deliverable_url": deliverable_url,
-            "notes": notes
-        })
-        resp.raise_for_status()
-        return resp.json()
-    
-    def accept_delivery(self, job_id: str) -> Dict[str, Any]:
-        """Accept delivery (releases escrow to worker)."""
-        resp = self.session.post(f"{self.base_url}/agent/jobs/{job_id}/accept")
-        resp.raise_for_status()
-        return resp.json()
-    
-    def dispute_delivery(self, job_id: str, reason: str) -> Dict[str, Any]:
-        """Reject delivery and initiate dispute."""
-        resp = self.session.post(f"{self.base_url}/agent/jobs/{job_id}/dispute", json={
-            "reason": reason
-        })
-        resp.raise_for_status()
-        return resp.json()
-    
-    def cancel_job(self, job_id: str) -> Dict[str, Any]:
-        """Cancel job and refund escrow."""
-        resp = self.session.post(f"{self.base_url}/agent/jobs/{job_id}/cancel")
-        resp.raise_for_status()
-        return resp.json()
-    
-    def get_reputation(self, wallet_address: Optional[str] = None) -> Dict[str, Any]:
-        """Get trust score & history for a wallet."""
-        addr = wallet_address or self.wallet_address
-        resp = self.session.get(f"{self.base_url}/agent/reputation/{addr}")
-        resp.raise_for_status()
-        return resp.json()
-    
-    def get_stats(self) -> Dict[str, Any]:
-        """Get marketplace overview statistics."""
-        resp = self.session.get(f"{self.base_url}/agent/stats")
-        resp.raise_for_status()
-        return resp.json()
+__version__ = "0.2.0"
+__all__ = [
+    "BASE_URL",
+    "RTC_WALLET_RE",
+    "RustChainAPIError",
+    "RustChainAgent",
+    "validate_agent_id",
+    "validate_wallet_address",
+]

--- a/sdks/python/rustchain_agent/__init__.py
+++ b/sdks/python/rustchain_agent/__init__.py
@@ -1,0 +1,110 @@
+"""RustChain Agent Economy SDK - RIP-302 Bounty Submission"""
+import requests
+from typing import Optional, Dict, Any, List
+from dataclasses import dataclass
+
+BASE_URL = "https://rustchain.org"
+
+@dataclass
+class Job:
+    id: str
+    poster: str
+    title: str
+    description: str
+    reward_rtc: int
+    status: str
+    created_at: str
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Job":
+        return cls(
+            id=data.get("id", ""),
+            poster=data.get("poster", ""),
+            title=data.get("title", ""),
+            description=data.get("description", ""),
+            reward_rtc=data.get("reward_rtc", 0),
+            status=data.get("status", ""),
+            created_at=data.get("created_at", "")
+        )
+
+class RustChainAgent:
+    """Client for RustChain Agent Economy API."""
+    
+    def __init__(self, wallet_address: str, api_key: Optional[str] = None, base_url: str = BASE_URL):
+        self.wallet_address = wallet_address
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+        if api_key:
+            self.session.headers["Authorization"] = f"Bearer {api_key}"
+        self.session.headers["X-Wallet-Address"] = wallet_address
+    
+    def post_job(self, title: str, description: str, reward_rtc: int) -> Job:
+        """Post a new job (locks RTC in escrow)."""
+        resp = self.session.post(f"{self.base_url}/agent/jobs", json={
+            "title": title,
+            "description": description,
+            "reward_rtc": reward_rtc
+        })
+        resp.raise_for_status()
+        return Job.from_dict(resp.json())
+    
+    def list_jobs(self, status: Optional[str] = None) -> List[Job]:
+        """Browse open jobs."""
+        params = {"status": status} if status else {}
+        resp = self.session.get(f"{self.base_url}/agent/jobs", params=params)
+        resp.raise_for_status()
+        return [Job.from_dict(j) for j in resp.json().get("jobs", [])]
+    
+    def get_job(self, job_id: str) -> Job:
+        """Get job details + activity log."""
+        resp = self.session.get(f"{self.base_url}/agent/jobs/{job_id}")
+        resp.raise_for_status()
+        return Job.from_dict(resp.json())
+    
+    def claim_job(self, job_id: str) -> Dict[str, Any]:
+        """Claim an open job."""
+        resp = self.session.post(f"{self.base_url}/agent/jobs/{job_id}/claim")
+        resp.raise_for_status()
+        return resp.json()
+    
+    def deliver_job(self, job_id: str, deliverable_url: str, notes: str = "") -> Dict[str, Any]:
+        """Submit deliverable for claimed job."""
+        resp = self.session.post(f"{self.base_url}/agent/jobs/{job_id}/deliver", json={
+            "deliverable_url": deliverable_url,
+            "notes": notes
+        })
+        resp.raise_for_status()
+        return resp.json()
+    
+    def accept_delivery(self, job_id: str) -> Dict[str, Any]:
+        """Accept delivery (releases escrow to worker)."""
+        resp = self.session.post(f"{self.base_url}/agent/jobs/{job_id}/accept")
+        resp.raise_for_status()
+        return resp.json()
+    
+    def dispute_delivery(self, job_id: str, reason: str) -> Dict[str, Any]:
+        """Reject delivery and initiate dispute."""
+        resp = self.session.post(f"{self.base_url}/agent/jobs/{job_id}/dispute", json={
+            "reason": reason
+        })
+        resp.raise_for_status()
+        return resp.json()
+    
+    def cancel_job(self, job_id: str) -> Dict[str, Any]:
+        """Cancel job and refund escrow."""
+        resp = self.session.post(f"{self.base_url}/agent/jobs/{job_id}/cancel")
+        resp.raise_for_status()
+        return resp.json()
+    
+    def get_reputation(self, wallet_address: Optional[str] = None) -> Dict[str, Any]:
+        """Get trust score & history for a wallet."""
+        addr = wallet_address or self.wallet_address
+        resp = self.session.get(f"{self.base_url}/agent/reputation/{addr}")
+        resp.raise_for_status()
+        return resp.json()
+    
+    def get_stats(self) -> Dict[str, Any]:
+        """Get marketplace overview statistics."""
+        resp = self.session.get(f"{self.base_url}/agent/stats")
+        resp.raise_for_status()
+        return resp.json()

--- a/sdks/python/rustchain_agent/client.py
+++ b/sdks/python/rustchain_agent/client.py
@@ -1,0 +1,350 @@
+"""Typed client for the RIP-302 wallet, payment, and reputation APIs."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+from urllib.parse import quote, urlsplit
+from uuid import uuid4
+
+import requests
+
+BASE_URL = "https://rustchain.org"
+RTC_WALLET_RE = re.compile(r"^RTC[0-9A-Fa-f]{40}$")
+AGENT_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+
+
+class RustChainAPIError(RuntimeError):
+    """Raised when a RustChain endpoint returns an invalid or failed response."""
+
+    def __init__(self, message: str, *, status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def validate_wallet_address(wallet_address: str) -> str:
+    """Validate the canonical RustChain address format required by the maintainer."""
+
+    if not isinstance(wallet_address, str) or not RTC_WALLET_RE.fullmatch(
+        wallet_address
+    ):
+        raise ValueError(
+            "wallet_address must be RTC followed by exactly 40 hex characters"
+        )
+    return wallet_address
+
+
+def validate_agent_id(agent_id: str) -> str:
+    """Validate the RIP-302 3-64 character lowercase agent identifier."""
+
+    if (
+        not isinstance(agent_id, str)
+        or not 3 <= len(agent_id) <= 64
+        or not AGENT_ID_RE.fullmatch(agent_id)
+    ):
+        raise ValueError(
+            "agent_id must be 3-64 lowercase alphanumeric/hyphen characters, "
+            "start with a letter, and contain no consecutive hyphens"
+        )
+    return agent_id
+
+
+def _required_text(value: str, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _positive_amount(value: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("amount must be a finite positive number")
+    amount = float(value)
+    if not math.isfinite(amount) or amount <= 0:
+        raise ValueError("amount must be a finite positive number")
+    return amount
+
+
+def _limit(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= 1000:
+        raise ValueError("limit must be an integer between 1 and 1000")
+    return value
+
+
+class RustChainAgent:
+    """Client for the official RIP-302 endpoint families.
+
+    The client implements only the wallet, payment, and reputation routes listed
+    by RIP-302. Mutating methods are ordinary SDK wrappers; unit tests mock every
+    request, and the checked-in live evidence uses GET requests only.
+    """
+
+    def __init__(
+        self,
+        *,
+        agent_id: str,
+        wallet_address: str,
+        api_key: Optional[str] = None,
+        base_url: str = BASE_URL,
+        timeout: float = 30.0,
+        session: Optional[requests.Session] = None,
+    ):
+        self.agent_id = validate_agent_id(agent_id)
+        self.wallet_address = validate_wallet_address(wallet_address)
+        parsed = urlsplit(base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("base_url must be an absolute HTTP(S) URL")
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+
+        self.base_url = base_url.rstrip("/")
+        self.timeout = float(timeout)
+        self.session = session or requests.Session()
+        self.session.headers.update(
+            {
+                "Accept": "application/json",
+                "User-Agent": "rustchain-agent/0.2.0 (RIP-302)",
+            }
+        )
+        if api_key:
+            self.session.headers["X-API-Key"] = api_key
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_payload: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        try:
+            response = self.session.request(
+                method,
+                url,
+                params=params,
+                json=json_payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            status_code = getattr(getattr(exc, "response", None), "status_code", None)
+            raise RustChainAPIError(
+                f"{method.upper()} {endpoint} failed",
+                status_code=status_code,
+            ) from exc
+
+        try:
+            payload = response.json()
+        except json.JSONDecodeError as exc:
+            raise RustChainAPIError(
+                f"{method.upper()} {endpoint} returned non-JSON data",
+                status_code=response.status_code,
+            ) from exc
+        if not isinstance(payload, dict):
+            raise RustChainAPIError(
+                f"{method.upper()} {endpoint} returned a non-object JSON payload",
+                status_code=response.status_code,
+            )
+        return payload
+
+    @staticmethod
+    def _segment(value: str, field: str) -> str:
+        return quote(_required_text(value, field), safe="")
+
+    # Wallet endpoints -----------------------------------------------------
+
+    def create_wallet(
+        self,
+        *,
+        name: Optional[str] = None,
+        base_address: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "agent_id": self.agent_id,
+            "wallet_address": self.wallet_address,
+            "name": name or self.agent_id,
+        }
+        if base_address is not None:
+            payload["base_address"] = _required_text(base_address, "base_address")
+        return self._request(
+            "POST",
+            "/api/agent/wallet/create",
+            json_payload=payload,
+        )
+
+    def get_wallet(self, agent_id: Optional[str] = None) -> Dict[str, Any]:
+        target = validate_agent_id(agent_id or self.agent_id)
+        return self._request(
+            "GET",
+            f"/api/agent/wallet/{self._segment(target, 'agent_id')}",
+        )
+
+    # Payment endpoints ----------------------------------------------------
+
+    def send_payment(
+        self,
+        *,
+        to_agent: str,
+        amount: float,
+        memo: Optional[str] = None,
+        resource: Optional[str] = None,
+        payment_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        recipient = validate_agent_id(to_agent)
+        if recipient == self.agent_id:
+            raise ValueError("to_agent must be different from agent_id")
+        pid = payment_id or f"pay_{uuid4().hex[:16]}"
+        payload: Dict[str, Any] = {
+            "payment_id": _required_text(pid, "payment_id"),
+            "from_agent": self.agent_id,
+            "to_agent": recipient,
+            "amount": _positive_amount(amount),
+        }
+        if memo is not None:
+            payload["memo"] = memo
+        if resource is not None:
+            payload["resource"] = _required_text(resource, "resource")
+        return self._request(
+            "POST",
+            "/api/agent/payment/send",
+            json_payload=payload,
+        )
+
+    def request_payment(
+        self,
+        *,
+        from_agent: str,
+        amount: float,
+        description: str,
+        resource: Optional[str] = None,
+        intent_id: Optional[str] = None,
+        expires_at: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payer = validate_agent_id(from_agent)
+        iid = intent_id or f"intent_{uuid4().hex[:12]}"
+        expiry = (
+            expires_at
+            or (datetime.now(timezone.utc) + timedelta(minutes=15)).isoformat()
+        )
+        payload = {
+            "intent_id": _required_text(iid, "intent_id"),
+            "from_agent": payer,
+            "to_agent": self.agent_id,
+            "amount": _positive_amount(amount),
+            "description": _required_text(description, "description"),
+            "resource": resource or f"/api/agent/payment/{iid}",
+            "expires_at": _required_text(expiry, "expires_at"),
+        }
+        return self._request(
+            "POST",
+            "/api/agent/payment/request",
+            json_payload=payload,
+        )
+
+    def get_payment(self, payment_id: str) -> Dict[str, Any]:
+        return self._request(
+            "GET",
+            f"/api/agent/payment/{self._segment(payment_id, 'payment_id')}",
+        )
+
+    def get_payment_history(
+        self,
+        *,
+        limit: int = 50,
+        status: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"limit": _limit(limit)}
+        if status is not None:
+            params["status"] = _required_text(status, "status")
+        return self._request("GET", "/api/agent/payment/history", params=params)
+
+    def create_x402_challenge(
+        self,
+        *,
+        resource: str,
+        required_amount: float,
+    ) -> Dict[str, Any]:
+        return self._request(
+            "POST",
+            "/api/agent/payment/x402/challenge",
+            json_payload={
+                "resource": _required_text(resource, "resource"),
+                "amount": _positive_amount(required_amount),
+                "recipient": self.agent_id,
+            },
+        )
+
+    # Reputation endpoints -------------------------------------------------
+
+    def get_reputation(self, agent_id: Optional[str] = None) -> Dict[str, Any]:
+        target = validate_agent_id(agent_id or self.agent_id)
+        return self._request(
+            "GET",
+            f"/api/agent/reputation/{self._segment(target, 'agent_id')}",
+        )
+
+    def submit_attestation(
+        self,
+        *,
+        to_agent: str,
+        rating: int,
+        comment: Optional[str] = None,
+        transaction_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if (
+            isinstance(rating, bool)
+            or not isinstance(rating, int)
+            or not 1 <= rating <= 5
+        ):
+            raise ValueError("rating must be an integer between 1 and 5")
+        payload: Dict[str, Any] = {
+            "from_agent": self.agent_id,
+            "to_agent": validate_agent_id(to_agent),
+            "rating": rating,
+        }
+        if comment is not None:
+            payload["comment"] = comment
+        if transaction_id is not None:
+            payload["transaction_id"] = _required_text(
+                transaction_id,
+                "transaction_id",
+            )
+        return self._request(
+            "POST",
+            "/api/agent/reputation/attest",
+            json_payload=payload,
+        )
+
+    def get_reputation_leaderboard(
+        self,
+        *,
+        limit: int = 100,
+        tier: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"limit": _limit(limit)}
+        if tier is not None:
+            params["tier"] = _required_text(tier, "tier")
+        return self._request(
+            "GET",
+            "/api/agent/reputation/leaderboard",
+            params=params,
+        )
+
+    def get_trust_proof(self, agent_id: Optional[str] = None) -> Dict[str, Any]:
+        target = validate_agent_id(agent_id or self.agent_id)
+        return self._request(
+            "GET",
+            f"/api/agent/reputation/{self._segment(target, 'agent_id')}/proof",
+        )
+
+    def close(self) -> None:
+        self.session.close()
+
+    def __enter__(self) -> "RustChainAgent":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()

--- a/sdks/python/tests/test_sdk.py
+++ b/sdks/python/tests/test_sdk.py
@@ -1,37 +1,249 @@
-"""Tests for rustchain_agent SDK."""
+"""Deterministic contract tests for the RIP-302 Python SDK."""
+
+import json
+from urllib.parse import parse_qs, urlsplit
+
 import pytest
 import responses
-from rustchain_agent import RustChainAgent, Job
+from rustchain_agent import RustChainAgent, RustChainAPIError
 
-BASE_URL = "https://rustchain.org"
+BASE_URL = "https://example.test"
+WALLET = "RTC0123456789abcdef0123456789abcdef01234567"
+
 
 @pytest.fixture
 def agent():
-    return RustChainAgent(wallet_address="0xTestWallet123")
+    return RustChainAgent(
+        agent_id="rafaio1",
+        wallet_address=WALLET,
+        base_url=BASE_URL,
+        timeout=5,
+    )
+
+
+def request_json(call):
+    return json.loads(call.request.body.decode("utf-8"))
+
+
+def test_wallet_and_agent_validation():
+    RustChainAgent(agent_id="valid-agent", wallet_address=WALLET)
+
+    with pytest.raises(ValueError, match="RTC"):
+        RustChainAgent(agent_id="valid-agent", wallet_address="0x1234")
+    with pytest.raises(ValueError, match="40 hex"):
+        RustChainAgent(agent_id="valid-agent", wallet_address="RTC1234")
+    with pytest.raises(ValueError, match="agent_id"):
+        RustChainAgent(agent_id="Invalid--Agent", wallet_address=WALLET)
+
 
 @responses.activate
-def test_list_jobs(agent):
+def test_wallet_endpoints_have_exact_urls_and_payload(agent):
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/agent/wallet/create",
+        json={"wallet_address": WALLET},
+        status=200,
+    )
     responses.add(
         responses.GET,
-        f"{BASE_URL}/agent/jobs",
-        json={"jobs": [{"id": "j1", "poster": "0xABC", "title": "Test Job", 
-                        "description": "Desc", "reward_rtc": 50, 
-                        "status": "open", "created_at": "2026-03-06T00:00:00Z"}]},
-        status=200
+        f"{BASE_URL}/api/agent/wallet/worker-agent",
+        json={"agent_id": "worker-agent", "wallet_address": WALLET},
+        status=200,
     )
-    jobs = agent.list_jobs()
-    assert len(jobs) == 1
-    assert jobs[0].id == "j1"
-    assert jobs[0].reward_rtc == 50
 
-@responses.activate  
-def test_claim_job(agent):
-    responses.add(responses.POST, f"{BASE_URL}/agent/jobs/j1/claim", json={"status": "claimed"}, status=200)
-    result = agent.claim_job("j1")
-    assert result["status"] == "claimed"
+    agent.create_wallet(name="Rafaio Agent")
+    agent.get_wallet("worker-agent")
+
+    assert responses.calls[0].request.url == f"{BASE_URL}/api/agent/wallet/create"
+    assert request_json(responses.calls[0]) == {
+        "agent_id": "rafaio1",
+        "wallet_address": WALLET,
+        "name": "Rafaio Agent",
+    }
+    assert responses.calls[1].request.url == (
+        f"{BASE_URL}/api/agent/wallet/worker-agent"
+    )
+
 
 @responses.activate
-def test_deliver_job(agent):
-    responses.add(responses.POST, f"{BASE_URL}/agent/jobs/j1/deliver", json={"status": "delivered"}, status=200)
-    result = agent.deliver_job("j1", "https://example.com/deliverable", "Done")
-    assert result["status"] == "delivered"
+def test_send_payment_uses_rip302_path_and_payload(agent):
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/agent/payment/send",
+        json={"status": "pending", "payment_id": "pay_test"},
+        status=200,
+    )
+
+    agent.send_payment(
+        to_agent="service-agent",
+        amount=1.25,
+        memo="test payment",
+        resource="/api/premium/data",
+        payment_id="pay_test",
+    )
+
+    assert responses.calls[0].request.url == f"{BASE_URL}/api/agent/payment/send"
+    assert request_json(responses.calls[0]) == {
+        "payment_id": "pay_test",
+        "from_agent": "rafaio1",
+        "to_agent": "service-agent",
+        "amount": 1.25,
+        "memo": "test payment",
+        "resource": "/api/premium/data",
+    }
+
+
+@responses.activate
+def test_request_payment_uses_deterministic_payload(agent):
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/agent/payment/request",
+        json={"status": "pending", "intent_id": "intent_test"},
+        status=200,
+    )
+
+    agent.request_payment(
+        from_agent="payer-agent",
+        amount=0.5,
+        description="analysis",
+        intent_id="intent_test",
+        expires_at="2026-08-28T20:30:00+00:00",
+    )
+
+    assert request_json(responses.calls[0]) == {
+        "intent_id": "intent_test",
+        "from_agent": "payer-agent",
+        "to_agent": "rafaio1",
+        "amount": 0.5,
+        "description": "analysis",
+        "resource": "/api/agent/payment/intent_test",
+        "expires_at": "2026-08-28T20:30:00+00:00",
+    }
+
+
+@responses.activate
+def test_payment_get_and_history_use_spec_paths(agent):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/agent/payment/pay_123",
+        json={"payment_id": "pay_123"},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/agent/payment/history",
+        json={"payments": []},
+        status=200,
+    )
+
+    agent.get_payment("pay_123")
+    agent.get_payment_history(limit=7, status="completed")
+
+    assert responses.calls[0].request.url == (f"{BASE_URL}/api/agent/payment/pay_123")
+    history_url = urlsplit(responses.calls[1].request.url)
+    assert history_url.path == "/api/agent/payment/history"
+    assert parse_qs(history_url.query) == {
+        "limit": ["7"],
+        "status": ["completed"],
+    }
+
+
+@responses.activate
+def test_x402_challenge_uses_spec_payload(agent):
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/agent/payment/x402/challenge",
+        json={"nonce": "abc"},
+        status=200,
+    )
+
+    agent.create_x402_challenge(
+        resource="/api/premium/data",
+        required_amount=2,
+    )
+
+    assert request_json(responses.calls[0]) == {
+        "resource": "/api/premium/data",
+        "amount": 2.0,
+        "recipient": "rafaio1",
+    }
+
+
+@responses.activate
+def test_reputation_read_endpoints_are_exact(agent):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/agent/reputation/service-agent",
+        json={"score": 80},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/agent/reputation/leaderboard",
+        json={"leaders": []},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/agent/reputation/service-agent/proof",
+        json={"proof": "test"},
+        status=200,
+    )
+
+    agent.get_reputation("service-agent")
+    agent.get_reputation_leaderboard(limit=10, tier="trusted")
+    agent.get_trust_proof("service-agent")
+
+    assert urlsplit(responses.calls[0].request.url).path == (
+        "/api/agent/reputation/service-agent"
+    )
+    leaderboard = urlsplit(responses.calls[1].request.url)
+    assert leaderboard.path == "/api/agent/reputation/leaderboard"
+    assert parse_qs(leaderboard.query) == {
+        "limit": ["10"],
+        "tier": ["trusted"],
+    }
+    assert urlsplit(responses.calls[2].request.url).path == (
+        "/api/agent/reputation/service-agent/proof"
+    )
+
+
+@responses.activate
+def test_attestation_payload_is_deterministic(agent):
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/agent/reputation/attest",
+        json={"attestation_id": "att_1"},
+        status=200,
+    )
+
+    agent.submit_attestation(
+        to_agent="service-agent",
+        rating=5,
+        comment="reliable",
+        transaction_id="tx_1",
+    )
+
+    assert request_json(responses.calls[0]) == {
+        "from_agent": "rafaio1",
+        "to_agent": "service-agent",
+        "rating": 5,
+        "comment": "reliable",
+        "transaction_id": "tx_1",
+    }
+
+
+@responses.activate
+def test_http_errors_include_status_without_response_body(agent):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/agent/reputation/rafaio1",
+        json={"error": "not found", "internal": "must not leak"},
+        status=404,
+    )
+
+    with pytest.raises(RustChainAPIError) as exc_info:
+        agent.get_reputation()
+
+    assert exc_info.value.status_code == 404
+    assert str(exc_info.value) == ("GET /api/agent/reputation/rafaio1 failed")

--- a/sdks/python/tests/test_sdk.py
+++ b/sdks/python/tests/test_sdk.py
@@ -1,0 +1,37 @@
+"""Tests for rustchain_agent SDK."""
+import pytest
+import responses
+from rustchain_agent import RustChainAgent, Job
+
+BASE_URL = "https://rustchain.org"
+
+@pytest.fixture
+def agent():
+    return RustChainAgent(wallet_address="0xTestWallet123")
+
+@responses.activate
+def test_list_jobs(agent):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/agent/jobs",
+        json={"jobs": [{"id": "j1", "poster": "0xABC", "title": "Test Job", 
+                        "description": "Desc", "reward_rtc": 50, 
+                        "status": "open", "created_at": "2026-03-06T00:00:00Z"}]},
+        status=200
+    )
+    jobs = agent.list_jobs()
+    assert len(jobs) == 1
+    assert jobs[0].id == "j1"
+    assert jobs[0].reward_rtc == 50
+
+@responses.activate  
+def test_claim_job(agent):
+    responses.add(responses.POST, f"{BASE_URL}/agent/jobs/j1/claim", json={"status": "claimed"}, status=200)
+    result = agent.claim_job("j1")
+    assert result["status"] == "claimed"
+
+@responses.activate
+def test_deliver_job(agent):
+    responses.add(responses.POST, f"{BASE_URL}/agent/jobs/j1/deliver", json={"status": "delivered"}, status=200)
+    result = agent.deliver_job("j1", "https://example.com/deliverable", "Done")
+    assert result["status"] == "delivered"


### PR DESCRIPTION
## Summary

Typed Python client for the current RIP-302 wallet, payment, and reputation API surface.

### Coverage

- 11 endpoints under `/api/agent/wallet/*`, `/api/agent/payment/*`, and `/api/agent/reputation/*`
- strict RustChain wallet validation: `RTC` followed by exactly 40 hexadecimal characters
- exact URL, query-parameter, and JSON-payload tests
- HTTP error handling through `RustChainAPIError`

The obsolete `/agent/jobs`, `/agent/stats`, and `/agent/reputation/*` marketplace wrappers were removed.

### Verification

- `python -m pytest -q`: 9 passed
- Ruff lint and formatting checks passed
- wheel build and `pip check` passed
- all GitHub checks passed

### Safe live-node evidence

`sdks/python/evidence/live_node_get_20260828.json` records sanitized, read-only requests to `https://bulbous-bouffant.metalseed.net`:

- `GET /api/stats` returned HTTP 200
- `GET /api/agent/reputation/leaderboard?limit=1` returned HTTP 404 and the node did not advertise RIP-302 at capture time

No wallet creation, payment, payment request, x402 challenge, attestation, credential, or other POST was sent. The SDK follows the current RIP-302 specification; the transcript makes the node deployment mismatch explicit instead of hiding it.

### Usage

```python
from rustchain_agent import RustChainAgent

client = RustChainAgent(
    agent_id="rafaio1",
    wallet_address="RTC0123456789abcdef0123456789abcdef01234567",
    base_url="https://bulbous-bouffant.metalseed.net",
)

leaderboard = client.get_reputation_leaderboard(limit=10)
```

Addresses the Python SDK item in #683 (Tier 1, 50 RTC).
