### PR TITLE
fix: fail closed on silent-success paths in audit scripts

### DIFF
--- a/scripts/bounty_claim.py
+++ b/scripts/bounty_claim.py
@@ -75,11 +75,11 @@ def gh(args, default=None):
 
 
 def gh_ok(args):
-    try:
-        return subprocess.run(["gh"] + args, capture_output=True, text=True,
-                              timeout=90).returncode == 0
-    except Exception:
+    result = subprocess.run(["gh"] + args, capture_output=True, text=True, timeout=90)
+    if result.returncode != 0:
+        print(f"[WARN] gh {' '.join(args[:3])} failed (exit {result.returncode}): {result.stderr.strip()}", file=sys.stderr)
         return False
+    return True
 
 
 def add_label(num, name):

--- a/scripts/docstring_gate.py
+++ b/scripts/docstring_gate.py
@@ -107,10 +107,10 @@ def gh(args, default=None, strict=False):
 
 
 def gh_raw(args):
-    try:
-        return subprocess.run(["gh"] + args, capture_output=True, text=True, timeout=120).stdout
-    except Exception:
-        return ""
+    result = subprocess.run(["gh"] + args, capture_output=True, text=True, timeout=120)
+    if result.returncode != 0:
+        raise GhError(f"gh {' '.join(args[:3])} failed (exit {result.returncode}): {result.stderr.strip()}")
+    return result.stdout
 
 
 

--- a/scripts/second_act.py
+++ b/scripts/second_act.py
@@ -122,11 +122,8 @@ def next_act(handle: str, repo: str, just_did: str) -> str:
 
 def build(handle: str, repo: str, just_did: str) -> str:
     """Return the trailing block for a payout comment. Never raises."""
-    try:
-        parts = [p for p in (standing(handle, repo), next_act(handle, repo, just_did)) if p]
-        return ("\n\n---\n" + "\n\n".join(parts)) if parts else ""
-    except Exception:
-        return ""
+    parts = [p for p in (standing(handle, repo), next_act(handle, repo, just_did)) if p]
+    return ("\n\n---\n" + "\n\n".join(parts)) if parts else ""
 
 
 if __name__ == "__main__":

--- a/scripts/sophia_scheduler.py
+++ b/scripts/sophia_scheduler.py
@@ -194,8 +194,10 @@ def sophia_get_last_inspected(sophia_url: str, miner_id: str) -> Optional[str]:
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read().decode())
             return data.get("created_at")
-    except Exception:
-        return None
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"Scheduler API returned HTTP {e.code}: {e.reason}") from e
+    except Exception as e:
+        raise RuntimeError(f"Scheduler API request failed: {e}") from e
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes silent-success anti-patterns identified in #16471 where broad `except Exception:` blocks returned empty/false defaults, causing workflows to exit green while doing no work.

### Changes
- **`scripts/docstring_gate.py`**: `gh_raw()` now raises `GhError` on non-zero exit instead of returning empty string
- **`scripts/sophia_scheduler.py`**: API fetch now raises `RuntimeError` on HTTP/network failure instead of returning `None`
- **`scripts/second_act.py`**: Removed bare `except Exception: return ""` that swallowed formatting errors in payout comments
- **`scripts/bounty_claim.py`**: `gh_ok()` now logs stderr warning on `gh` failure for visibility (still returns False to preserve existing control flow)

### Testing
All changes are fail-closed: functions that previously returned silent defaults now either raise or log explicitly. No behavioral change for success paths.

Claiming against master audit bounty #16471 (35 RTC + 10/defect).