### PR TITLE
fix(docstring-gate): fail closed when payout labels cannot be applied (Fixes #16662)

### DIFF
--- a/scripts/docstring_gate.py
+++ b/scripts/docstring_gate.py
@@ -113,24 +113,39 @@ def gh_raw(args):
 
 
 
-def add_labels(*names):
-    """Apply labels via REST.
+def add_labels(*names, strict=False):
+    """Apply labels via REST in one POST.
 
     `gh issue edit --add-label` goes through GraphQL and currently fails with a
     Projects-classic deprecation error -- and it fails SILENTLY, so the gate
     would post "verified" while never marking the claim eligible, and the payout
     runner would never see it. Verified by observing an adjudicated claim come
     back with `labels: []`.
+
+    When `strict=True`, a failed write raises `GhError` so money-path callers
+    fail closed instead of posting a verified/queued comment without labels.
     """
-    ok = True
+    if not names:
+        return True
+    args = ["gh", "api", "-X", "POST", f"/repos/{REPO}/issues/{NUM}/labels"]
     for n in names:
-        r = subprocess.run(["gh", "api", "-X", "POST",
-                            f"/repos/{REPO}/issues/{NUM}/labels", "-f", f"labels[]={n}"],
-                           capture_output=True, text=True, timeout=60)
-        if r.returncode != 0:
-            print(f"::warning::could not apply label {n}: {r.stderr.strip()[:120]}")
-            ok = False
-    return ok
+        args.extend(["-f", f"labels[]={n}"])
+    r = subprocess.run(args, capture_output=True, text=True, timeout=60)
+    if r.returncode != 0:
+        msg = (f"could not apply labels {list(names)}: "
+               f"{(r.stderr or r.stdout or '').strip()[:200]}")
+        if strict:
+            raise GhError(msg)
+        print(f"::warning::{msg}")
+        return False
+    return True
+
+
+def issue_has_labels(*names):
+    """Return True only when every named label is present on the issue."""
+    iss = gh(["issue", "view", NUM, "-R", REPO, "--json", "labels"], None, strict=True)
+    present = {l["name"] for l in (iss.get("labels") or [])}
+    return all(n in present for n in names)
 
 
 
@@ -311,7 +326,20 @@ def main():
                 f"Paying the verified number. If you think the gate has miscounted, say so and a "
                 f"human will check — miscounts are usually arithmetic, not bad faith.")
 
-    add_labels("bounty-eligible", "docstring-verified")
+    try:
+        add_labels("bounty-eligible", "docstring-verified", strict=True)
+        if not issue_has_labels("bounty-eligible", "docstring-verified"):
+            raise GhError("payable labels missing after REST apply")
+    except GhError as e:
+        gh(["issue", "comment", NUM, "-R", REPO, "--body",
+            f"🤖 Docstring gate: verified **{doc_count} docstrings** in {pr_repo}#{pr_num} "
+            f"(**{amount} RTC**), but could not apply the payout labels right now.\n\n"
+            f"Holding rather than posting a verified/queued marker — a green run without "
+            f"`bounty-eligible` + `docstring-verified` would never pay. This retries "
+            f"automatically on the next sweep."], None)
+        print(f"::error::label apply failed, refusing to approve: {e}", file=sys.stderr)
+        return 1
+
     gh(["issue", "comment", NUM, "-R", REPO, "--body",
         f"✅ 🤖 **Docstring gate: verified.**\n\n"
         f"- PR {pr_repo}#{pr_num} is **merged**\n"

--- a/tests/test_docstring_gate.py
+++ b/tests/test_docstring_gate.py
@@ -8,8 +8,10 @@ anything at all. These pin that it counts docstrings and nothing else.
 """
 import importlib.util
 import os
+import subprocess
 import unittest
 from pathlib import Path
+from unittest import mock
 
 os.environ.setdefault("GITHUB_TOKEN", "dummy")
 SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "docstring_gate.py"
@@ -134,3 +136,92 @@ class WeeklyCeilingTests(unittest.TestCase):
         the per-claim ceiling, so volume is unbounded without it."""
         typical_batch_rtc = 10 * dg.RATE     # 10 functions
         self.assertLess(typical_batch_rtc, dg.MAX_RTC)
+
+
+class LabelWriteFailClosedTests(unittest.TestCase):
+    """Regression for #16662: ignored label REST failures must not exit green."""
+
+    def setUp(self):
+        self._run = subprocess.run
+        dg.NUM = "16662"
+        dg.REPO = "Scottcjn/rustchain-bounties"
+
+    def tearDown(self):
+        subprocess.run = self._run
+
+    def test_strict_add_labels_raises_on_rest_failure(self):
+        class R:
+            stdout = ""
+            stderr = "rate limit"
+            returncode = 1
+
+        subprocess.run = lambda *a, **k: R()
+        with self.assertRaises(dg.GhError):
+            dg.add_labels("bounty-eligible", "docstring-verified", strict=True)
+
+    def test_strict_add_labels_uses_single_post(self):
+        seen = []
+
+        class R:
+            stdout = "[]"
+            stderr = ""
+            returncode = 0
+
+        def capture(args, **kwargs):
+            seen.append(args)
+            return R()
+
+        subprocess.run = capture
+        dg.add_labels("bounty-eligible", "docstring-verified", strict=True)
+        self.assertEqual(len(seen), 1)
+        joined = " ".join(seen[0])
+        self.assertIn("labels[]=bounty-eligible", joined)
+        self.assertIn("labels[]=docstring-verified", joined)
+
+    def test_payable_path_fails_closed_when_labels_do_not_stick(self):
+        comments = []
+
+        def fake_gh(args, default=None, strict=False):
+            joined = " ".join(args)
+            if "issue view" in joined or joined.startswith("gh issue view"):
+                return {
+                    "title": "Bounty claim: BoTTube docstring PR #9999",
+                    "body": "https://github.com/Scottcjn/bottube/pull/1696\nFunctions documented: 2",
+                    "labels": [],
+                    "author": {"login": "claimant"},
+                    "state": "OPEN",
+                }
+            if "pr view" in joined:
+                return {
+                    "state": "MERGED",
+                    "additions": 4,
+                    "deletions": 0,
+                    "files": [],
+                    "author": {"login": "claimant"},
+                    "mergedAt": "2026-01-01",
+                }
+            if len(args) >= 2 and args[0] == "issue" and args[1] == "comment":
+                comments.append(args)
+            if "search/issues" in joined:
+                return {"items": []}
+            return default
+
+        dg.gh = fake_gh
+        dg.gh_raw = lambda args: (
+            'diff --git a/x.py b/x.py\n'
+            '+++ b/x.py\n'
+            '+    """One."""\n'
+            '+    """Two."""\n'
+        )
+
+        with mock.patch.object(dg, "add_labels", side_effect=dg.GhError("label write failed")):
+            rc = dg.main()
+
+        self.assertEqual(rc, 1)
+        self.assertTrue(
+            any("could not apply the payout labels" in " ".join(c) for c in comments),
+            "expected hold comment, not verified marker",
+        )
+        self.assertFalse(
+            any("Docstring gate: verified." in " ".join(c) for c in comments),
+        )


### PR DESCRIPTION
## Summary
Fixes #16662

### Changes Implemented:
- `add_labels()` now applies both payable labels in a single REST POST and supports `strict=True` to raise `GhError` on failure instead of printing a warning and returning.
- Payable path uses strict label apply, live-reads issue labels via `issue_has_labels()`, and returns non-zero before posting any verified/queued comment when labels do not stick.
- Regression suite `LabelWriteFailClosedTests` (3 tests) pins REST failure raising, single-post semantics, and the payable path failing closed without a verified marker.

### Verification:
- `python3 -m unittest discover -s tests -p 'test_*.py' -q` — all tests pass.

### Payout Settlement:
- **Wallet**: `RTCe3eac583f4bc8dcb44b045fee3a65464d5df45b6`