### PR TITLE
Complete fail-safe miner monitor state loading

### DIFF
--- a/miner-notifications/miner_monitor.py
+++ b/miner-notifications/miner_monitor.py
@@ -130,8 +130,21 @@ class MinerMonitor:
         except (OSError, json.JSONDecodeError) as exc:
             logger.warning("state file unreadable; starting fresh: %s", exc)
             return
+        if not isinstance(data, dict):
+            logger.warning(
+                "state file must contain a JSON object; starting fresh (got %s)",
+                type(data).__name__,
+            )
+            return
+        miners_data = data.get("miners", {})
+        if not isinstance(miners_data, dict):
+            logger.warning(
+                "state file 'miners' must contain an object; starting fresh (got %s)",
+                type(miners_data).__name__,
+            )
+            return
         loaded = {}
-        for k, v in (data.get("miners") or {}).items():
+        for k, v in miners_data.items():
             try:
                 loaded[k] = MinerState.from_dict(v)
             except (KeyError, TypeError, ValueError) as exc:

--- a/miner-notifications/test_miner_monitor.py
+++ b/miner-notifications/test_miner_monitor.py
@@ -238,6 +238,26 @@ class TestMinerMonitor:
             data = json.load(f)
             assert "test-miner-1" in data['miners']
             assert data['miners']['test-miner-1']['alert_count'] == 2
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            [],
+            {"miners": []},
+            {"miners": "not-an-object"},
+        ],
+    )
+    def test_load_state_rejects_valid_json_with_wrong_shape(
+        self, mock_config, tmp_path, payload
+    ):
+        """A valid JSON document with the wrong schema must not abort startup."""
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps(payload), encoding="utf-8")
+
+        with patch('miner_monitor.STATE_FILE', state_file):
+            monitor = MinerMonitor(mock_config)
+
+        assert monitor.miners == {}
     
     def test_run_once(self, monitor):
         """Test single monitoring cycle"""


### PR DESCRIPTION
## Summary
- close the post-merge review gap identified on #16791
- reject a valid JSON document when its top-level value is not an object
- reject a non-object `miners` collection before calling `.items()`
- preserve the existing per-entry skip behavior for malformed miner records

## Why
The original hardening caught JSON syntax errors and malformed individual rows, but structurally valid JSON such as `[]` or `{"miners": []}` still raised `AttributeError` outside the per-entry guard and aborted monitor startup.

## Proof
- targeted wrong-shape + save/load tests: 4/4 passed
- complete miner monitor suite: 24/24 passed
- Python compile and diff-integrity checks clean

Follow-up to the owner change request on #16791: https://github.com/Scottcjn/rustchain-bounties/pull/16791#pullrequestreview-5026867505