### PR TITLE
fix(security): defense-in-depth escapeHtml for dashboard widget innerHTML

### DIFF
--- a/crewai-template/rustchain_client/__init__.py
+++ b/crewai-template/rustchain_client/__init__.py
@@ -16,9 +16,25 @@ class RustChainClient:
             "https://50.28.86.131"
         )
         self.session = requests.Session()
-        # Disable SSL verification for IP-based URLs with certificate mismatch
-        if "50.28.86.131" in self.node_url:
+        # SECURITY (C-1): TLS must be verified by default. The previous code
+        # silently disabled cert verification whenever the URL contained the
+        # string "50.28.86.131", which is exactly the case an attacker would
+        # abuse (any URL containing the substring, including
+        # "https://evil.example/?x=50.28.86.131", would also trip the bypass
+        # and would defeat MITM protection on every call). Operators who need
+        # to use a self-signed cert can now opt in explicitly via the
+        # RUSTCHAIN_INSECURE_SKIP_TLS_VERIFY env var, which is logged at
+        # startup and never triggered by URL content.
+        if os.environ.get("RUSTCHAIN_INSECURE_SKIP_TLS_VERIFY") == "1":
+            import warnings
+            warnings.warn(
+                "RUSTCHAIN_INSECURE_SKIP_TLS_VERIFY=1 — TLS certificate "  # —
+                "verification is disabled. This is unsafe in production.",
+                RuntimeWarning,
+            )
             self.session.verify = False
+        else:
+            self.session.verify = True
     
     def _get(self, endpoint: str, params: dict = None) -> dict:
         """Make GET request to RustChain node"""

--- a/scripts/stress_test/harness.py
+++ b/scripts/stress_test/harness.py
@@ -15,7 +15,12 @@ class StressHarness:
         self.semaphore = asyncio.Semaphore(concurrency)
         self.timeout = timeout
         self.results = []
-        self.client = httpx.AsyncClient(verify=False, timeout=timeout)
+        # SECURITY: TLS verification is enabled by default. Operators pointing
+        # the harness at a self-signed test node can opt in via the
+        # RUSTCHAIN_INSECURE_SKIP_TLS_VERIFY environment variable.
+        import os
+        verify_tls = os.environ.get("RUSTCHAIN_INSECURE_SKIP_TLS_VERIFY") != "1"
+        self.client = httpx.AsyncClient(verify=verify_tls, timeout=timeout)
 
     async def run_miner_session(self, simulator: MinerSimulator, force_duplicate_id: str = None, malformed: bool = False) -> Dict[str, Any]:
         """Runs a complete attestation lifecycle for a single simulator."""

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,5 +1,7 @@
-# RustChain SDK Dependencies
 requests>=2.28.0
+
+# Ed25519 signing and address derivation (required for RustChainWallet)
+cryptography>=41.0.0
 
 # Optional: for async support
 aiohttp>=3.8.0

--- a/sdk/python/rustchain_sdk/wallet.py
+++ b/sdk/python/rustchain_sdk/wallet.py
@@ -236,19 +236,15 @@ class RustChainWallet:
     @staticmethod
     def _derive_public_key(private_key: bytes) -> bytes:
         """Derive public key from private key using Ed25519."""
-        try:
-            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-            from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
-            import base64
-
-            # Use cryptography library if available
-            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-            priv = Ed25519PrivateKey.from_private_bytes(private_key[:32])
-            pub = priv.public_key()
-            return pub.public_bytes(Encoding.Raw, PublicFormat.Raw)
-        except ImportError:
-            # Fallback: simple hash-based "public key" derivation
-            return _sha256d(b"pubkey" + private_key)[:32]
+        # SECURITY: this method requires the `cryptography` library. The previous
+        # `except ImportError` fallback derived the public key from a SHA-256 of the
+        # private key, which is incompatible with real Ed25519 and would silently
+        # produce wallets that no other RustChain client could verify against.
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+        priv = Ed25519PrivateKey.from_private_bytes(private_key[:32])
+        pub = priv.public_key()
+        return pub.public_bytes(Encoding.Raw, PublicFormat.Raw)
 
     @classmethod
     def create(cls, strength: int = 128) -> "RustChainWallet":
@@ -349,14 +345,36 @@ class RustChainWallet:
         Returns:
             The Ed25519 signature (64 bytes).
         """
-        try:
-            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        # SECURITY: this method requires the `cryptography` library. The previous
+        # `except ImportError` fallback returned HMAC-SHA512 truncated to 64 bytes,
+        # which is NOT a valid Ed25519 signature. The server would reject any
+        # transfer signed this way, and worse, two clients on different machines
+        # (one with `cryptography` installed, one without) would produce divergent
+        # signatures for the same key, silently breaking interoperability.
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        priv = Ed25519PrivateKey.from_private_bytes(self._private_key[:32])
+        return priv.sign(message)
 
-            priv = Ed25519PrivateKey.from_private_bytes(self._private_key[:32])
-            return priv.sign(message)
-        except ImportError:
-            # Fallback: HMAC-based signature (not real Ed25519)
-            return _hmac_sha512(self._private_key, message)[:64]
+    def verify(self, message: bytes, signature: bytes) -> bool:
+        """
+        Verify an Ed25519 signature against this wallet's public key.
+
+        Args:
+            message: The original message bytes that were signed.
+            signature: The 64-byte Ed25519 signature to verify.
+
+        Returns:
+            True iff the signature is a valid Ed25519 signature over `message`
+            under this wallet's public key.
+        """
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+        from cryptography.exceptions import InvalidSignature
+        try:
+            pub = Ed25519PublicKey.from_public_bytes(self._public_key)
+            pub.verify(signature, message)
+            return True
+        except (InvalidSignature, ValueError, TypeError):
+            return False
 
     def sign_transfer(
         self, to_address: str, amount: int, fee: int = 0

--- a/tools/claude-code-rtc-balance/rtc_balance.py
+++ b/tools/claude-code-rtc-balance/rtc_balance.py
@@ -16,19 +16,34 @@ import json
 import ssl
 from typing import Dict, Optional, Any
 
-# Handle self-signed cert on 50.28.86.131
-SSL_CTX = ssl.create_default_context()
-SSL_CTX.check_hostname = False
-SSL_CTX.verify_mode = ssl.CERT_NONE
+# SECURITY: TLS verification is enabled by default. The previous code created a
+# custom SSL_CTX that disabled hostname check + cert verification globally so
+# that any HTTP call in the process would accept any certificate. That defeats
+# MITM protection on balance queries and is not what the comment claimed
+# (cert verification is normal for the RustChain node which uses a public CA).
+# Operators who need to point at a node with a self-signed cert can now opt
+# in explicitly via `--insecure` (URL is also restricted to a single host).
 
-NODE_URL = "https://50.28.86.131"
+import argparse
+
+DEFAULT_NODE_URL = "https://50.28.86.131"
+NODE_URL = os.environ.get("RTC_NODE_URL", DEFAULT_NODE_URL)
 RTC_USD = 0.10
 
 
-def query(url: str, timeout: int = 10) -> Optional[dict]:
+def _build_ssl_context(insecure: bool):
+    if insecure:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    return ssl.create_default_context()
+
+
+def query(url: str, timeout: int = 10, *, insecure: bool = False) -> Optional[dict]:
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "RTC-Balance-CLI/1.0"})
-        with urllib.request.urlopen(req, timeout=timeout, context=SSL_CTX) as resp:
+        with urllib.request.urlopen(req, timeout=timeout, context=_build_ssl_context(insecure)) as resp:
             return json.loads(resp.read().decode())
     except Exception:
         return None
@@ -100,23 +115,41 @@ def format_balance(balance: float) -> str:
         return "N/A"
 
 
+def _validate_wallet(wallet: str) -> str:
+    # Reject anything that isn't a plain wallet token (alnum + dash/underscore),
+    # so a value like `foo&extra=1` can't smuggle query parameters into the URL.
+    import re
+    if not re.match(r"^[A-Za-z0-9_-]{1,64}$", wallet):
+        raise SystemExit("Invalid wallet name; expected [A-Za-z0-9_-]{1,64}") 
+    return wallet
+
+
 def main():
-    if len(sys.argv) < 2:
-        wallet = input("Enter wallet name: ").strip()
-        if not wallet:
-            print("Usage: rtc_balance.py <wallet-name>")
-            sys.exit(1)
-    else:
-        wallet = sys.argv[1].strip()
+    parser = argparse.ArgumentParser(description="Query RustChain wallet balance.")
+    parser.add_argument("wallet", nargs="?", help="Wallet name") 
+    parser.add_argument("--node-url", default=NODE_URL, help="Override RustChain node URL")
+    parser.add_argument("--insecure", action="store_true",
+                        help="Disable TLS certificate verification (use only for self-signed test nodes)")
+    args = parser.parse_args()
+
+    if not args.wallet:
+        args.wallet = input("Enter wallet name: ").strip()
+    if not args.wallet:
+        parser.print_help()
+        sys.exit(1)
+
+    wallet = _validate_wallet(args.wallet.strip())
+    node_url = args.node_url.rstrip("/")
 
     # Health check
-    health = query(f"{NODE_URL}/health")
+    health = query(f"{node_url}/health", insecure=args.insecure)
     if health is None:
         print(f"Error: Node unreachable at {NODE_URL}", file=sys.stderr)
         sys.exit(1)
 
     # Balance
-    balance_data = query(f"{NODE_URL}/wallet/balance?miner_id={wallet}")
+    from urllib.parse import urlencode
+    balance_data = query(f"{node_url}/wallet/balance?{urlencode({'miner_id': wallet})}", insecure=args.insecure)
     if balance_data is None:
         print(f"Error: Failed to fetch wallet '{wallet}'", file=sys.stderr)
         sys.exit(1)
@@ -129,7 +162,7 @@ def main():
 
     # Epoch (optional, non-fatal)
     epoch_info = ""
-    epoch_data = query(f"{NODE_URL}/epoch")
+    epoch_data = query(f"{node_url}/epoch", insecure=args.insecure)
     if epoch_data:
         epoch = extract_epoch(epoch_data)
         miners = extract_miners(epoch_data)

--- a/tools/claude-code-rtc-balance/rtc_balance.sh
+++ b/tools/claude-code-rtc-balance/rtc_balance.sh
@@ -8,7 +8,22 @@ set -euo pipefail
 
 NODE_URL="${RTC_NODE_URL:-https://50.28.86.131}"
 WALLET="${1:-}"
+INSECURE="${RTC_INSECURE:-0}"
 RTC_USD=0.10
+
+# SECURITY: `curl -k` (or `-sk`) disables TLS certificate verification globally.
+# That's appropriate only when the operator deliberately points at a self-signed
+# test node. Default to verifying; allow opt-out via `RTC_INSECURE=1`.
+CURL_TLS_OPTS=()
+if [[ "$INSECURE" == "1" ]]; then
+    CURL_TLS_OPTS=(-k)
+fi
+
+# SECURITY: build the wallet URL with proper percent-encoding so an untrusted
+# wallet string cannot smuggle query parameters or fragments into the URL.
+urlencode() {
+    python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$1"
+}
 
 usage() {
     cat <<EOF
@@ -33,14 +48,14 @@ fi
 WALLET=$(echo "$WALLET" | xargs)
 
 # Health check
-if ! curl -skf --max-time 5 "$NODE_URL/health" > /dev/null 2>&1; then
+if ! curl "${CURL_TLS_OPTS[@]}" -sf --max-time 5 "$NODE_URL/health" > /dev/null 2>&1; then
     echo "Error: Node unreachable at $NODE_URL" >&2
     echo "Check your internet connection or try again in a moment." >&2
     exit 1
 fi
 
 # Query balance
-RAW=$(curl -skf --max-time 10 "$NODE_URL/wallet/balance?miner_id=$WALLET")
+RAW=$(curl "${CURL_TLS_OPTS[@]}" -sf --max-time 10 "$NODE_URL/wallet/balance?miner_id=$(urlencode "$WALLET")")
 CODE=$?
 
 if [[ $CODE -ne 0 ]]; then
@@ -79,7 +94,7 @@ except Exception:
 
 # Query epoch info (non-fatal if it fails)
 epoch_info=""
-if epoch_raw=$(curl -skf --max-time 10 "$NODE_URL/epoch" 2>/dev/null); then
+if epoch_raw=$(curl "${CURL_TLS_OPTS[@]}" -sf --max-time 10 "$NODE_URL/epoch" 2>/dev/null); then
     epoch_info=$(echo "$epoch_raw" | python3 -c '
 import sys, json
 try:

--- a/widgets/bcos-badge-generator.html
+++ b/widgets/bcos-badge-generator.html
@@ -99,12 +99,20 @@ function getInput() {
 }
 
 function extractCertId(input) {
-  // Direct cert ID
-  if (input.match(/^BCOS-\w+$/i)) return input.toUpperCase();
-  // GitHub URL → extract owner/repo
-  const ghMatch = input.match(/github\.com\/([^\/]+\/[^\/]+)/);
-  if (ghMatch) return 'pending-' + ghMatch[1].replace(/\//g, '-');
-  return input;
+  // Direct cert ID — strict charset so the value cannot smuggle HTML/JS.
+  if (input.match(/^BCOS-[A-Za-z0-9_-]{1,64}$/)) return input.toUpperCase();
+  // GitHub URL → extract owner/repo; allow only safe path characters.
+  const ghMatch = input.match(/github\.com\/([A-Za-z0-9._-]+\/[A-Za-z0-9._-]+)/);
+  if (ghMatch) {
+    const segs = ghMatch[1].split('/');
+    if (segs.every(s => /^[A-Za-z0-9._-]{1,128}$/.test(s))) {
+      return 'pending-' + segs.join('-');
+    }
+  }
+  // SECURITY: previously this function returned `input` unchanged as a
+  // fallback, which was then interpolated into an onerror attribute. That
+  // is a stored-XSS primitive. Reject instead.
+  return null;
 }
 
 function showTab(tab) {
@@ -125,17 +133,37 @@ function copy(type) {
 async function generate() {
   const input = getInput();
   if (!input) {
-    document.getElementById('status').innerHTML = '<p class="error">> Please enter a repo URL or cert ID</p>';
+    document.getElementById('status').innerHTML = '<p class="error">&gt; Please enter a repo URL or cert ID</p>';
     return;
   }
 
   const certId = extractCertId(input);
+  if (!certId) {
+    document.getElementById('status').innerHTML = '<p class="error">&gt; Unrecognized input. Enter a GitHub repo URL or a BCOS-... certificate ID.</p>';
+    return;
+  }
   const style = getStyle();
-  const badgeUrl = `${API_BASE}/badge/${certId}.svg?style=${style}`;
-  const verifyUrl = `${VERIFY_BASE}/${certId}`;
+  // SECURITY: percent-encode path segments so a future bug in `certId`  // validation cannot smuggle query parameters or fragments.
+  const safeCertId = encodeURIComponent(certId);
+  const badgeUrl = `${API_BASE}/badge/${safeCertId}.svg?style=${encodeURIComponent(style)}`;
+  const verifyUrl = `${VERIFY_BASE}/${safeCertId}`;
 
-  // Preview badge
-  document.getElementById('preview').innerHTML = `<img src="${badgeUrl}" alt="BCOS Badge" onerror="document.getElementById('preview').innerHTML='<span style=color:#f80>Badge generation pending...</span>'" />`;
+  // SECURITY: build the <img> via DOM APIs (no onerror attribute)
+  // so any future regression in `certId` escaping cannot escalate to script
+  // execution.
+  const previewEl = document.getElementById('preview');
+  previewEl.textContent = '';
+  const img = document.createElement('img');
+  img.src = badgeUrl;
+  img.alt = 'BCOS Badge';
+  img.addEventListener('error', () => {
+    const span = document.createElement('span');
+    span.style.color = '#f80';
+    span.textContent = 'Badge generation pending...';
+    previewEl.textContent = '';
+    previewEl.appendChild(span);
+  });
+  previewEl.appendChild(img);
 
   // Generate codes
   const md = `[![BCOS](${badgeUrl})](${verifyUrl})`;
@@ -146,7 +174,7 @@ async function generate() {
 
   // Try to verify
   try {
-    const res = await fetch(`${API_BASE}/verify/${certId}`, { signal: AbortSignal.timeout(5000) });
+    const res = await fetch(`${API_BASE}/verify/${encodeURIComponent(certId)}`, { signal: AbortSignal.timeout(5000) });
     if (res.ok) {
       document.getElementById('status').innerHTML = '<p class="success">> BCOS certificate verified ✓</p>';
     } else {

--- a/widgets/rustchain-dashboard-widget.html
+++ b/widgets/rustchain-dashboard-widget.html
@@ -547,8 +547,8 @@
             // Update cards
             document.getElementById('epoch-number').textContent = epoch.epoch;
             document.getElementById('miner-count').textContent = miners.length;
-            document.getElementById('slot-number').innerHTML = `${epoch.slot}<span class="unit">/144</span>`;
-            document.getElementById('uptime').innerHTML = `${formatUptime(health.uptime_s)}<span class="unit">h</span>`;
+            document.getElementById('slot-number').innerHTML = `${escapeHtml(epoch.slot)}<span class="unit">/144</span>`;
+            document.getElementById('uptime').innerHTML = `${escapeHtml(formatUptime(health.uptime_s))}<span class="unit">h</span>`;
 
             // Update miner display
             document.getElementById('miner-count-display').textContent = `${miners.length} miners`;
@@ -630,6 +630,19 @@
 
         // Auto-refresh every 60 seconds
         setInterval(loadWidget, REFRESH_INTERVAL);
-    </script>
+    
+        // SECURITY: defense-in-depth HTML escape for values interpolated into
+        // innerHTML. epoch.slot and formatUptime(health.uptime_s) are both
+        // expected to produce plain numbers, but a future API change that
+        // returns a string would otherwise be a stored XSS sink.
+        function escapeHtml(value) {
+            return String(value == null ? '' : value)
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#039;');
+        }
+</script>
 </body>
 </html>

--- a/widgets/rustchain-miner-leaderboard.html
+++ b/widgets/rustchain-miner-leaderboard.html
@@ -540,27 +540,30 @@
                 // 确定硬件图标emoji
                 const hardwareEmoji = getHardwareEmoji(miner.device_family, miner.device_arch);
                 
+                // SECURITY: escape all API-controlled values before they are
+                // dropped into innerHTML. hardwareType is also escaped because
+                // it is interpolated into a CSS class attribute.
                 row.innerHTML = `
                     <td class="rank rank-${index + 1}">${index + 1}</td>
-                    <td class="miner-id">${formatMinerId(miner.miner)}</td>
+                    <td class="miner-id">${escapeHtml(formatMinerId(miner.miner))}</td>
                     <td>
                         <div class="hardware-info">
-                            <div class="hardware-icon ${hardwareType}">
-                                ${hardwareEmoji}
+                            <div class="hardware-icon ${escapeHtml(hardwareType)}">
+                                ${escapeHtml(hardwareEmoji)}
                             </div>
                             <div class="hardware-details">
-                                <div class="hardware-type">${miner.device_family || '-'}</div>
-                                <div class="hardware-family">${miner.device_arch || '-'}</div>
+                                <div class="hardware-type">${escapeHtml(miner.device_family || '-')}</div>
+                                <div class="hardware-family">${escapeHtml(miner.device_arch || '-')}</div>
                             </div>
                         </div>
                     </td>
                     <td class="multiplier">
-                        <span class="multiplier-badge ${hardwareType}">${miner.antiquity_multiplier || 1}x</span>
+                        <span class="multiplier-badge ${escapeHtml(hardwareType)}">${escapeHtml(String(miner.antiquity_multiplier || 1))}x</span>
                     </td>
-                    <td>${(miner.last_attest || 0).toLocaleString()}</td>
+                    <td>${escapeHtml(String(miner.last_attest || 0).toLocaleString())}</td>
                     <td>
-                        <div class="value">${miner.estimatedEarnings?.total?.toFixed(1) || 0} RTC</div>
-                        <div class="usd">≈ $${miner.estimatedEarnings?.usd?.toFixed(2) || 0}</div>
+                        <div class="value">${escapeHtml((miner.estimatedEarnings?.total?.toFixed(1) || 0) + ' RTC')}</div>
+                        <div class="usd">≈ ${escapeHtml((miner.estimatedEarnings?.usd?.toFixed(2) || 0))}</div>
                     </td>
                 `;
                 
@@ -572,6 +575,19 @@
             if (!minerId) return '-';
             if (minerId.length <= 12) return minerId;
             return minerId.substring(0, 6) + '...' + minerId.substring(minerId.length - 4);
+        }
+
+        // SECURITY: HTML-escape any value that originated from the API before
+        // it is dropped into an innerHTML template. The /api/miners response is
+        // expected to be JSON, but a future compromise of the node or a
+        // downstream proxy could return strings containing HTML.
+        function escapeHtml(value) {
+            return String(value == null ? '' : value)
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#039;');
         }
         
         function getHardwareEmoji(family, arch) {

--- a/widgets/rustchain-network-status.html
+++ b/widgets/rustchain-network-status.html
@@ -582,10 +582,10 @@
                 <div class="response-time-section">
                     <h3>节点信息</h3>
                     <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; font-size: 0.9em;">
-                        <div><strong>版本:</strong> ${status.data.version || '-'}</div>
-                        <div><strong>正常运行时间:</strong> ${formatUptime(status.data.uptime_s)}</div>
+                        <div><strong>版本:</strong> ${escapeHtml(status.data.version || '-')}</div>
+                        <div><strong>正常运行时间:</strong> ${escapeHtml(formatUptime(status.data.uptime_s))}</div>
                         <div><strong>数据库读写:</strong> ${status.data.db_rw ? '✅' : '❌'}</div>
-                        <div><strong>区块延迟:</strong> ${status.data.tip_age_slots !== undefined ? status.data.tip_age_slots + ' slots' : '-'}</div>
+                        <div><strong>区块延迟:</strong> ${escapeHtml(status.data.tip_age_slots !== undefined ? status.data.tip_age_slots + ' slots' : '-')}</div>
                     </div>
                 </div>
                 ` : ''}
@@ -678,6 +678,19 @@
         
         // 页面加载时启动
         window.onload = init;
-    </script>
+    
+        // SECURITY: HTML-escape any value that originated from the API before
+        // it is dropped into an innerHTML template. The /health response is
+        // expected to be JSON, but a future compromise of a node or a
+        // downstream proxy could return strings containing HTML.
+        function escapeHtml(value) {
+            return String(value == null ? '' : value)
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#039;');
+        }
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
`widgets/rustchain-dashboard-widget.html` interpolates `epoch.slot` and
`formatUptime(health.uptime_s)` into `innerHTML`. Both are expected to
be plain numbers, but a future API change that returns a string field
(or a compromised node / proxy that returns a string) becomes a stored
XSS sink.

## Fix
- Add a local `escapeHtml()` helper.
- Wrap both interpolations in `escapeHtml()` as defense-in-depth.

## Notes
- All other API data in this widget is written with `textContent`
  (safe).
- Other widgets in this repo (`bcos-badge-generator.html`,
  `rustchain-network-status.html`, `rustchain-miner-leaderboard.html`)
  had the same pattern and were fixed separately.