### PR TITLE
backfill: fail closed on gh issue-list failure (#16471)

### DIFF
--- a/scripts/pr_review_gate_backfill.py
+++ b/scripts/pr_review_gate_backfill.py
@@ -56,17 +56,32 @@ def _load_gate():
 
 
 def list_unprocessed(gate):
-    """Open review claims that carry neither the processed label nor a verdict."""
-    out = subprocess.run(
+    """Open review claims that carry neither the processed label nor a verdict.
+
+    Authoritative issue enumeration must fail CLOSED. `gh issue list` failing
+    (auth, rate-limit, 5xx, network) or returning unparseable JSON must NOT be
+    read as "zero open claims" -- that would silently strand every unprocessed
+    claim while this safety-net run reports success. Any failure here exits the
+    process non-zero so the backlog forces a retry instead of looking handled.
+    Reported by @bgrubbs1 under #16471; same failure shape as the cap-lookup
+    fix in test_pr_review_gate_cap_fails_closed.py -- check the effect, not the
+    exit code.
+    """
+    proc = subprocess.run(
         ["gh", "issue", "list", "-R", REPO, "--state", "open",
          "--limit", "1000", "--json", "number,title,labels"],
         capture_output=True, text=True, timeout=180,
-    ).stdout
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()[:200]
+        print(f"::error::gh issue list failed (exit {proc.returncode}): {detail}",
+              file=sys.stderr)
+        sys.exit(1)
     try:
-        issues = json.loads(out or "[]")
-    except json.JSONDecodeError:
-        print("::error::could not parse issue list", file=sys.stderr)
-        return []
+        issues = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        print(f"::error::could not parse issue list as JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     never, stranded = [], []
     for i in issues:

--- a/tests/test_pr_review_gate_backfill.py
+++ b/tests/test_pr_review_gate_backfill.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: MIT
+"""The PR-review-gate backfill sweep must fail CLOSED on issue enumeration.
+
+`list_unprocessed()` used to read `subprocess.run(...).stdout` and discard the
+return code, so a failed `gh issue list` (auth, rate-limit, 5xx, network) or
+truncated JSON on a zero exit became an empty list -> "zero open claims" -> a
+green run that adjudicated nothing while every unprocessed claim stayed
+stranded. That is this project's signature failure shape: reports success while
+doing nothing. Reported by @bgrubbs1 under #16471.
+
+These tests pin that authoritative enumeration failure exits non-zero, while a
+genuine empty result on a successful exit is still treated as a real zero.
+"""
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def load_backfill():
+    script = (
+        Path(__file__).resolve().parents[1] / "scripts" / "pr_review_gate_backfill.py"
+    )
+    spec = importlib.util.spec_from_file_location("pr_review_gate_backfill_test", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeGate:
+    """Minimal stand-in for the gate module's is_review_claim() classifier."""
+
+    @staticmethod
+    def is_review_claim(title):
+        return title.startswith("Bounty #73 claim")
+
+
+def _completed(returncode, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["gh", "issue", "list"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_gh_nonzero_exit_fails_closed(monkeypatch):
+    """gh issue list failing with empty stdout must NOT read as zero claims."""
+    mod = load_backfill()
+    monkeypatch.setattr(
+        mod.subprocess, "run", lambda *a, **k: _completed(1, stdout="", stderr="HTTP 503")
+    )
+    with pytest.raises(SystemExit) as exc:
+        mod.list_unprocessed(FakeGate())
+    assert exc.value.code == 1
+
+
+def test_malformed_json_on_success_fails_closed(monkeypatch):
+    """Exit 0 with truncated/garbage JSON must NOT read as zero claims."""
+    mod = load_backfill()
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: _completed(0, stdout="{"))
+    with pytest.raises(SystemExit) as exc:
+        mod.list_unprocessed(FakeGate())
+    assert exc.value.code == 1
+
+
+def test_empty_issue_list_on_success_is_a_real_zero(monkeypatch):
+    """A genuine empty list on a zero exit is a real zero, not a failure."""
+    mod = load_backfill()
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: _completed(0, stdout="[]"))
+    never, stranded = mod.list_unprocessed(FakeGate())
+    assert never == []
+    assert stranded == []
+
+
+def test_normal_path_partitions_claims(monkeypatch):
+    """The fix must not break normal classification of open claims."""
+    mod = load_backfill()
+    issues = [
+        {"number": 5, "title": "Bounty #73 claim: review of PR #100", "labels": []},
+        {"number": 6, "title": "Bounty #73 claim: review of PR #101",
+         "labels": [{"name": "needs-human"}]},
+        {"number": 7, "title": "Bounty #73 claim: review of PR #102",
+         "labels": [{"name": "bounty-eligible"}]},
+        {"number": 8, "title": "unrelated issue", "labels": []},
+    ]
+    monkeypatch.setattr(
+        mod.subprocess, "run", lambda *a, **k: _completed(0, stdout=json.dumps(issues))
+    )
+    never, stranded = mod.list_unprocessed(FakeGate())
+    assert never == [5]        # unlabeled review claim -> never adjudicated
+    assert stranded == [6]     # needs-human -> re-drive
+    # #7 (bounty-eligible) is done; #8 is not a review claim -> both excluded


### PR DESCRIPTION
## Fail closed on issue enumeration in the PR-review-gate backfill (#16471)

### Problem
`scripts/pr_review_gate_backfill.py` is the safety net that re-drives the #73 gate over review claims the on-arrival gate missed. Its `list_unprocessed()` read `subprocess.run(...).stdout` and **discarded the return code**:

```python
out = subprocess.run([...], capture_output=True, text=True, timeout=180).stdout
issues = json.loads(out or "[]")
```

Two failure modes silently became an authoritative empty queue:
1. `gh issue list` exits non-zero with empty stdout (auth, rate-limit, 5xx, network) → `json.loads("" or "[]")` → `[]`.
2. `gh` exits zero but stdout is malformed/truncated JSON → `JSONDecodeError` branch returned `[]`.

Either way `main()` computed `total = 0`, adjudicated nothing, and **returned 0 (green)** — during exactly the kind of API failure that creates the backlog this script exists to clear. This is the repo's signature failure shape ("reports success while doing nothing"); it's the same class as the cap-lookup bug already pinned by `tests/test_pr_review_gate_cap_fails_closed.py`.

### Fix
- Keep the `CompletedProcess`; check `returncode` before parsing.
- Non-zero exit → bounded `::error::` diagnostic + `sys.exit(1)` (fail closed).
- `JSONDecodeError` → `::error::` + `sys.exit(1)`, instead of returning `[]`.
- A genuine empty list on a **zero** exit is still treated as a real zero.

### Tests
Adds `tests/test_pr_review_gate_backfill.py` (4 cases, all passing): non-zero exit fails closed, malformed-JSON-on-success fails closed, empty-list-on-success is a real zero, and the normal claim-partitioning path is unchanged.

### Attribution
Reported by **@bgrubbs1** (bgrubbs@vt.edu) via the documented email fallback under bounty **#16471**. Payout is the maintainer's call — flagging the reporter for settlement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
