### PR TITLE
fix(claim-form): ask for an RTC address, not a wallet "name"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty-proof.yml
+++ b/.github/ISSUE_TEMPLATE/bounty-proof.yml
@@ -59,11 +59,37 @@ body:
   - type: input
     id: rtc_wallet
     attributes:
-      label: RTC wallet name
-      description: Use a RustChain wallet name, not a SOL, ETH, Base, or Ergo address.
-      placeholder: my-wallet-name
+      label: RTC payout address
+      description: |
+        An RTC address: the letters `RTC` followed by 40 hex characters.
+        NOT your GitHub handle, and NOT a SOL / ETH / Base / Ergo address — a `0x...`
+        address cannot be paid here and the claim will stall at the last step.
+
+        Do not have one? It takes about two minutes:
+
+            git clone https://github.com/Scottcjn/Rustchain
+            cd Rustchain/rustchain-wallet && cargo install --path .
+            rtc-wallet create --name my-wallet
+
+        That prints your `RTC...` address. The address is public and safe to post here.
+        Your private key and seed phrase are not, and nobody from this project will
+        ever ask you for either.
+      placeholder: RTC0123456789abcdef0123456789abcdef01234567
     validations:
       required: true
+
+  - type: input
+    id: fallback_handle
+    attributes:
+      label: "Fallback: credit a bare name instead (not recommended)"
+      description: |
+        Leave this empty unless you genuinely cannot generate an address yet.
+
+        We can credit a bare name, but that balance has **no keypair behind it**, so
+        you cannot sign a transfer out of it. It will show as paid while being
+        unspendable until you supply a real address and we migrate it by hand.
+        Supplying an address above is strictly better for you.
+      placeholder: leave blank if you gave an RTC address above
 
   - type: input
     id: platform_identity
@@ -101,7 +127,15 @@ body:
       options:
         - label: I am not using a product repo issue for this claim.
           required: true
-        - label: I provided an RTC wallet name, not an external chain address.
+        - label: My payout field is an RTC address (`RTC` + 40 hex), or I deliberately used the fallback and accept that the balance cannot be spent until migrated.
           required: true
         - label: I understand payout is reviewed manually and may be partial or rejected if the proof is weak, duplicated, or out of scope.
           required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **Blocked by `403 Resource not accessible by integration`?** That is a token-scope
+        limit on your integration, not on our side. Email the submission to
+        `sophia.eagent@gmail.com` and we will file it on GitHub in your name, with credit.


### PR DESCRIPTION
## The bug

`bounty-proof.yml` asked for:

```yaml
label: RTC wallet name
description: Use a RustChain wallet name, not a SOL, ETH, Base, or Ergo address.
placeholder: my-wallet-name
```

with a **required** checkbox reading *"I provided an RTC wallet name, not an external chain address."*

Contributors did exactly that. Five of the seven most recent claimants submitted a GitHub handle rather than an address:

| claimant | submitted | RTC held up |
|---|---|---|
| meteop | `meteop-x` | 15 |
| martinextrabox-netizen | `martinextrabox-netizen` | 8 |
| 8hatay9-commits | `8hatay9-commits` | 3 |
| robin1121 | `robin1121` | 10 |
| AInoAKARI | *(registered identity, address not locatable)* | 44 |

**80 RTC of verified, accepted work is currently unpayable** — not because the work was in doubt, but because the form asked for the wrong thing and everyone complied.

## Why a bare name is not harmless

A name **is** creditable — `scripts/bounty_payout.py` has a `HANDLE_RE` alongside `WALLET_RE`. But the resulting balance has **no keypair behind it**, so the recipient cannot sign a transfer out. It reads as paid while being unspendable.

That is not theoretical: `~/payouts/pay_yyswhsccc_305.sh` exists right now to *"migrate handle-credited balance to supplied address"* for a contributor who hit this. **The form has been generating the stranded balances that the migration script exists to unwind.**

## The change

- `rtc_wallet` now asks for an **RTC address** (`RTC` + 40 hex), with the `rtc-wallet create` command inline so nobody has to go looking, and an explicit note that the address is public but the seed phrase is never requested by us.
- Added a separate, clearly-labelled **fallback** field for a bare name — kept, because `HANDLE_RE` supports it and sometimes it is the only option, but it now states plainly that the balance cannot be spent until migrated by hand.
- The required checkbox no longer instructs people to supply a name.
- Added a footer explaining the `403 Resource not accessible by integration` email fallback, since several contributors hit that and had no documented route.

## Note

This is the same defect shape as the `bounty-spec` `submit: [pr, email]` issue fixed on 2026-08-20: a structured instruction that contradicts what the system actually needs, where the contributors who follow it most carefully are the ones it penalises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)