### PR TITLE
fix(security): escape API-controlled values in otc-bridge templates

### DIFF
--- a/community/dashboards/jonasxzb-rustchain-stats/index.html
+++ b/community/dashboards/jonasxzb-rustchain-stats/index.html
@@ -555,6 +555,7 @@
       $("statusText").textContent = text;
     }
 
+    function esc(v){return String(v==null?'':v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
     function renderBars(miners) {
       const top = [...miners]
         .sort((a, b) => Number(b.antiquity_multiplier || 0) - Number(a.antiquity_multiplier || 0))
@@ -562,7 +563,7 @@
       const max = Math.max(1, ...top.map((m) => Number(m.antiquity_multiplier || 0)));
       $("minerChart").innerHTML = top.map((miner) => {
         const height = Math.max(8, Math.round((Number(miner.antiquity_multiplier || 0) / max) * 100));
-        return `<div class="bar" style="height:${height}%" title="${shortId(miner.miner)}: ${miner.antiquity_multiplier || 0}x"></div>`;
+        return `<div class="bar" style="height:${height}%" title="${esc(shortId(miner.miner))}: ${esc(miner.antiquity_multiplier || 0)}x"></div>`;
       }).join("");
     }
 
@@ -572,11 +573,11 @@
         .slice(0, 10)
         .map((miner) => `
           <tr>
-            <td class="mono" title="${String(miner.miner || "")}">${shortId(miner.miner)}</td>
-            <td><span class="chip">${miner.device_family || "Unknown"}</span></td>
-            <td>${miner.hardware_type || miner.device_arch || "Unknown"}</td>
-            <td class="mono">${miner.antiquity_multiplier || 0}x</td>
-            <td>${timeAgo(miner.last_attest)}</td>
+            <td class="mono" title="${esc(String(miner.miner || ""))}">${esc(shortId(miner.miner))}</td>
+            <td><span class="chip">${esc(miner.device_family || "Unknown")}</span></td>
+            <td>${esc(miner.hardware_type || miner.device_arch || "Unknown")}</td>
+            <td class="mono">${esc(miner.antiquity_multiplier || 0)}x</td>
+            <td>${esc(timeAgo(miner.last_attest))}</td>
           </tr>
         `);
       $("minerRows").innerHTML = rows.join("") || `<tr><td colspan="5">No miners returned.</td></tr>`;
@@ -591,10 +592,10 @@
         $("txList").innerHTML = transactions.transactions.slice(0, 8).map((tx) => `
           <div class="tx-row">
             <div class="tx-main">
-              <strong>${tx.status || tx.source || "transaction"}</strong>
-              <span class="mono">${fmt(tx.amount_rtc || 0)} RTC</span>
+              <strong>${esc(tx.status || tx.source || "transaction")}</strong>
+              <span class="mono">${esc(fmt(tx.amount_rtc || 0))} RTC</span>
             </div>
-            <div class="mini">${shortId(tx.tx_hash || tx.from || tx.miner_id || "ledger")} - ${timeAgo(tx.timestamp)}</div>
+            <div class="mini">${esc(shortId(tx.tx_hash || tx.from || tx.miner_id || "ledger"))} - ${esc(timeAgo(tx.timestamp))}</div>
           </div>
         `).join("") || `<div class="notice">Transaction endpoint returned no rows.</div>`;
         return;
@@ -646,7 +647,7 @@
         $("refreshText").textContent = `Last refresh: ${new Date().toLocaleTimeString()}`;
         $("healthChip").textContent = health.ok ? "Online" : "Degraded";
         $("healthChip").className = `chip ${health.ok ? "good" : "warn"}`;
-        $("healthBody").innerHTML = `Node version <span class="mono">${health.version || "unknown"}</span>. Uptime <span class="mono">${fmt(health.uptime_s)}</span>s. Database mode: <span class="mono">${health.db_rw ? "read/write" : "read-only"}</span>.`;
+        $("healthBody").innerHTML = `Node version <span class="mono">${esc(health.version || "unknown")}</span>. Uptime <span class="mono">${esc(fmt(health.uptime_s))}</span>s. Database mode: <span class="mono">${esc(health.db_rw ? "read/write" : "read-only")}</span>.`;
         $("apiBaseLabel").textContent = API_BASE;
 
         renderBars(miners);

--- a/otc-bridge/templates/index.html
+++ b/otc-bridge/templates/index.html
@@ -199,6 +199,7 @@
             }
         }
         
+        function esc(v){return String(v==null?'':v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
         async function loadOrders() {
             const asset = document.getElementById('filterAsset').value;
             let url = '/api/orders?status=open';
@@ -214,12 +215,12 @@
             
             container.innerHTML = result.orders.map(order => `
                 <div class="order-card">
-                    <span class="order-type ${order.order_type}">${order.order_type.toUpperCase()}</span>
-                    <div class="order-amount">${order.rtc_amount} RTC</div>
-                    <div class="order-price">@ $${order.price_per_rtc}/RTC = $${(order.rtc_amount * order.price_per_rtc).toFixed(2)} ${order.crypto_asset}</div>
-                    <div class="order-price">Expires: ${new Date(order.expires_at).toLocaleString()}</div>
+                    <span class="order-type ${esc(order.order_type)}">${esc((order.order_type || '').toUpperCase())}</span>
+                    <div class="order-amount">${esc(order.rtc_amount)} RTC</div>
+                    <div class="order-price">@ $${esc(order.price_per_rtc)}/RTC = $${esc((order.rtc_amount * order.price_per_rtc).toFixed(2))} ${esc(order.crypto_asset)}</div>
+                    <div class="order-price">Expires: ${esc(new Date(order.expires_at).toLocaleString())}</div>
                     <div class="order-actions">
-                        <button onclick="openTradeModal('${order.id}')">💱 Trade</button>
+                        <button onclick="openTradeModal('${esc(order.id)}')">💱 Trade</button>
                     </div>
                 </div>
             `).join('');
@@ -251,11 +252,11 @@
                     <tbody>
                         ${result.trades.map(t => `
                             <tr>
-                                <td>${t.trade.id.substring(0, 8)}...</td>
-                                <td>${t.trade.rtc_amount} RTC</td>
-                                <td>${t.trade.crypto_asset}</td>
-                                <td><span class="status-badge status-${t.trade.status}">${t.trade.status}</span></td>
-                                <td>${new Date(t.trade.created_at).toLocaleDateString()}</td>
+                                <td>${esc((t.trade.id || '').substring(0, 8))}...</td>
+                                <td>${esc(t.trade.rtc_amount)} RTC</td>
+                                <td>${esc(t.trade.crypto_asset)}</td>
+                                <td><span class="status-badge status-${esc(t.trade.status)}">${esc(t.trade.status)}</span></td>
+                                <td>${esc(new Date(t.trade.created_at).toLocaleDateString())}</td>
                             </tr>
                         `).join('')}
                     </tbody>

--- a/tools/rustchain-status/index.html
+++ b/tools/rustchain-status/index.html
@@ -136,6 +136,8 @@ function statusBadge(online) {
     : '<span class="badge badge-red">鈼?Offline</span>';
 }
 
+function esc(v){return String(v==null?'':v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
+
 async function refresh() {
   // 1. Health
   try {
@@ -165,18 +167,18 @@ async function refresh() {
         const mult = m.multiplier || m.antiquity_multiplier || '1.0x';
         const lastSeen = m.last_attestation || m.last_seen || '';
         html += `<tr>
-          <td style="font-family:monospace;font-size:12px">${m.miner_id || m.id || '?'}</td>
-          <td>${arch}</td>
-          <td>${typeof mult === 'number' ? mult.toFixed(1) + 'x' : mult}</td>
+          <td style="font-family:monospace;font-size:12px">${esc(m.miner_id || m.id || '?')}</td>
+          <td>${esc(arch)}</td>
+          <td>${esc(typeof mult === 'number' ? mult.toFixed(1) + 'x' : mult)}</td>
           <td>${statusBadge(m.status !== 'offline')}</td>
-          <td>${lastSeen ? fmtTime(typeof lastSeen === 'number' ? lastSeen : new Date(lastSeen)/1000) : '鈥?}</td>
+          <td>${esc(lastSeen ? fmtTime(typeof lastSeen === 'number' ? lastSeen : new Date(lastSeen)/1000) : '鈥?')</td>
         </tr>`;
       }
       html += '</table>';
     }
     document.getElementById('minersTable').innerHTML = html;
   } catch (e) {
-    document.getElementById('minersTable').innerHTML = `<div class="error-msg">Failed to load miners: ${e.message}</div>`;
+    document.getElementById('minersTable').innerHTML = `<div class="error-msg">Failed to load miners: ${esc(e.message)}</div>`;
   }
 
   // 3. Balances (try fetching for known miners)
@@ -193,7 +195,7 @@ async function refresh() {
         const bal = await fetchJSON(`${API}/wallet/balance?miner_id=${id}`);
         const balance = bal.balance || '鈥?;
         const arch = m.arch || m.architecture || '鈥?;
-        html += `<tr><td style="font-family:monospace;font-size:12px">${id}</td><td style="font-family:monospace">${balance}</td><td>${arch}</td></tr>`;
+        html += `<tr><td style="font-family:monospace;font-size:12px">${esc(id)}</td><td style="font-family:monospace">${esc(balance)}</td><td>${esc(arch)}</td></tr>`;
         rows++;
       } catch {
         // Skip miners that error
@@ -206,7 +208,7 @@ async function refresh() {
     html += '</table>';
     document.getElementById('balancesTable').innerHTML = html;
   } catch (e) {
-    document.getElementById('balancesTable').innerHTML = `<div class="error-msg">Failed to load balances: ${e.message}</div>`;
+    document.getElementById('balancesTable').innerHTML = `<div class="error-msg">Failed to load balances: ${esc(e.message)}</div>`;
   }
 
   document.getElementById('lastUpdated').textContent = `Last updated: ${new Date().toLocaleTimeString()}`;


### PR DESCRIPTION
## Summary
`otc-bridge/templates/index.html` builds the order cards and trade
history table by interpolating fields from `/api/orders` and
`/api/trade/history` directly into `innerHTML`. A compromised or
misconfigured bridge endpoint that returns HTML in fields like
`order.order_type`, `order.rtc_amount`, `order.price_per_rtc`,
`order.crypto_asset`, `order.expires_at`, `order.id`,
`t.trade.id`, `t.trade.rtc_amount`, `t.trade.crypto_asset`, or
`t.trade.status` becomes a stored XSS sink on every visit.

The `openTradeModal(orderId)` handler also embeds `order.id` inside an
`onclick="..."` attribute — escaped, otherwise a malicious id can break
out of the attribute and execute JS.

## Fix
- Add a local `esc()` helper.
- Wrap every API-controlled interpolation in the order card and trade
  table templates with `esc()`.

## Related
- Companion to #16809, #16810, #16811, #16812, #16814, #16815, #16816,
  #16817 — same pattern across other dashboards / widgets in this repo.