### PR TITLE
fix(verify): correct three STAR_REPOS names that 404

### DIFF
--- a/scripts/verify_bounties.py
+++ b/scripts/verify_bounties.py
@@ -58,13 +58,14 @@ STAR_REPOS = [
     "beacon-skill",
     "grazer-skill",
     "ram-coffers",
-    "llama-power8",
-    "elyan-site",
+    "llama-cpp-power8",   # was "llama-power8" (404: repo is named llama-cpp-power8)
     "rust-ppc-tiger",
     "rustchain-mcp",
     "shaprai",
-    "beacon-rs",
+    "beacon-skill-rs",    # was "beacon-rs" (404: repo is named beacon-skill-rs)
     "trashclaw",
+    # "elyan-site" removed: the site repos (elyan-labs-site, elyanlabs-ai-site) are private
+    # and cannot be starred, so a sweep over them can never succeed.
 ]
 
 # Issue numbers by bounty type


### PR DESCRIPTION
Probed every entry of `STAR_REPOS` against the API: `llama-power8`, `elyan-site`, `beacon-rs` return 404 for every token (repos are `llama-cpp-power8`, private site repos, `beacon-skill-rs`). Since #16515 made the sweep fail closed, one wrong name skips all star bounties. Fixed the two names, dropped the unstarable private one.