### PR TITLE
fix(verify): point issue lists at the OPEN star/badge bounties

### DIFF
--- a/scripts/verify_bounties.py
+++ b/scripts/verify_bounties.py
@@ -69,10 +69,13 @@ STAR_REPOS = [
 ]
 
 # Issue numbers by bounty type
-STAR_BOUNTY_ISSUES = [2175, 47, 773, 1595]
-BADGE_BOUNTY_ISSUES = [2177]
-FOLLOW_BOUNTY_ISSUES = [2173, 2155]
-EMOJI_BOUNTY_ISSUES = [1611, 2180]
+# Only OPEN bounty issues belong here: the phases skip closed issues, so a list of
+# closed numbers makes the sweep succeed while checking nobody (2026-08-28: all four
+# star entries had been closed for months while claims piled up on the live ones).
+STAR_BOUNTY_ISSUES = [16238, 9017, 165, 171, 378]   # star 3 repos / May Flowers / ClawHub / pick-one / BoTTube
+BADGE_BOUNTY_ISSUES = [13949]                        # RustChain badge in any README
+FOLLOW_BOUNTY_ISSUES = [2155]                        # (2173 closed)
+EMOJI_BOUNTY_ISSUES = [2180]                         # (1611 closed)
 
 # Bot signature so we can detect our own comments and avoid duplicates
 BOT_SIGNATURE = "<!-- bounty-verify-bot -->"


### PR DESCRIPTION
Follow-up to #16653/#16655. The sweep is green now (876 stargazers / 12 repos), but Phase 2 skipped every listed issue because all four are closed, and the badge/follow/emoji lists each carried a closed number too. This points them at the open bounties people actually claim on: star #16238 #9017 #165 #171 #378, badge #13949, follow #2155, emoji #2180.

Note for #171/#378 (single-repo bounties): the star report shows `Partial (1 stars)` for a correct claim since VERIFIED needs ≥3 — the table is still the right evidence; a per-issue threshold is a reasonable follow-up.