### PR TITLE
fix(security): scope tabs permission and harden bottube-chrome popup

### DIFF
--- a/extensions/bottube-chrome/manifest.json
+++ b/extensions/bottube-chrome/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0",
   "description": "A Chrome extension for BoTTube functionality",
   "permissions": [
-    "tabs",
+    "activeTab",
     "storage"
   ],
   "action": {

--- a/extensions/bottube-chrome/popup.html
+++ b/extensions/bottube-chrome/popup.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'">
   <style>
     body {
       width: 300px;
@@ -41,19 +42,25 @@
   <script>
     document.getElementById('browse-btn').addEventListener('click', function() {
       chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-        chrome.tabs.sendMessage(tabs[0].id, {action: "browse"});
+        if (!tabs || !tabs[0] || !tabs[0].id) { return; }
+        if (!/^https?:\/\//.test(tabs[0].url || '')) { return; }
+        chrome.tabs.sendMessage(tabs[0].id, {action: "browse"}, function() { void chrome.runtime.lastError; });
       });
     });
 
     document.getElementById('vote-btn').addEventListener('click', function() {
       chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-        chrome.tabs.sendMessage(tabs[0].id, {action: "vote"});
+        if (!tabs || !tabs[0] || !tabs[0].id) { return; }
+        if (!/^https?:\/\//.test(tabs[0].url || '')) { return; }
+        chrome.tabs.sendMessage(tabs[0].id, {action: "vote"}, function() { void chrome.runtime.lastError; });
       });
     });
 
     document.getElementById('upload-btn').addEventListener('click', function() {
       chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-        chrome.tabs.sendMessage(tabs[0].id, {action: "upload"});
+        if (!tabs || !tabs[0] || !tabs[0].id) { return; }
+        if (!/^https?:\/\//.test(tabs[0].url || '')) { return; }
+        chrome.tabs.sendMessage(tabs[0].id, {action: "upload"}, function() { void chrome.runtime.lastError; });
       });
     });
   </script>


### PR DESCRIPTION
## Summary

Hardens the `extensions/bottube-chrome` Chrome extension against overly broad host access, missing CSP, and a few Manifest V3 foot-guns.

## Findings

- **F-1 (High) Over-broad `tabs` permission**  
  The extension requested `"tabs"`, which exposes the URL of every open tab to the extension's background code, even tabs the user has not interacted with. The popup only ever talks to the *active* tab on user click, which is exactly what `"activeTab"` is designed for.

- **F-2 (Medium) Missing Content-Security-Policy in popup**  
  No `Content-Security-Policy` meta tag in `popup.html`. If any HTML or script path is ever compromised, an attacker can inject inline scripts, eval, or remote iframes. Adds a strict CSP that locks the popup to self-hosted scripts and styles only.

- **F-3 (Medium) `tabs[0].id` crash on devtools / chrome:// tabs**  
  The popup used `chrome.tabs.sendMessage(tabs[0].id, ...)` without checking `tabs[0]` exists. When the active tab is `chrome://`, `devtools://`, or similar, the popup currently throws an uncaught error. Now guards `tabs[0]` and the `tabs[0].id`.

- **F-4 (Medium) Sending `sendMessage` to non-http(s) targets**  
  We previously dispatched the action to any URL. This skips `chrome://`, `devtools://`, `file://`, `javascript:`, etc., so a user cannot accidentally or maliciously trigger the extension against those origins.

- **F-5 (Low) Missing response callback on `sendMessage`**  
  Manifest V3 logs a noisy "The message port closed before a response was received" warning on every click when no listener replies. The popup now passes a response callback that consumes `chrome.runtime.lastError` and otherwise ignores the result.

## Verification

```
node --check  # (script parsed via vm)  → SYNTAX OK
# `/^https?:\/\//` test cases:
#   https://evil.com   → true
#   http://localhost   → true
#   javascript:alert(1)→ false
#   chrome://settings → false
```

🤖 Generated with [Codex](https://openai.com/codex/)