### PR TITLE
feat: verify bounty claims when comments arrive

### DIFF
--- a/.github/workflows/verify-bounties.yml
+++ b/.github/workflows/verify-bounties.yml
@@ -1,14 +1,27 @@
 name: Verify Bounty Claims
 
 on:
+  issue_comment:
+    types: [created]
   schedule:
     - cron: '0 */6 * * *'  # Every 6 hours
   workflow_dispatch:        # Manual trigger
 
 jobs:
   verify:
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.state == 'open' &&
+       github.event.comment.user.login != github.repository_owner &&
+       github.event.comment.user.login != 'github-actions[bot]' &&
+       (contains(github.event.comment.body, 'claim') ||
+        contains(github.event.comment.body, 'wallet:') ||
+        contains(github.event.comment.body, 'stars:') ||
+        contains(github.event.comment.body, 'github:') ||
+        contains(github.event.comment.body, 'live-url:')))
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write        # Post/update comments on issues
     steps:
       - uses: actions/checkout@v7
@@ -24,6 +37,7 @@ jobs:
         run: python scripts/verify_bounties.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           # The Actions app token gets 403 "Resource not accessible by
           # integration" from /stargazers on every repo; the star sweep needs
           # a user PAT (Metadata: read is enough). Comments still go out on

--- a/scripts/verify_bounties.py
+++ b/scripts/verify_bounties.py
@@ -3,7 +3,8 @@
 RustChain Bounty Verification Bot
 
 Auto-verifies star/badge/follow/emoji claims on rustchain-bounties issues.
-Runs as a GitHub Action every 6 hours, or manually via workflow_dispatch.
+Runs immediately for new claim comments, every 6 hours as a reconciliation
+sweep, or manually via workflow_dispatch.
 
 Checks:
   1. Star claims   - Did the user star the specified repos?
@@ -23,6 +24,7 @@ import sys
 import json
 import time
 import base64
+import html
 import re
 import logging
 from datetime import datetime, timezone
@@ -87,6 +89,11 @@ DISTRIBUTION_BOUNTY_ISSUES = [315, 16601, 16497, 282, 399, 2798, 14481]
 LIVE_URL_VERIFIED_LABEL = "live-url-verified"
 OFFPLATFORM_TIMEOUT = 20  # seconds per fetch
 OFFPLATFORM_UA = "rustchain-bounty-verify-bot/1.0 (+https://github.com/Scottcjn/rustchain-bounties)"
+ARTICLE_MIN_WORDS = 300
+ARTICLE_TOPIC_RE = re.compile(
+    r"\b(?:rustchain|proof[ -]of[ -]antiquity|elyan(?: labs)?)\b",
+    re.IGNORECASE,
+)
 
 # Bot signature so we can detect our own comments and avoid duplicates
 BOT_SIGNATURE = "<!-- bounty-verify-bot -->"
@@ -706,14 +713,24 @@ def verify_youtube_url(url: str) -> dict:
 
 
 def verify_article_url(url: str) -> dict:
-    """dev.to / hashnode / medium / hackaday: the page exists (HTTP 200)."""
+    """Verify that an article is live and contains substantive project text."""
     try:
         r = _http_get(url)
     except Exception as e:
         return _result("UNVERIFIED", f"fetch failed: {type(e).__name__}")
     if r.status_code != 200:
         return _result("UNVERIFIED", f"HTTP {r.status_code}")
-    return _result("VERIFIED", "HTTP 200")
+    page = re.sub(r"(?is)<(?:script|style)[^>]*>.*?</(?:script|style)>", " ", r.text)
+    text = html.unescape(re.sub(r"(?s)<[^>]+>", " ", page))
+    words = re.findall(r"\b[\w'-]+\b", text, flags=re.UNICODE)
+    if len(words) < ARTICLE_MIN_WORDS:
+        return _result(
+            "UNVERIFIED",
+            f"HTTP 200 but only {len(words)} words (minimum {ARTICLE_MIN_WORDS})",
+        )
+    if not ARTICLE_TOPIC_RE.search(text):
+        return _result("UNVERIFIED", f"{len(words)} words but no RustChain topic marker")
+    return _result("VERIFIED", f"HTTP 200 · {len(words)} words · topic marker present")
 
 
 PLATFORM_VERIFIERS = {
@@ -857,11 +874,62 @@ def run_phase(name: str, issues: list[int], runner) -> list[str]:
     return failures
 
 
+def run_targeted_issue(issue_number: int) -> list[str]:
+    """Run only the verifier configured for one issue-comment event.
+
+    A comment webhook must not launch the expensive all-repository star sweep
+    unless the comment belongs to a star bounty. The scheduled run remains the
+    reconciliation backstop for missed events and transient API failures.
+    """
+    if not is_issue_open(issue_number):
+        return []
+
+    if issue_number in STAR_BOUNTY_ISSUES:
+        try:
+            all_stars = get_all_stargazers()
+        except IncompleteSweep as e:
+            return [f"targeted star verification #{issue_number}: {e}"]
+        return run_phase(
+            "Targeted star bounty",
+            [issue_number],
+            lambda issue: verify_star_claims(issue, all_stars),
+        )
+    if issue_number in BADGE_BOUNTY_ISSUES:
+        return run_phase("Targeted badge bounty", [issue_number], verify_badge_claims)
+    if issue_number in FOLLOW_BOUNTY_ISSUES:
+        return run_phase("Targeted follow bounty", [issue_number], verify_follow_claims)
+    if issue_number in EMOJI_BOUNTY_ISSUES:
+        return run_phase("Targeted emoji bounty", [issue_number], verify_emoji_claims)
+    if issue_number in DISTRIBUTION_BOUNTY_ISSUES:
+        return run_phase(
+            "Targeted distribution bounty",
+            [issue_number],
+            verify_distribution_claims,
+        )
+
+    log.info("Issue #%d has no configured automatic verifier; skipping", issue_number)
+    return []
+
+
 def main() -> int:
     log.info("=" * 60)
     log.info("RustChain Bounty Verification Bot starting")
     log.info("Owner: %s | Bounty repo: %s", OWNER, BOUNTY_REPO)
     log.info("=" * 60)
+
+    event_issue = os.environ.get("EVENT_ISSUE_NUMBER", "").strip()
+    if event_issue:
+        try:
+            issue_number = int(event_issue)
+        except ValueError:
+            log.error("EVENT_ISSUE_NUMBER must be an integer, got %r", event_issue)
+            return 2
+        failures = run_targeted_issue(issue_number)
+        if failures:
+            for failure in failures:
+                log.error("  - %s", failure)
+            return 1
+        return 0
 
     failures: list[str] = []
 

--- a/tests/test_verify_bounties.py
+++ b/tests/test_verify_bounties.py
@@ -6,6 +6,7 @@ import sys
 import types
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 def load_verify_bounties():
@@ -98,6 +99,41 @@ class TestVerifyBounties(unittest.TestCase):
             claimants[1]["wallet"],
             "6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2",
         )
+
+    def test_targeted_distribution_event_does_not_fetch_stargazers(self):
+        mod = load_verify_bounties()
+        with patch.object(mod, "is_issue_open", return_value=True), \
+             patch.object(mod, "verify_distribution_claims") as verify, \
+             patch.object(mod, "get_all_stargazers") as get_stars:
+            failures = mod.run_targeted_issue(mod.DISTRIBUTION_BOUNTY_ISSUES[0])
+
+        self.assertEqual(failures, [])
+        verify.assert_called_once_with(mod.DISTRIBUTION_BOUNTY_ISSUES[0])
+        get_stars.assert_not_called()
+
+    def test_targeted_unknown_issue_is_a_clean_noop(self):
+        mod = load_verify_bounties()
+        with patch.object(mod, "is_issue_open", return_value=True), \
+             patch.object(mod, "get_all_stargazers") as get_stars:
+            failures = mod.run_targeted_issue(999999)
+
+        self.assertEqual(failures, [])
+        get_stars.assert_not_called()
+
+    def test_zero_star_claim_is_reported_as_unverified(self):
+        mod = load_verify_bounties()
+        comments = [{
+            "id": 1,
+            "user": {"login": "alice"},
+            "body": "/claim\nWallet: RTCC8CDAA67B90F9B06987135B8B65AB037BFB603A9",
+        }]
+        posted = []
+        with patch.object(mod, "get_issue_comments", return_value=comments), \
+             patch.object(mod, "post_comment", side_effect=lambda n, b: posted.append((n, b))):
+            mod.verify_star_claims(1, {repo: set() for repo in mod.STAR_REPOS})
+
+        self.assertEqual(len(posted), 1)
+        self.assertIn(f"| @alice | 0/{len(mod.STAR_REPOS)} | None | No stars found |", posted[0][1])
 
 
 if __name__ == "__main__":

--- a/tests/test_verify_bounties_distribution.py
+++ b/tests/test_verify_bounties_distribution.py
@@ -143,9 +143,27 @@ class ArticleVerifier(unittest.TestCase):
     def setUp(self):
         self.mod = load_verify_bounties()
 
-    def test_200_verified_else_unverified(self):
-        install_http(self.mod, lambda u, p: FakeResponse(200))
-        self.assertEqual(self.mod.verify_article_url("https://dev.to/a/b")["status"], "VERIFIED")
+    def test_200_substantive_on_topic_article_is_verified(self):
+        article = "<article><h1>RustChain</h1><p>" + ("evidence " * 305) + "</p></article>"
+        install_http(self.mod, lambda u, p: FakeResponse(200, text=article))
+        result = self.mod.verify_article_url("https://dev.to/a/b")
+        self.assertEqual(result["status"], "VERIFIED")
+        self.assertIn("words", result["metric"])
+        self.assertIn("topic marker present", result["metric"])
+
+    def test_short_or_off_topic_article_is_unverified(self):
+        install_http(self.mod, lambda u, p: FakeResponse(200, text="<p>RustChain short post</p>"))
+        result = self.mod.verify_article_url("https://dev.to/a/b")
+        self.assertEqual(result["status"], "UNVERIFIED")
+        self.assertIn("minimum 300", result["metric"])
+
+        off_topic = "<article>" + ("unrelated " * 305) + "</article>"
+        install_http(self.mod, lambda u, p: FakeResponse(200, text=off_topic))
+        result = self.mod.verify_article_url("https://dev.to/a/b")
+        self.assertEqual(result["status"], "UNVERIFIED")
+        self.assertIn("no RustChain topic marker", result["metric"])
+
+    def test_non_200_or_network_error_is_unverified(self):
         install_http(self.mod, lambda u, p: FakeResponse(404))
         self.assertEqual(self.mod.verify_article_url("https://dev.to/a/b")["status"], "UNVERIFIED")
         install_http(self.mod, lambda u, p: ConnectionError())
@@ -175,7 +193,8 @@ class DistributionPhase(unittest.TestCase):
             {"id": 2, "user": {"login": "bob"}, "body": "Live-URL: https://gist.github.com/bob/x"},
             {"id": 3, "user": {"login": "carol"}, "body": "posting now, will update"},
         )
-        install_http(self.mod, lambda u, p: FakeResponse(200))
+        article = "<article>RustChain " + ("evidence " * 305) + "</article>"
+        install_http(self.mod, lambda u, p: FakeResponse(200, text=article))
         self.mod.verify_distribution_claims(2798)
         self.assertEqual(len(self.posted), 1)
         self.assertEqual(self.updated, [])
@@ -198,11 +217,25 @@ class DistributionPhase(unittest.TestCase):
             {"id": 9, "user": {"login": "github-actions[bot]"}, "body": f"{self.mod.BOT_SIGNATURE}\nold"},
             {"id": 1, "user": {"login": "alice"}, "body": "Live-URL: https://dev.to/a/p"},
         )
-        install_http(self.mod, lambda u, p: FakeResponse(200))
+        article = "<article>RustChain " + ("evidence " * 305) + "</article>"
+        install_http(self.mod, lambda u, p: FakeResponse(200, text=article))
         self.mod.verify_distribution_claims(399)
         self.assertEqual(self.posted, [])
         self.assertEqual(len(self.updated), 1)
         self.assertEqual(self.updated[0][0], 9)
+
+    def test_same_user_and_url_claim_is_verified_once(self):
+        self._comments(
+            {"id": 1, "user": {"login": "alice"}, "body": "Live-URL: https://dev.to/a/p"},
+            {"id": 2, "user": {"login": "Alice"}, "body": "/claim\nLive-URL: https://dev.to/a/p"},
+        )
+        article = "<article>Proof of Antiquity " + ("evidence " * 305) + "</article>"
+        calls = install_http(self.mod, lambda u, p: FakeResponse(200, text=article))
+
+        self.mod.verify_distribution_claims(399)
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("Checked **1** `Live-URL:` claim(s)", self.posted[0][1])
 
     def test_no_live_url_claims_posts_nothing(self):
         self._comments({"id": 1, "user": {"login": "alice"}, "body": "/claim"})

--- a/tests/test_verify_bounties_incomplete_sweep.py
+++ b/tests/test_verify_bounties_incomplete_sweep.py
@@ -48,7 +48,7 @@ def install_pages(mod, pages):
     """Make gh_get walk `pages` (a list of FakeResponse) in order."""
     calls = {"n": 0}
 
-    def fake_get(url, params=None):
+    def fake_get(url, params=None, session=None):
         i = calls["n"]
         calls["n"] += 1
         return pages[i] if i < len(pages) else FakeResponse(200, [])


### PR DESCRIPTION
## Summary
- run the configured verifier when a new claim or evidence comment arrives
- route comment events to only the matching bounty verifier while keeping the six-hour reconciliation sweep
- fail article verification closed unless the page has at least 300 words and a RustChain topic marker
- preserve idempotent reports and cover same-user/same-URL deduplication and zero-star claims

## Why
The existing scheduled workflow can leave new claims waiting for up to six hours and runs unrelated verification phases. Event-targeted execution reacts promptly without launching the full stargazer sweep for non-star bounties.

## Tests
- `python -m unittest tests.test_verify_bounties tests.test_verify_bounties_distribution tests.test_verify_bounties_incomplete_sweep` (36 passed)
- workflow YAML parsed with PyYAML

Refs #747

RTC wallet: `RTCc8cdaa67b90f9b06987135b8b65ab037bfb603a9`