### PR TITLE
gate: fail closed when inline-comment lookup fails (#16471)

### DIFF
--- a/scripts/pr_review_gate.py
+++ b/scripts/pr_review_gate.py
@@ -369,7 +369,34 @@ def main():
         _unresolved(f"🤖 Gate: couldn't read reviews for {target}#{pr} (private/deleted?). Flagged for human review.", quiet); return
     rv=[r for r in reviews if r.get("submitted_at")]
     rv.sort(key=lambda r:r["submitted_at"])
-    inl = api(f"/repos/{target}/pulls/{pr}/comments?per_page=100") or []
+    # Inline comments are money-decision evidence: is_substantive_review()
+    # treats inline_count > 0 as a positive signal, so a failed read that
+    # silently became [] could drop a real first substantive reviewer (paying
+    # the wrong person) OR close a valid short-summary claim as a rubber stamp.
+    # STRICT: a failed/unreadable lookup holds the claim for a human instead of
+    # adjudicating on a false "zero inline comments". Reported by @bgrubbs1
+    # under #16471; same remedy as the cap lookup below.
+    try:
+        inl = api(f"/repos/{target}/pulls/{pr}/comments?per_page=100",
+                  strict=True) or []
+    except ApiError as e:
+        print(f"gate: inline-comment lookup failed, refusing to adjudicate: {e}",
+              file=sys.stderr)
+        _unresolved(
+            f"🤖 Gate: couldn't read the inline review comments for {target}#{pr}, and "
+            f"those decide whether a review is substantive and who reviewed first. Holding "
+            f"for a human rather than risk approving the wrong claimant or closing a valid "
+            f"one — a failed read is not proof there were zero inline comments. Nothing is "
+            f"needed from you.", quiet)
+        return
+    if not isinstance(inl, list):
+        print("gate: inline-comment lookup returned a non-list shape; holding for human",
+              file=sys.stderr)
+        _unresolved(
+            f"🤖 Gate: the inline review comments for {target}#{pr} came back in an "
+            f"unexpected shape, so substantiveness can't be judged reliably. Holding for "
+            f"a human.", quiet)
+        return
     # Per-author inline counts (so the rubber-stamp filter is per-review).
     author_inline = {}
     for c in inl:

--- a/tests/test_pr_review_gate_inline_fails_closed.py
+++ b/tests/test_pr_review_gate_inline_fails_closed.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: MIT
+"""The #73 gate must fail CLOSED when it cannot read inline review comments.
+
+`is_substantive_review()` treats inline_count > 0 as a positive signal, so the
+inline-comments lookup is money-decision evidence. It used to be read with the
+non-strict helper and `or []`, so an HTTP 403/429/5xx became "zero inline
+comments" -- indistinguishable from a real empty result. That could:
+  1. drop a genuine first substantive reviewer (whose findings are inline) and
+     approve a later reviewer for the RTC, or
+  2. close a valid short-summary + inline-comments claim as a rubber stamp.
+Both complete on a green run. Reported by @bgrubbs1 under #16471.
+
+This test proves a failed inline-comments lookup holds the claim for a human
+and neither approves nor closes it.
+"""
+import importlib.util
+from pathlib import Path
+
+
+def load_gate():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "pr_review_gate.py"
+    spec = importlib.util.spec_from_file_location("pr_review_gate_inlinefix", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+AUTHOR = "alice"
+PR = "1396"
+SHORT_BODY = "See inline findings."
+
+
+class FakeApi:
+    """api() stand-in whose inline-comments lookup fails with an HTTP error."""
+
+    def __init__(self, api_error):
+        self._api_error = api_error
+        self.labels = []
+        self.comments = []
+        self.patches = []
+
+    def __call__(self, path, method="GET", data=None, strict=False):
+        if method == "POST" and path.endswith("/labels"):
+            self.labels.extend(data["labels"])
+            return {}
+        if method == "POST" and path.endswith("/comments"):
+            self.comments.append(data["body"])
+            return {}
+        if method == "PATCH":
+            self.patches.append(data)
+            return {}
+        if "/pulls/" in path and path.endswith("/reviews"):
+            return [{
+                "user": {"login": AUTHOR},
+                "body": SHORT_BODY,
+                "submitted_at": "2026-08-01T00:00:00Z",
+            }]
+        if "/pulls/" in path and "/comments" in path:
+            # The authoritative inline-comment read fails. Strict callers must
+            # get an ApiError, not a swallowed None -> [].
+            if strict:
+                raise self._api_error("GET /pulls/.../comments -> HTTP 403")
+            return None
+        if path.startswith("/search/issues"):
+            return {"total_count": 0}
+        if path.endswith("/issues/42"):
+            return {
+                "state": "open",
+                "labels": [],
+                "title": f"Bounty #73 claim: review of PR #{PR}",
+                "body": "wallet RTC" + "a" * 40,
+                "user": {"login": AUTHOR},
+            }
+        raise AssertionError(f"unexpected API call: {method} {path}")
+
+
+def run_gate():
+    mod = load_gate()
+    mod.NUM = "42"
+    mod.REPO = "Scottcjn/rustchain-bounties"
+    mod.TARGET = "Scottcjn/Rustchain"
+    fake = FakeApi(mod.ApiError)
+    mod.api = fake
+    mod.main()
+    return mod, fake
+
+
+def test_inline_lookup_failure_holds_for_human():
+    _, fake = run_gate()
+
+    assert "needs-human" in fake.labels, (
+        "a failed inline-comment read must hold the claim for a human"
+    )
+    assert "bounty-eligible" not in fake.labels, (
+        "must not approve when the substantiveness evidence could not be read"
+    )
+    assert not any(p.get("state") == "closed" for p in fake.patches), (
+        "must not close a valid claim just because the inline read failed"
+    )


### PR DESCRIPTION
## Fail closed when the inline-comment lookup fails (#16471)

### Problem
`scripts/pr_review_gate.py` read PR inline review comments with the non-strict helper:

```python
inl = api(f"/repos/{target}/pulls/{pr}/comments?per_page=100") or []
```

`api()` returns `None` on an HTTP error for non-strict GETs, so `or []` turns a **failed read into "zero inline comments"** — indistinguishable from a real empty result. Since `is_substantive_review()` treats `inline_count > 0` as a positive signal, a transient 403/429/5xx on that endpoint can, on a **green run**:
1. drop a genuine first substantive reviewer (whose findings are inline) and approve a *later* reviewer for the RTC, or
2. close a valid short-summary + inline-comments claim as a rubber stamp (`if inline == 0 and body_len < 120: close(...)`).

### Fix
Read the inline comments with `strict=True` and, on `ApiError` or a non-list shape, route to `_unresolved()` (needs-human hold) instead of adjudicating on a false zero — the same fail-closed pattern already used for the reviews read and the cap lookup.

### Tests
Adds `tests/test_pr_review_gate_inline_fails_closed.py`: a failing inline-comment lookup must hold for a human and neither approve nor close. All 26 existing gate tests still pass.

### Attribution
Reported by **@bgrubbs1** (bgrubbs@vt.edu) under bounty **#16471** (his 2nd/3rd findings; the first is #16878). Payout is the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
