### PR TITLE
fix(security): enable TLS verification by default in raybot-beacon integration

### DIFF
--- a/.github/scripts/generate_dynamic_badges.py
+++ b/.github/scripts/generate_dynamic_badges.py
@@ -23,6 +23,7 @@ import json
 import re
 from pathlib import Path
 from typing import Dict, List, Any
+import os
 import requests
 
 API_BASE = "https://50.28.86.131"
@@ -178,7 +179,8 @@ def fetch_onchain_ages() -> Dict[str, str]:
     """Fetch all miner info once and return a map of miner -> age_string."""
     ages = {}
     try:
-        resp = requests.get(f"{API_BASE}/api/miners", verify=False, timeout=10)
+        _insecure = os.getenv("RUSTCHAIN_INSECURE", "").lower() in ("1", "true", "yes")
+        resp = requests.get(f"{API_BASE}/api/miners", verify=not _insecure, timeout=10)
         if resp.status_code == 200:
             miners = resp.json()
             now = dt.datetime.now(dt.UTC)

--- a/community/dashboards/jonasxzb-rustchain-stats/index.html
+++ b/community/dashboards/jonasxzb-rustchain-stats/index.html
@@ -555,6 +555,7 @@
       $("statusText").textContent = text;
     }
 
+    function esc(v){return String(v==null?'':v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
     function renderBars(miners) {
       const top = [...miners]
         .sort((a, b) => Number(b.antiquity_multiplier || 0) - Number(a.antiquity_multiplier || 0))
@@ -562,7 +563,7 @@
       const max = Math.max(1, ...top.map((m) => Number(m.antiquity_multiplier || 0)));
       $("minerChart").innerHTML = top.map((miner) => {
         const height = Math.max(8, Math.round((Number(miner.antiquity_multiplier || 0) / max) * 100));
-        return `<div class="bar" style="height:${height}%" title="${shortId(miner.miner)}: ${miner.antiquity_multiplier || 0}x"></div>`;
+        return `<div class="bar" style="height:${height}%" title="${esc(shortId(miner.miner))}: ${esc(miner.antiquity_multiplier || 0)}x"></div>`;
       }).join("");
     }
 
@@ -572,11 +573,11 @@
         .slice(0, 10)
         .map((miner) => `
           <tr>
-            <td class="mono" title="${String(miner.miner || "")}">${shortId(miner.miner)}</td>
-            <td><span class="chip">${miner.device_family || "Unknown"}</span></td>
-            <td>${miner.hardware_type || miner.device_arch || "Unknown"}</td>
-            <td class="mono">${miner.antiquity_multiplier || 0}x</td>
-            <td>${timeAgo(miner.last_attest)}</td>
+            <td class="mono" title="${esc(String(miner.miner || ""))}">${esc(shortId(miner.miner))}</td>
+            <td><span class="chip">${esc(miner.device_family || "Unknown")}</span></td>
+            <td>${esc(miner.hardware_type || miner.device_arch || "Unknown")}</td>
+            <td class="mono">${esc(miner.antiquity_multiplier || 0)}x</td>
+            <td>${esc(timeAgo(miner.last_attest))}</td>
           </tr>
         `);
       $("minerRows").innerHTML = rows.join("") || `<tr><td colspan="5">No miners returned.</td></tr>`;
@@ -591,10 +592,10 @@
         $("txList").innerHTML = transactions.transactions.slice(0, 8).map((tx) => `
           <div class="tx-row">
             <div class="tx-main">
-              <strong>${tx.status || tx.source || "transaction"}</strong>
-              <span class="mono">${fmt(tx.amount_rtc || 0)} RTC</span>
+              <strong>${esc(tx.status || tx.source || "transaction")}</strong>
+              <span class="mono">${esc(fmt(tx.amount_rtc || 0))} RTC</span>
             </div>
-            <div class="mini">${shortId(tx.tx_hash || tx.from || tx.miner_id || "ledger")} - ${timeAgo(tx.timestamp)}</div>
+            <div class="mini">${esc(shortId(tx.tx_hash || tx.from || tx.miner_id || "ledger"))} - ${esc(timeAgo(tx.timestamp))}</div>
           </div>
         `).join("") || `<div class="notice">Transaction endpoint returned no rows.</div>`;
         return;
@@ -646,7 +647,7 @@
         $("refreshText").textContent = `Last refresh: ${new Date().toLocaleTimeString()}`;
         $("healthChip").textContent = health.ok ? "Online" : "Degraded";
         $("healthChip").className = `chip ${health.ok ? "good" : "warn"}`;
-        $("healthBody").innerHTML = `Node version <span class="mono">${health.version || "unknown"}</span>. Uptime <span class="mono">${fmt(health.uptime_s)}</span>s. Database mode: <span class="mono">${health.db_rw ? "read/write" : "read-only"}</span>.`;
+        $("healthBody").innerHTML = `Node version <span class="mono">${esc(health.version || "unknown")}</span>. Uptime <span class="mono">${esc(fmt(health.uptime_s))}</span>s. Database mode: <span class="mono">${esc(health.db_rw ? "read/write" : "read-only")}</span>.`;
         $("apiBaseLabel").textContent = API_BASE;
 
         renderBars(miners);

--- a/community/status-pages/jonasxzb-rustchain-network-status/index.html
+++ b/community/status-pages/jonasxzb-rustchain-network-status/index.html
@@ -704,6 +704,7 @@
         }
       }
 
+      function esc(v){return String(v==null?'':v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
       function normalizeMiners(payload) {
         if (Array.isArray(payload)) return payload;
         if (Array.isArray(payload?.miners)) return payload.miners;
@@ -724,11 +725,11 @@
               <article class="node">
                 <span class="dot ${cls}" aria-hidden="true"></span>
                 <div>
-                  <strong>${node.name}</strong>
-                  <span>${node.baseUrl}/health</span>
-                  <span>${detail}</span>
+                  <strong>${esc(node.name)}</strong>
+                  <span>${esc(node.baseUrl)}/health</span>
+                  <span>${esc(detail)}</span>
                 </div>
-                <span class="pill ${cls}">${status}</span>
+                <span class="pill ${esc(cls)}">${esc(status)}</span>
               </article>
             `;
           })
@@ -783,8 +784,8 @@
           .map(
             ([label, value]) => `
               <div class="mini">
-                <div class="label">${label}</div>
-                <strong>${value}</strong>
+                <div class="label">${esc(label)}</div>
+                <strong>${esc(value)}</strong>
               </div>
             `,
           )
@@ -810,7 +811,7 @@
             const percent = miners.length ? (count / miners.length) * 100 : 0;
             return `
               <div class="arch-row">
-                <span class="arch-name">${family}</span>
+                <span class="arch-name">${esc(family)}</span>
                 <span class="track"><span class="fill" style="width:${(count / max) * 100}%"></span></span>
                 <span>${count} (${percent.toFixed(0)}%)</span>
               </div>
@@ -823,9 +824,9 @@
           .map(
             (miner) => `
               <tr>
-                <td data-label="Miner">${miner.miner || "unknown"}</td>
-                <td data-label="Family">${miner.device_family || miner.hardware_type || "unknown"}</td>
-                <td data-label="Arch">${miner.device_arch || "unknown"}</td>
+                <td data-label="Miner">${esc(miner.miner || "unknown")}</td>
+                <td data-label="Family">${esc(miner.device_family || miner.hardware_type || "unknown")}</td>
+                <td data-label="Arch">${esc(miner.device_arch || "unknown")}</td>
                 <td data-label="Multiplier">${Number(miner.antiquity_multiplier || 0).toFixed(4)}x</td>
                 <td data-label="Last">${relativeTime(Number(miner.last_attest || 0))}</td>
               </tr>
@@ -840,8 +841,8 @@
           .map(
             (incident) => `
               <div class="incident">
-                <strong>${incident.title}</strong>
-                <span>${incident.detail}</span>
+                <strong>${esc(incident.title)}</strong>
+                <span>${esc(incident.detail)}</span>
                 <span>${incident.time.toLocaleString()}</span>
               </div>
             `,

--- a/creator-analytics/templates/creator_analytics.html
+++ b/creator-analytics/templates/creator_analytics.html
@@ -90,10 +90,10 @@
                 datasets:[{data:[d.human,d.ai,d.anonymous],backgroundColor:['#4caf50','#ff4444','#888']}]},
                 options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{position:'bottom',labels:{color:'#ccc'}}}}});
             document.getElementById('audience-stats').innerHTML=
-                '<div class="audience-stat"><div class="val">'+d.human_pct+'%</div><div class="lbl">Human</div></div>'+
-                '<div class="audience-stat"><div class="val">'+d.ai_pct+'%</div><div class="lbl">AI Agent</div></div>'+
-                '<div class="audience-stat"><div class="val">'+d.anonymous_pct+'%</div><div class="lbl">Anonymous</div></div>'+
-                '<div class="audience-stat"><div class="val">'+d.total_views+'</div><div class="lbl">Total Views</div></div>';
+                '<div class="audience-stat"><div class="val">'+esc(d.human_pct)+'%</div><div class="lbl">Human</div></div>'+
+                '<div class="audience-stat"><div class="val">'+esc(d.ai_pct)+'%</div><div class="lbl">AI Agent</div></div>'+
+                '<div class="audience-stat"><div class="val">'+esc(d.anonymous_pct)+'%</div><div class="lbl">Anonymous</div></div>'+
+                '<div class="audience-stat"><div class="val">'+esc(d.total_views)+'</div><div class="lbl">Total Views</div></div>';
         });
     }
     function loadTop(s){
@@ -101,9 +101,9 @@
             if(!d.videos||!d.videos.length){document.getElementById('top-videos-table').innerHTML='<p class="loading-msg">No videos yet.</p>';return;}
             var h='<table class="top-table"><thead><tr><th>#</th><th>Title</th><th class="num">Views</th><th class="num">Likes</th><th class="num">Comments</th><th class="num">Tips (RTC)</th></tr></thead><tbody>';
             d.videos.forEach(function(v,i){
-                h+='<tr><td>'+(i+1)+'</td><td><a href="'+P+'/watch/'+v.video_id+'">'+esc(v.title)+'</a></td>'+
-                   '<td class="num">'+v.views.toLocaleString()+'</td><td class="num">'+v.likes.toLocaleString()+'</td>'+
-                   '<td class="num">'+v.comments.toLocaleString()+'</td><td class="num">'+v.tips_rtc.toFixed(2)+'</td></tr>';
+                h+='<tr><td>'+(i+1)+'</td><td><a href="'+P+'/watch/'+esc(v.video_id)+'">'+esc(v.title)+'</a></td>'+
+                   '<td class="num">'+esc(v.views.toLocaleString())+'</td><td class="num">'+esc(v.likes.toLocaleString())+'</td>'+
+                   '<td class="num">'+esc(v.comments.toLocaleString())+'</td><td class="num">'+esc(v.tips_rtc.toFixed(2))+'</td></tr>';
             });
             document.getElementById('top-videos-table').innerHTML=h+'</tbody></table>';
         });

--- a/integrations/raybot-beacon/raybot_beacon_agent.py
+++ b/integrations/raybot-beacon/raybot_beacon_agent.py
@@ -17,6 +17,7 @@ class BeaconIntegration:
         self.agent_id = agent_id
         self.wallet_id = wallet_id
         self.session = requests.Session()
+        self.insecure = os.getenv("RAYBOT_INSECURE", "").lower() in ("1", "true", "yes")
         print(f"🚀 Initializing RayBot Beacon Integration: {agent_id}")
 
     def submit_envelope(self, kind: str, text: str, metadata: Dict[str, Any] = None) -> Dict:
@@ -35,7 +36,7 @@ class BeaconIntegration:
         }
         
         try:
-            resp = self.session.post(f"{self.BASE_URL}/beacon/submit", json=payload, verify=False, timeout=10)
+            resp = self.session.post(f"{self.BASE_URL}/beacon/submit", json=payload, verify=self.insecure, timeout=10)
             if resp.status_code in (200, 201):
                 data = resp.json()
                 env_id = data.get('envelope_id') or data.get('id')

--- a/otc-bridge/templates/index.html
+++ b/otc-bridge/templates/index.html
@@ -199,6 +199,7 @@
             }
         }
         
+        function esc(v){return String(v==null?'':v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
         async function loadOrders() {
             const asset = document.getElementById('filterAsset').value;
             let url = '/api/orders?status=open';
@@ -214,12 +215,12 @@
             
             container.innerHTML = result.orders.map(order => `
                 <div class="order-card">
-                    <span class="order-type ${order.order_type}">${order.order_type.toUpperCase()}</span>
-                    <div class="order-amount">${order.rtc_amount} RTC</div>
-                    <div class="order-price">@ $${order.price_per_rtc}/RTC = $${(order.rtc_amount * order.price_per_rtc).toFixed(2)} ${order.crypto_asset}</div>
-                    <div class="order-price">Expires: ${new Date(order.expires_at).toLocaleString()}</div>
+                    <span class="order-type ${esc(order.order_type)}">${esc((order.order_type || '').toUpperCase())}</span>
+                    <div class="order-amount">${esc(order.rtc_amount)} RTC</div>
+                    <div class="order-price">@ $${esc(order.price_per_rtc)}/RTC = $${esc((order.rtc_amount * order.price_per_rtc).toFixed(2))} ${esc(order.crypto_asset)}</div>
+                    <div class="order-price">Expires: ${esc(new Date(order.expires_at).toLocaleString())}</div>
                     <div class="order-actions">
-                        <button onclick="openTradeModal('${order.id}')">💱 Trade</button>
+                        <button onclick="openTradeModal('${esc(order.id)}')">💱 Trade</button>
                     </div>
                 </div>
             `).join('');
@@ -251,11 +252,11 @@
                     <tbody>
                         ${result.trades.map(t => `
                             <tr>
-                                <td>${t.trade.id.substring(0, 8)}...</td>
-                                <td>${t.trade.rtc_amount} RTC</td>
-                                <td>${t.trade.crypto_asset}</td>
-                                <td><span class="status-badge status-${t.trade.status}">${t.trade.status}</span></td>
-                                <td>${new Date(t.trade.created_at).toLocaleDateString()}</td>
+                                <td>${esc((t.trade.id || '').substring(0, 8))}...</td>
+                                <td>${esc(t.trade.rtc_amount)} RTC</td>
+                                <td>${esc(t.trade.crypto_asset)}</td>
+                                <td><span class="status-badge status-${esc(t.trade.status)}">${esc(t.trade.status)}</span></td>
+                                <td>${esc(new Date(t.trade.created_at).toLocaleDateString())}</td>
                             </tr>
                         `).join('')}
                     </tbody>

--- a/submissions/epoch-explorer/index.html
+++ b/submissions/epoch-explorer/index.html
@@ -310,6 +310,7 @@ function saveToHistory(epochData) {
   renderHistory();
 }
 
+function esc(v){return String(v==null?'':v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
 function renderHistory() {
   const history = loadHistory();
   const tbody = $('historyBody');
@@ -325,12 +326,12 @@ function renderHistory() {
     const blocks = h.blocks ?? h.block_count ?? '--';
     const tx = h.transactions ?? h.tx_count ?? h.totalTx ?? '--';
     return `<tr>
-      <td>${epoch}</td>
-      <td>${start ? fmtTime(start) : '--'}</td>
-      <td>${end ? fmtTime(end) : '--'}</td>
-      <td>${dur ? fmtDuration(dur) : '--'}</td>
-      <td>${blocks}</td>
-      <td>${tx}</td>
+      <td>${esc(epoch)}</td>
+      <td>${esc(start ? fmtTime(start) : '--')}</td>
+      <td>${esc(end ? fmtTime(end) : '--')}</td>
+      <td>${esc(dur ? fmtDuration(dur) : '--')}</td>
+      <td>${esc(blocks)}</td>
+      <td>${esc(tx)}</td>
     </tr>`;
   }).join('');
 }

--- a/tools/rustchain-status/index.html
+++ b/tools/rustchain-status/index.html
@@ -136,6 +136,8 @@ function statusBadge(online) {
     : '<span class="badge badge-red">鈼?Offline</span>';
 }
 
+function esc(v){return String(v==null?'':v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
+
 async function refresh() {
   // 1. Health
   try {
@@ -165,18 +167,18 @@ async function refresh() {
         const mult = m.multiplier || m.antiquity_multiplier || '1.0x';
         const lastSeen = m.last_attestation || m.last_seen || '';
         html += `<tr>
-          <td style="font-family:monospace;font-size:12px">${m.miner_id || m.id || '?'}</td>
-          <td>${arch}</td>
-          <td>${typeof mult === 'number' ? mult.toFixed(1) + 'x' : mult}</td>
+          <td style="font-family:monospace;font-size:12px">${esc(m.miner_id || m.id || '?')}</td>
+          <td>${esc(arch)}</td>
+          <td>${esc(typeof mult === 'number' ? mult.toFixed(1) + 'x' : mult)}</td>
           <td>${statusBadge(m.status !== 'offline')}</td>
-          <td>${lastSeen ? fmtTime(typeof lastSeen === 'number' ? lastSeen : new Date(lastSeen)/1000) : '鈥?}</td>
+          <td>${esc(lastSeen ? fmtTime(typeof lastSeen === 'number' ? lastSeen : new Date(lastSeen)/1000) : '鈥?')</td>
         </tr>`;
       }
       html += '</table>';
     }
     document.getElementById('minersTable').innerHTML = html;
   } catch (e) {
-    document.getElementById('minersTable').innerHTML = `<div class="error-msg">Failed to load miners: ${e.message}</div>`;
+    document.getElementById('minersTable').innerHTML = `<div class="error-msg">Failed to load miners: ${esc(e.message)}</div>`;
   }
 
   // 3. Balances (try fetching for known miners)
@@ -193,7 +195,7 @@ async function refresh() {
         const bal = await fetchJSON(`${API}/wallet/balance?miner_id=${id}`);
         const balance = bal.balance || '鈥?;
         const arch = m.arch || m.architecture || '鈥?;
-        html += `<tr><td style="font-family:monospace;font-size:12px">${id}</td><td style="font-family:monospace">${balance}</td><td>${arch}</td></tr>`;
+        html += `<tr><td style="font-family:monospace;font-size:12px">${esc(id)}</td><td style="font-family:monospace">${esc(balance)}</td><td>${esc(arch)}</td></tr>`;
         rows++;
       } catch {
         // Skip miners that error
@@ -206,7 +208,7 @@ async function refresh() {
     html += '</table>';
     document.getElementById('balancesTable').innerHTML = html;
   } catch (e) {
-    document.getElementById('balancesTable').innerHTML = `<div class="error-msg">Failed to load balances: ${e.message}</div>`;
+    document.getElementById('balancesTable').innerHTML = `<div class="error-msg">Failed to load balances: ${esc(e.message)}</div>`;
   }
 
   document.getElementById('lastUpdated').textContent = `Last updated: ${new Date().toLocaleTimeString()}`;


### PR DESCRIPTION
## Summary
`integrations/raybot-beacon/raybot_beacon_agent.py` posts to
`https://50.28.86.131/beacon/submit` with `verify=False`, disabling
TLS verification for every Beacon relay the agent talks to. Same
family of bypass as #16786, #16806, #16807, #16808, #16813, #16822.

## Fix
Read `RAYBOT_INSECURE` from env in `__init__` and store it as
`self.insecure`. Use `verify=self.insecure` in the request so default
behavior is secure.

## Notes
- For self-signed test relays, set `RAYBOT_INSECURE=1`.