### PR TITLE
fix(gate): avoid silent starvation after transient review lookup failures

### DIFF
--- a/scripts/pr_review_gate.py
+++ b/scripts/pr_review_gate.py
@@ -236,7 +236,6 @@ def main():
     if {"bounty-eligible","needs-human","gate-processed"} & labels: return  # idempotent
     title=iss.get("title",""); body=iss.get("body") or ""; author=iss["user"]["login"]
     if not is_review_claim(title): return  # not our claim type; leave for other workflows
-    add_label(NUM,"gate-processed")
     claim_repo, pr = pr_ref(title, body)
     if not pr:
         add_label(NUM,"needs-human"); comment(NUM,"🤖 Gate: couldn't find a single PR reference. Per **Bounty #73**, file one claim per PR with `PR #<number>` (a full PR URL is best). Flagged for human review."); return
@@ -283,6 +282,7 @@ def main():
     if elig.get("total_count",0)>=CAP:
         close(NUM,f"🤖 Gate: @{author} has reached the **{CAP} eligible reviews/contributor** cap (Bounty #73). Quality over volume — thanks!"); return
     add_label(NUM,"bounty-eligible")
+    add_label(NUM,"gate-processed")
     comment(NUM,f"✅ 🤖 Gate: **verified eligible** — @{author} is the first substantive reviewer of {target}#{pr}. **{RATE} RTC** pending payout (native `RTC…` wallet if not on file).")
 
 if __name__=="__main__":

--- a/tests/test_pr_review_gate_gate_processed_timing.py
+++ b/tests/test_pr_review_gate_gate_processed_timing.py
@@ -1,0 +1,85 @@
+import scripts.pr_review_gate as gate
+
+
+def _reset(monkeypatch):
+    monkeypatch.setattr(gate, 'NUM', '16710')
+    monkeypatch.setattr(gate, 'REPO', 'Scottcjn/rustchain-bounties')
+    monkeypatch.setattr(gate, 'TARGET', 'Scottcjn/Rustchain')
+    monkeypatch.setattr(gate, 'CAP', 15)
+    monkeypatch.setattr(gate, 'RATE', '3')
+
+
+def test_gate_processed_not_written_before_success(monkeypatch):
+    _reset(monkeypatch)
+    calls = []
+
+    issue = {
+        'state': 'open',
+        'title': 'PR Review RustChain #9999',
+        'body': 'RTC14241718572ec3bd1c0c4ee26ed2fc4bf6fca15',
+        'user': {'login': 'reviewer'},
+        'labels': [],
+    }
+
+    def fake_api(path, method='GET', data=None, strict=False):
+        calls.append((method, path, data, strict))
+        if path == '/repos/Scottcjn/rustchain-bounties/issues/16710':
+            return issue
+        if path == '/repos/Scottcjn/Rustchain/pulls/9999/reviews':
+            raise RuntimeError('transient github 502')
+        raise AssertionError(path)
+
+    monkeypatch.setattr(gate, 'api', fake_api)
+    monkeypatch.setattr(gate, 'comment', lambda *a, **k: calls.append(('COMMENT', a, k)))
+    monkeypatch.setattr(gate, 'close', lambda *a, **k: calls.append(('CLOSE', a, k)))
+    monkeypatch.setattr(gate, 'add_label', lambda *a, **k: calls.append(('LABEL', a, k)))
+
+    try:
+        gate.main()
+    except RuntimeError:
+        pass
+
+    labels = [c for c in calls if c[0] == 'LABEL']
+    assert labels == [], labels
+
+
+def test_gate_processed_written_after_eligible_verdict(monkeypatch):
+    _reset(monkeypatch)
+    calls = []
+
+    issue = {
+        'state': 'open',
+        'title': 'PR Review RustChain #9999',
+        'body': 'RTC14241718572ec3bd1c0c4ee26ed2fc4bf6fca15',
+        'user': {'login': 'reviewer'},
+        'labels': [],
+    }
+    reviews = [
+        {'submitted_at': '2026-08-30T12:00:00Z', 'user': {'login': 'reviewer'}, 'body': 'Ref: `src/main.py` line 44 can fail closed if the lookup times out.'}
+    ]
+    inline_comments = [
+        {'user': {'login': 'reviewer'}}
+    ]
+    elig = {'total_count': 0}
+
+    def fake_api(path, method='GET', data=None, strict=False):
+        calls.append((method, path, data, strict))
+        if path == '/repos/Scottcjn/rustchain-bounties/issues/16710':
+            return issue
+        if path == '/repos/Scottcjn/Rustchain/pulls/9999/reviews':
+            return reviews
+        if path == '/repos/Scottcjn/Rustchain/pulls/9999/comments?per_page=100':
+            return inline_comments
+        if path.startswith('/search/issues?q=user:Scottcjn+label:bounty-eligible+author:reviewer+type:issue'):
+            return elig
+        raise AssertionError(path)
+
+    monkeypatch.setattr(gate, 'api', fake_api)
+    monkeypatch.setattr(gate, 'comment', lambda *a, **k: calls.append(('COMMENT', a, k)))
+    monkeypatch.setattr(gate, 'close', lambda *a, **k: calls.append(('CLOSE', a, k)))
+    monkeypatch.setattr(gate, 'add_label', lambda *a, **k: calls.append(('LABEL', a, k)))
+
+    gate.main()
+
+    labels = [c[1][1] for c in calls if c[0] == 'LABEL']
+    assert labels == ['bounty-eligible', 'gate-processed'], labels


### PR DESCRIPTION
## Summary
- move `gate-processed` labeling until after a claim has been fully adjudicated
- add a regression test proving transient review-fetch failures do not mark the claim processed
- keep the happy path idempotent by labeling `bounty-eligible` and `gate-processed` together only after success

## Testing
- `python3 -m pytest -q tests/test_pr_review_gate_rubber_stamp.py tests/test_pr_review_gate_gate_processed_timing.py`

/claim #16710