### PR TITLE
fix(gate-backfill): fail closed when gh issue list returns bad JSON (audit #16471)

### DIFF
--- a/scripts/pr_review_gate_backfill.py
+++ b/scripts/pr_review_gate_backfill.py
@@ -45,6 +45,10 @@ PROCESSED_LABEL = os.environ.get("PROCESSED_LABEL", "gate-processed")
 SCRIPT_DIR = Path(__file__).resolve().parent
 
 
+class GhListError(RuntimeError):
+    """`gh issue list` failed or returned unparseable JSON. Not an empty queue."""
+
+
 def _load_gate():
     """Import pr_review_gate for its is_review_claim() classifier only."""
     spec = importlib.util.spec_from_file_location(
@@ -57,16 +61,22 @@ def _load_gate():
 
 def list_unprocessed(gate):
     """Open review claims that carry neither the processed label nor a verdict."""
-    out = subprocess.run(
+    r = subprocess.run(
         ["gh", "issue", "list", "-R", REPO, "--state", "open",
          "--limit", "1000", "--json", "number,title,labels"],
         capture_output=True, text=True, timeout=180,
-    ).stdout
+    )
+    if r.returncode != 0:
+        raise GhListError(
+            f"gh issue list exited {r.returncode}: {(r.stderr or r.stdout or '').strip()[:200]}"
+        )
     try:
-        issues = json.loads(out or "[]")
-    except json.JSONDecodeError:
-        print("::error::could not parse issue list", file=sys.stderr)
-        return []
+        issues = json.loads(r.stdout or "[]")
+    except json.JSONDecodeError as e:
+        raise GhListError(
+            f"gh issue list returned unparseable JSON: {e}; "
+            f"head={(r.stdout or '')[:120]!r}"
+        ) from e
 
     never, stranded = [], []
     for i in issues:
@@ -106,7 +116,11 @@ def adjudicate(number, retry=False):
 
 def main():
     gate = _load_gate()
-    never, stranded = list_unprocessed(gate)
+    try:
+        never, stranded = list_unprocessed(gate)
+    except GhListError as e:
+        print(f"::error::could not enumerate backfill queue: {e}", file=sys.stderr)
+        return 1
     total = len(never) + len(stranded)
     # Never-adjudicated claims get the budget first: those contributors have
     # heard nothing at all, whereas a stranded claim at least got a verdict.

--- a/tests/test_canonical_wallets_fail_closed.py
+++ b/tests/test_canonical_wallets_fail_closed.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Regression for audit bounty #16471: corrupt CLAIMANTS.md must fail closed."""
+import importlib.util
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+os.environ.setdefault("GITHUB_TOKEN", "dummy")
+os.environ.setdefault("RTC_ADMIN_KEY", "dummy")
+os.environ.setdefault("RTC_VPS_HOST", "127.0.0.1")
+
+ROOT = Path(__file__).resolve().parent.parent
+_orig_run = subprocess.run
+
+
+def _load_bp():
+    def stub(*a, **k):
+        class R:
+            stdout = "[]"
+            stderr = ""
+            returncode = 0
+        return R()
+
+    subprocess.run = stub
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "bounty_payout_canonical_test", ROOT / "scripts" / "bounty_payout.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        subprocess.run = _orig_run
+
+
+bp = _load_bp()
+
+
+class CanonicalWalletLoadTests(unittest.TestCase):
+    def test_missing_claimants_file_returns_empty(self):
+        with mock.patch("builtins.open", side_effect=FileNotFoundError):
+            self.assertEqual(bp._load_canonical_wallets(), {})
+
+    def test_corrupt_claimants_file_raises(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"\xff\xfe")
+            path = f.name
+        try:
+            with mock.patch.object(bp.os.path, "join", return_value=path):
+                with self.assertRaises(bp.CanonicalWalletError):
+                    bp._load_canonical_wallets()
+        finally:
+            os.unlink(path)
+
+    def test_valid_claimants_file_parses(self):
+        wallets = bp._load_canonical_wallets()
+        self.assertIsInstance(wallets, dict)
+        if wallets:
+            for handle, wallet in wallets.items():
+                self.assertTrue(handle)
+                self.assertRegex(wallet, r"^RTC[0-9a-fA-F]{40}$")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_review_gate_backfill_list_fail_closed.py
+++ b/tests/test_pr_review_gate_backfill_list_fail_closed.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Regression for payout audit #16471: gate backfill must not exit green on bad gh JSON."""
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "pr_review_gate_backfill_test",
+        ROOT / "scripts" / "pr_review_gate_backfill.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+bf = _load()
+
+
+class _FakeGate:
+    @staticmethod
+    def is_review_claim(title):
+        return "pr review" in (title or "").lower()
+
+
+class ListFailClosedTests(unittest.TestCase):
+    def test_malformed_json_raises(self):
+        class R:
+            stdout = "{"
+            stderr = ""
+            returncode = 0
+
+        with mock.patch("subprocess.run", return_value=R()):
+            with self.assertRaises(bf.GhListError):
+                bf.list_unprocessed(_FakeGate())
+
+    def test_nonzero_gh_exit_raises(self):
+        class R:
+            stdout = ""
+            stderr = "rate limit"
+            returncode = 1
+
+        with mock.patch("subprocess.run", return_value=R()):
+            with self.assertRaises(bf.GhListError):
+                bf.list_unprocessed(_FakeGate())
+
+    def test_valid_json_is_parsed(self):
+        payload = [
+            {"number": 1, "title": "Bounty claim: PR Review - foo", "labels": []},
+            {"number": 2, "title": "Docstring batch claim", "labels": []},
+        ]
+
+        class R:
+            stdout = json.dumps(payload)
+            stderr = ""
+            returncode = 0
+
+        with mock.patch("subprocess.run", return_value=R()):
+            never, stranded = bf.list_unprocessed(_FakeGate())
+        self.assertEqual(never, [1])
+        self.assertEqual(stranded, [])
+
+    def test_main_fails_closed_when_listing_fails(self):
+        with mock.patch.object(bf, "_load_gate", return_value=_FakeGate()):
+            with mock.patch.object(
+                bf, "list_unprocessed", side_effect=bf.GhListError("bad json")
+            ):
+                self.assertEqual(bf.main(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Payout audit finding under #16471 (same silent-success class as #16660).

### Defect
`pr_review_gate_backfill.list_unprocessed()` caught `json.JSONDecodeError` and returned `[]`, and ignored non-zero `gh` exit codes. A successful-exit but malformed `gh issue list` response therefore became an authoritative empty queue: the sweep printed `0 never-adjudicated` and exited green while stranded review claims were never processed.

### Changes Implemented
- Introduce `GhListError` for enumeration failures.
- Check `gh` return code and let `JSONDecodeError` propagate as `GhListError` with a bounded stdout diagnostic.
- `main()` returns non-zero when the queue cannot be enumerated.
- Regression suite `test_pr_review_gate_backfill_list_fail_closed.py` (4 tests).

### Verification
- `python3 -m unittest tests.test_pr_review_gate_backfill_list_fail_closed -v` — all pass.

### Payout Settlement
- **Wallet**: `RTCe3eac583f4bc8dcb44b045fee3a65464d5df45b6`