### PR TITLE
fix(security): top rungs of the xxzzzzy stack, rebased (#16826 #16827 #16828 #16829 #16833)

### DIFF
--- a/docs/beacon-integration/beacon_client.py
+++ b/docs/beacon-integration/beacon_client.py
@@ -5,6 +5,7 @@ Implements Beacon 2.6 protocol: heartbeat, mayday, and contracts
 """
 
 import requests
+import os
 import json
 import time
 from datetime import datetime
@@ -14,7 +15,7 @@ class BeaconClient:
     """Beacon 2.6 client for AI agent coordination"""
 
     def __init__(self, agent_id: str, role: str = "worker",
-                 beacon_url: str = "http://50.28.86.131:8070/beacon",
+                 beacon_url: str = os.environ.get("BEACON_URL", "https://50.28.86.131:8070/beacon"),
                  wallet_address: Optional[str] = None):
         """
         Initialize Beacon client
@@ -300,7 +301,7 @@ def demo():
     beacon = BeaconClient(
         agent_id="green-dragon-agent",
         role="worker",
-        beacon_url="http://50.28.86.131:8070/beacon",
+        beacon_url=os.environ.get("BEACON_URL", "https://50.28.86.131:8070/beacon"),
         wallet_address="BR3TzHGHWTA53Db6oHoRqes3eBnEkbjmsprTMUbvoJYs"
     )
 

--- a/otc-bridge/templates/index.html
+++ b/otc-bridge/templates/index.html
@@ -220,7 +220,7 @@
                     <div class="order-price">@ $${esc(order.price_per_rtc)}/RTC = $${esc((order.rtc_amount * order.price_per_rtc).toFixed(2))} ${esc(order.crypto_asset)}</div>
                     <div class="order-price">Expires: ${esc(new Date(order.expires_at).toLocaleString())}</div>
                     <div class="order-actions">
-                        <button onclick="openTradeModal('${esc(order.id)}')">💱 Trade</button>
+                        <button                         <button onclick="openTradeModal('${esc(order.id)}','${esc(order.order_type)}')">💱 Trade</button>
                     </div>
                 </div>
             `).join('');
@@ -272,13 +272,17 @@
             document.getElementById('statVolume').textContent = (result.total_volume_rtc || 0).toFixed(2);
         }
         
-        function openTradeModal(orderId) {
+        function openTradeModal(orderId, orderType) {
             selectedOrder = orderId;
             const modal = document.getElementById('tradeModal');
+            // orderType is supplied by the caller (now passed from the order-card button), so it can be
+            // attacker-controlled. Coerce + escape so it can't break out of the <li> or inject markup.
+            const safeType = esc(String(orderType == null ? '' : orderType));
+            const depositInstr = safeType === 'sell' ? 'ETH/ERG/USDC' : 'RTC';
             document.getElementById('tradeModalContent').innerHTML = `
                 <p>To trade, you'll need to:</p>
                 <ol style="margin: 16px 0; padding-left: 20px;">
-                    <li>Deposit ${order.order_type === 'sell' ? 'ETH/ERG/USDC' : 'RTC'} to escrow</li>
+                    <li>Deposit ${depositInstr} to escrow</li>
                     <li>Wait for counterparty to deposit</li>
                     <li>Execute atomic swap</li>
                 </ol>
@@ -315,9 +319,9 @@
             });
             
             if (result.error) {
-                alertDiv.innerHTML = `<div class="alert alert-error">${result.error}</div>`;
+                alertDiv.innerHTML = `<div class="alert alert-error">${esc(result.error)}</div>`;
             } else {
-                alertDiv.innerHTML = `<div class="alert alert-success">Order created! ID: ${result.order.id}</div>`;
+                alertDiv.innerHTML = `<div class="alert alert-success">Order created! ID: ${esc(result.order && result.order.id)}</div>`;
                 document.getElementById('createOrderForm').reset();
             }
         });

--- a/sdk/javascript/src/client.js
+++ b/sdk/javascript/src/client.js
@@ -23,16 +23,16 @@ export class RustChainClient {
    * @param {object} [opts]
    * @param {string} [opts.baseUrl] - Node RPC base URL (defaults to https://50.28.86.131).
    * @param {number} [opts.timeoutMs] - Per-request timeout. Defaults to 30s.
-   * @param {boolean} [opts.rejectUnauthorized] - TLS strictness. The public
-   *   node uses a self-signed cert; the Python SDK pins it via
-   *   ~/.rustchain/node_cert.pem. For parity we default to `false` so the
-   *   SDK works out of the box; set `true` if you have a properly trusted cert.
+   * @param {boolean} [opts.rejectUnauthorized] - TLS strictness. Defaults to
+   *   `true`. Set to `false` (or set RUSTCHAIN_INSECURE=true) only if you trust
+   *   the network path to the node and accept self-signed / invalid certs.
    * @param {typeof fetch} [opts.fetch] - Inject a custom fetch (used by tests).
    */
   constructor(opts = {}) {
     this.baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
     this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    this.rejectUnauthorized = opts.rejectUnauthorized ?? false;
+    const _insecure = (typeof process !== "undefined" && process.env && process.env.RUSTCHAIN_INSECURE && process.env.RUSTCHAIN_INSECURE.toLowerCase() !== "false");
+    this.rejectUnauthorized = !(_insecure || opts.rejectUnauthorized === false);
     this._fetch = opts.fetch ?? globalThis.fetch;
 
     if (typeof this._fetch !== "function") {

--- a/showcase/elyanlabs-upstream-contributions/index.html
+++ b/showcase/elyanlabs-upstream-contributions/index.html
@@ -143,7 +143,9 @@
 
   <script>
     const fmt = new Intl.NumberFormat('en-US');
-    const shortDate = (iso) => new Date(iso).toLocaleDateString('en-US', { year:'numeric', month:'short', day:'numeric' });
+    const shortDate
+    function esc(v){return String(v==null?'':v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
+     = (iso) => new Date(iso).toLocaleDateString('en-US', { year:'numeric', month:'short', day:'numeric' });
 
     fetch('./data.json')
       .then(r => r.json())
@@ -166,27 +168,27 @@
         ];
 
         document.getElementById('summary').innerHTML = summary.map(item => `
-          <div class="stat"><div class="k">${item.k}</div><div class="l">${item.l}</div></div>
+          <div class="stat"><div class="k">${esc(item.k)}</div><div class="l">${esc(item.l)}</div></div>
         `).join('');
 
         document.getElementById('merged-grid').innerHTML = mergedRepos.map(repo => `
           <article class="card">
             <div class="repo-head">
-              <img class="avatar" src="${repo.avatar}" alt="${repo.repo} owner avatar" loading="lazy" />
+              <img class="avatar" src="${esc(repo.avatar)}" alt="${esc(repo.repo)} owner avatar" loading="lazy" />
               <div>
-                <p class="repo-title"><a href="${repo.repo_url || `https://github.com/${repo.repo}`}" target="_blank" rel="noopener">${repo.repo}</a></p>
-                <div class="repo-meta">${repo.description || 'Open-source repository'} </div>
+                <p class="repo-title"><a href="${esc(repo.repo_url || `https://github.com/${repo.repo}`)}" target="_blank" rel="noopener">${esc(repo.repo)}</a></p>
+                <div class="repo-meta">${esc(repo.description || 'Open-source repository')} </div>
               </div>
             </div>
             <div class="chips">
-              <span class="chip ok">Merged ${repo.prs.length} PR${repo.prs.length > 1 ? 's' : ''}</span>
+              <span class="chip ok">Merged ${esc(repo.prs.length)} PR${repo.prs.length > 1 ? 's' : ''}</span>
               <span class="chip">⭐ ${fmt.format(repo.stars || 0)} stars</span>
             </div>
             <ul class="pr-list">
               ${repo.prs.sort((a,b) => (b.merged_at || '').localeCompare(a.merged_at || '')).map(pr => `
                 <li>
                   <div class="pr-top">
-                    <div class="pr-title"><a href="${pr.url}" target="_blank" rel="noopener">PR #${pr.number}</a> — ${pr.title}</div>
+                    <div class="pr-title"><a href="${esc(pr.url)}" target="_blank" rel="noopener">PR #${esc(pr.number)}</a> — ${esc(pr.title)}</div>
                     <div class="pr-date">${pr.merged_at ? shortDate(pr.merged_at) : 'Merged'}</div>
                   </div>
                 </li>
@@ -200,17 +202,17 @@
           .map(pr => `
             <article class="card">
               <div class="repo-head">
-                <img class="avatar" src="${pr.avatar}" alt="${pr.repo} owner avatar" loading="lazy" />
+                <img class="avatar" src="${esc(pr.avatar)}" alt="${esc(pr.repo)} owner avatar" loading="lazy" />
                 <div>
-                  <p class="repo-title"><a href="${pr.repo_url || `https://github.com/${pr.repo}`}" target="_blank" rel="noopener">${pr.repo}</a></p>
-                  <div class="repo-meta">${pr.description || 'Open-source repository'}</div>
+                  <p class="repo-title"><a href="${esc(pr.repo_url || `https://github.com/${pr.repo}`)}" target="_blank" rel="noopener">${esc(pr.repo)}</a></p>
+                  <div class="repo-meta">${esc(pr.description || 'Open-source repository')}</div>
                 </div>
               </div>
               <div class="chips">
-                <span class="chip warn">${pr.status}</span>
+                <span class="chip warn">${esc(pr.status)}</span>
                 <span class="chip">⭐ ${fmt.format(pr.stars || 0)} stars</span>
               </div>
-              <div class="pr-title"><a href="${pr.url}" target="_blank" rel="noopener">PR #${pr.number}</a> — ${pr.title}</div>
+              <div class="pr-title"><a href="${esc(pr.url)}" target="_blank" rel="noopener">PR #${esc(pr.number)}</a> — ${esc(pr.title)}</div>
             </article>
           `).join('');
       })

--- a/submissions/vscode-rustchain/src/walletPanel.js
+++ b/submissions/vscode-rustchain/src/walletPanel.js
@@ -113,6 +113,8 @@ class WalletPanel {
   <p class="subtitle">Monitor your wallet, miner status, and network activity</p>
   <div id="content" class="loading">Loading dashboard...</div>
   <script>
+    function esc(v){return String(v==null?'':v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
+
     (function() {
       const vscode = acquireVsCodeApi();
       window.addEventListener('message', event => {
@@ -214,7 +216,7 @@ class WalletPanel {
 
         const minerEl = document.getElementById('miner-status');
         const active = d.miner.status === 'active' || d.miner.status === 'mining';
-        minerEl.innerHTML = '<span class="badge ' + (active ? 'badge-active' : 'badge-offline') + '">' + d.miner.status + '</span>';
+        minerEl.innerHTML = '<span class="badge ' + (active ? 'badge-active' : 'badge-offline') + '">' + esc(d.miner.status) + '</span>';
         document.getElementById('miner-hashrate').textContent = 'Hashrate: ' + (d.miner.hashrate || '—') + ' | Workers: ' + (d.miner.activeWorkers || 0);
 
         document.getElementById('epoch').textContent = d.network.epoch;
@@ -225,7 +227,7 @@ class WalletPanel {
         const tbody = document.getElementById('tx-body');
         if (d.transactions && d.transactions.length > 0) {
           tbody.innerHTML = d.transactions.map(tx =>
-            '<tr><td>' + (tx.hash || '—').substring(0, 16) + '...</td><td>' + (tx.amount || '—') + '</td><td>' + (tx.type || '—') + '</td><td>' + (tx.timestamp || '—') + '</td></tr>'
+            '<tr><td>' + esc(String(tx.hash || '—').substring(0, 16)) + '...</td><td>' + esc(tx.amount || '—') + '</td><td>' + esc(tx.type || '—') + '</td><td>' + esc(tx.timestamp || '—') + '</td></tr>'
           ).join('');
         } else {
           tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--muted)">No recent transactions</td></tr>';

--- a/tests/test_otc_bridge_alert_modal_xss.py
+++ b/tests/test_otc_bridge_alert_modal_xss.py
@@ -1,0 +1,90 @@
+"""XSS regression tests for otc-bridge/templates/index.html alert + modal.
+
+Companion to the esc() patches in PR #16818. These three patches (alertDiv, button
+onclick, openTradeModal) close the residual XSS surface that PR #16818 missed:
+  * result.error and result.order.id interpolated into alertDiv.innerHTML.
+  * openTradeModal(order.id) inlined into an onclick attribute.
+  * order.order_type interpolated into the trade-modal innerHTML.
+
+Run with: pytest -q tests/test_otc_bridge_alert_modal_xss.py
+"""
+
+import pathlib
+import re
+import sys
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+TPL = REPO / "otc-bridge" / "templates" / "index.html"
+
+
+def _load_script() -> str:
+    text = TPL.read_text(encoding="utf-8")
+    s = text.index("<script>") + len("<script>")
+    e = text.rindex("</script>")
+    assert e > s
+    return text[s:e]
+
+
+SCRIPT = _load_script()
+
+def _strip_comments(src):
+    return re.sub(r"//[^\n]*", "", src)
+
+
+SCRIPT_CODE = _strip_comments(SCRIPT)
+
+
+PAT_ERR = "alertDiv\\.innerHTML\\s*=\\s*\\`<div class=\"alert alert-error\">\\${([^}]+)}</div>\\`"
+PAT_OK = "alertDiv\\.innerHTML\\s*=\\s*\\`<div class=\"alert alert-success\">Order created! ID:\\s*\\${([^}]+)}</div>\\`"
+PAT_BTN = "onclick=\"openTradeModal\\('\\${([^}]+)}','\\${([^}]+)}'\\)\""
+PAT_SIG = "function openTradeModal\\(([^)]+)\\)\\s*\\{"
+PAT_BODY = "function openTradeModal\\(orderId, orderType\\)\\s*\\{(.*?)\\n        \\}"
+
+def test_esc_helper_present():
+    assert "function esc(v)" in SCRIPT, "esc() helper missing from otc-bridge index.html"
+
+def test_alertDiv_result_error_escaped():
+    m = re.search(PAT_ERR, SCRIPT_CODE)
+    assert m, "alertDiv error block not found"
+    interp = m.group(1)
+    assert "esc(" in interp, "alertDiv error interpolation must call esc(): " + interp
+
+def test_alertDiv_order_id_escaped():
+    m = re.search(PAT_OK, SCRIPT_CODE)
+    assert m, "alertDiv success block not found"
+    interp = m.group(1)
+    assert "esc(" in interp, "alertDiv order.id interpolation must call esc(): " + interp
+
+def test_button_onclick_passes_escaped_order_type():
+    m = re.search(PAT_BTN, SCRIPT_CODE)
+    assert m, "openTradeModal button onclick pattern not found"
+    for grp in m.groups():
+        assert "esc(" in grp, "openTradeModal arg must be esc()-wrapped: " + grp
+
+def test_openTradeModal_signature_accepts_orderType():
+    m = re.search(PAT_SIG, SCRIPT_CODE)
+    assert m, "openTradeModal function not found"
+    sig = m.group(1)
+    assert "orderId" in sig and "orderType" in sig, (
+        "openTradeModal signature must accept both args: " + sig
+    )
+
+def test_openTradeModal_does_not_reference_undefined_order():
+    m = re.search(PAT_BODY, SCRIPT_CODE, flags=re.DOTALL)
+    assert m, "openTradeModal body not found"
+    body = m.group(1)
+    assert "order.order_type" not in body, (
+        "openTradeModal still references the bare `order.` identifier (undefined when called by name)"
+    )
+
+def test_openTradeModal_uses_safe_deposit_instr():
+    m = re.search(PAT_BODY, SCRIPT_CODE, flags=re.DOTALL)
+    assert m
+    body = m.group(1)
+    assert "safeType" in body, "openTradeModal must compute a safeType from esc(orderType)"
+    assert "depositInstr" in body, "openTradeModal must derive depositInstr from safeType"
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Maintainer rebase of the five remaining rungs of @xxzzzzy's security stack, each carrying ONLY its own file(s) onto current main (the lower rungs are already merged). Authorship preserved per commit.

- #16826 escape API-controlled values in the elyanlabs showcase
- #16827 HTTPS by default in beacon_client.py
- #16828 JS SDK TLS verification on by default
- #16829 escape values in the vscode-rustchain wallet panel
- #16833 escape alertDiv/openTradeModal in otc-bridge templates (+ test)

Supersedes those five PRs. Credit to @xxzzzzy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn