### PR TITLE
fix(docstring-gate): restore intended 0.01 RTC/function (was 50x overpay)

### DIFF
--- a/.github/workflows/docstring-gate.yml
+++ b/.github/workflows/docstring-gate.yml
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          RATE_PER_FUNC: "0.5"
+          RATE_PER_FUNC: "0.01"  # matches scripts/docstring_gate.py intended rate; the 0.5 override was a 50x overpay bug
           MAX_RTC: "25"
         # `set -e` is deliberately NOT used: the sweep must keep going past one
         # bad claim. Every exit status is therefore captured and acted on


### PR DESCRIPTION
## The bug
`scripts/docstring_gate.py` defaults to the **intended 0.01 RTC/function** (line 46, with the comment "At 0.01 RTC/function the weekly cap is a soft backstop…"). But the workflow `docstring-gate.yml` overrode it with `RATE_PER_FUNC: "0.5"` — so the gate has been pricing docstring claims at **50× the intended rate**.

## Impact
The current open docstring wave (yaegerbomb42, ~35 PRs, #1763–1821) is titled at 0.5/function — e.g. "87 functions, **43.5 RTC**". At the correct 0.01, that same PR is worth **0.87 RTC**. Total exposure drops from ~700 RTC to ~14 RTC. This restores the de-incentivized rate that was the whole point of lowering docstring bounties.

## Fix
One line: `RATE_PER_FUNC: "0.5"` → `"0.01"` in the workflow, matching the script's intended default and comments. Once merged, the gate's scheduled re-check re-prices held `awaiting-merge` claims at the correct rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)