### PR TITLE
fix(payout): fail closed when CLAIMANTS.md is present but unreadable (audit #16471)

### DIFF
--- a/scripts/bounty_payout.py
+++ b/scripts/bounty_payout.py
@@ -105,13 +105,26 @@ def _find_handle_in_text(text):
         if m:
             return m.group(1)
     return None
+
+
+class GhError(RuntimeError):
+    """A `gh` invocation failed. Never swallow this into an empty result."""
+
+
+class CanonicalWalletError(GhError):
+    """CLAIMANTS.md exists but cannot be parsed into a trusted registry."""
+
+
 def _load_canonical_wallets():
     """Parse docs/CLAIMANTS.md into {handle_lower: native_RTC_wallet}.
 
     Canonical registry: a handle listed here is ALWAYS paid to its registered
     native wallet, regardless of what an individual claim body says. Only native
-    `RTC[0-9a-fA-F]{40}` rows are honored. Missing/garbled file -> empty map
-    (resolution falls back to per-claim parsing).
+    `RTC[0-9a-fA-F]{40}` rows are honored.
+
+    A missing file falls back to per-claim parsing (empty map). A present but
+    unreadable or corrupt file fails closed — an empty map would silently skip
+    canonical routing and risk paying the wrong destination.
     """
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "docs", "CLAIMANTS.md")
     out = {}
@@ -128,17 +141,15 @@ def _load_canonical_wallets():
                 if handle and m and not handle.lower().startswith(("github handle", "---")):
                     out[handle.lower()] = m.group(0)
     except FileNotFoundError:
-        pass
+        return out
     except Exception as e:
-        print(f"::warning::could not parse CLAIMANTS.md: {e}")
+        raise CanonicalWalletError(
+            f"could not parse CLAIMANTS.md at {path}: {e}"
+        ) from e
     return out
 
 
 CANONICAL_WALLETS = _load_canonical_wallets()
-
-
-class GhError(RuntimeError):
-    """A `gh` invocation failed. Never swallow this into an empty result."""
 
 
 def gh(args, _check=True):

--- a/tests/test_canonical_wallets_fail_closed.py
+++ b/tests/test_canonical_wallets_fail_closed.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Regression for audit bounty #16471: corrupt CLAIMANTS.md must fail closed."""
+import importlib.util
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+os.environ.setdefault("GITHUB_TOKEN", "dummy")
+os.environ.setdefault("RTC_ADMIN_KEY", "dummy")
+os.environ.setdefault("RTC_VPS_HOST", "127.0.0.1")
+
+ROOT = Path(__file__).resolve().parent.parent
+_orig_run = subprocess.run
+
+
+def _load_bp():
+    def stub(*a, **k):
+        class R:
+            stdout = "[]"
+            stderr = ""
+            returncode = 0
+        return R()
+
+    subprocess.run = stub
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "bounty_payout_canonical_test", ROOT / "scripts" / "bounty_payout.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        subprocess.run = _orig_run
+
+
+bp = _load_bp()
+
+
+class CanonicalWalletLoadTests(unittest.TestCase):
+    def test_missing_claimants_file_returns_empty(self):
+        with mock.patch("builtins.open", side_effect=FileNotFoundError):
+            self.assertEqual(bp._load_canonical_wallets(), {})
+
+    def test_corrupt_claimants_file_raises(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"\xff\xfe")
+            path = f.name
+        try:
+            with mock.patch.object(bp.os.path, "join", return_value=path):
+                with self.assertRaises(bp.CanonicalWalletError):
+                    bp._load_canonical_wallets()
+        finally:
+            os.unlink(path)
+
+    def test_valid_claimants_file_parses(self):
+        wallets = bp._load_canonical_wallets()
+        self.assertIsInstance(wallets, dict)
+        if wallets:
+            for handle, wallet in wallets.items():
+                self.assertTrue(handle)
+                self.assertRegex(wallet, r"^RTC[0-9a-fA-F]{40}$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes audit defect from #16471: `_load_canonical_wallets()` silently returned `{}` on any parse error, letting the payout runner skip canonical routing while exiting green.

### Changes
- Raise `CanonicalWalletError` when `docs/CLAIMANTS.md` exists but cannot be read/parsed.
- Keep missing-file behavior: empty map + per-claim fallback.
- Add `tests/test_canonical_wallets_fail_closed.py` (3 regression tests).

### Verification
```text
python3 -m unittest tests.test_canonical_wallets_fail_closed tests.test_payout_authorization -q
OK
```

### Payout Settlement
- **Wallet**: `RTCe3eac583f4bc8dcb44b045fee3a65464d5df45b6`