### PR TITLE
fix(gate): skip weekly-cap-reached claims to prevent duplicate cron comment spam (Closes #16711)

### DIFF
--- a/scripts/docstring_gate.py
+++ b/scripts/docstring_gate.py
@@ -212,7 +212,7 @@ def main():
         print(f"could not read {REPO}#{NUM}", file=sys.stderr)
         return 1
     labels = {l["name"] for l in iss.get("labels", [])}
-    if {"bounty-eligible", "docstring-verified", "gate-processed"} & labels:
+    if {"bounty-eligible", "docstring-verified", "gate-processed", "weekly-cap-reached"} & labels:
         print("already adjudicated; skipping")
         return 0
     title, body = iss.get("title", ""), iss.get("body") or ""

--- a/tests/test_docstring_gate.py
+++ b/tests/test_docstring_gate.py
@@ -134,3 +134,21 @@ class WeeklyCeilingTests(unittest.TestCase):
         the per-claim ceiling, so volume is unbounded without it."""
         typical_batch_rtc = 10 * dg.RATE     # 10 functions
         self.assertLess(typical_batch_rtc, dg.MAX_RTC)
+
+    def test_weekly_cap_reached_label_skips_duplicate_adjudication(self):
+        """Claims already marked weekly-cap-reached should skip adjudication
+        to prevent duplicate spam comments on every cron sweep."""
+        old_num = dg.NUM
+        dg.NUM = "12345"
+        try:
+            dg.gh = lambda args, default=None, strict=False: {
+                "title": "BoTTube docstring PR #999",
+                "body": "https://github.com/Scottcjn/bottube/pull/999",
+                "labels": [{"name": "weekly-cap-reached"}],
+                "author": {"login": "contributor"},
+                "state": "OPEN"
+            }
+            res = dg.main()
+            self.assertEqual(res, 0)
+        finally:
+            dg.NUM = old_num


### PR DESCRIPTION
### Summary
Fixes the silent infinite comment spam defect in `scripts/docstring_gate.py` where claims already marked with `weekly-cap-reached` were not included in the top-level adjudication skip check.

Closes #16711
Audit Bounty #16471

### Changes
1. **`scripts/docstring_gate.py`**:
   - Added `"weekly-cap-reached"` to the skip filter:
     `if {"bounty-eligible", "docstring-verified", "gate-processed", "weekly-cap-reached"} & labels:`
2. **`tests/test_docstring_gate.py`**:
   - Added `test_weekly_cap_reached_label_skips_duplicate_adjudication` regression test.

### Payout Details
- Contributor: @ravendevhub
- Wallet Address: `RTC14241718572ec3bd1c0c4ee26ed2fc4bf6fca15`