### PR TITLE
docs(contributing): clarify repository setup and scoped smoke check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,17 +127,57 @@ Only `@Scottcjn` (or a clearly labeled project automation account speaking on hi
 
 ## 🔧 Development Setup
 
+### Choose the repository and component first
+
+This repository contains the bounty board and multiple independent tools and
+examples, not a single application with one install or test command. Check the
+bounty's target repository and the component's README before installing anything.
+The steps below are for contributors working in `rustchain-bounties` itself.
+
+### Clone your fork
+
+Install Git, fork this repository on GitHub, then replace `YOUR_GITHUB_USERNAME`
+with the owner of your fork in the following Bash commands:
+
 ```bash
-# Clone your fork
-git clone https://github.com/Scottcjn/rustchain-bounties.git
+git clone https://github.com/YOUR_GITHUB_USERNAME/rustchain-bounties.git
 cd rustchain-bounties
-
-# Install dependencies
-npm install  # or cargo build (for Rust components)
-
-# Run tests
-npm test     # or cargo test
+git switch -c docs/contributor-setup
 ```
+
+Run the following check from the repository root, not from inside `tests/`.
+
+### Run a dependency-free Python smoke check
+
+With Python 3 installed, exercise the existing bounty-claimer helper tests:
+
+```bash
+python3 -m unittest discover -s tests -p 'test_bounty_claimer.py' -v
+```
+
+The two tests in [tests/test_bounty_claimer.py](tests/test_bounty_claimer.py)
+exercise the real [claim formatter](agent_framework/bounty_claimer.py) and its
+CLI failure handling. Expect both tests to pass and the summary to end in `OK`.
+They mock the `gh` subprocess, so this check does not post a claim and needs no
+GitHub CLI, credentials, wallet, live node, or third-party Python packages.
+Do not run the helper itself as a smoke check: it posts a real issue comment.
+
+### Validate the component you change
+
+The smoke check above is not a full-repository test suite. For another component,
+follow its own README, dependency manifest, and applicable workflow under
+[.github/workflows](.github/workflows) and run the checks for your change.
+Install only that component's dependencies, using an isolated environment where
+appropriate.
+
+The root [package.json](package.json) describes a VS Code extension and defines
+`compile` and `watch`, but no `test` script; `npm test` at the repository root
+fails with `Missing script: "test"`. There is no root `Cargo.toml` either, so
+`cargo build` and `cargo test` are not repository-wide setup commands.
+
+For documentation changes, execute the commands you introduce and check their
+paths and expected output. In your PR, report the exact checks and their scope;
+a passing offline test does not establish that a build or live integration works.
 
 ## 📝 Commit Message Convention
 


### PR DESCRIPTION
The Development Setup section now clones the contributor's fork and provides the existing dependency-free Python smoke check. It explains why the root npm and Cargo commands are not repository-wide setup commands. Only this section of CONTRIBUTING.md changes.

Preserved validation: two existing bounty-claimer tests passed in an isolated Python 3.13.5 environment without third-party dependencies; forward/reverse patch application, byte round-trip, and whitespace checks passed. These results cover the documentation command and mocked CLI behavior, not a full build or live integrations. No tests were rerun while preparing this PR.

Contributor and RTC wallet name: woahwhattheheck. AI/automation disclosure: Bryce's authorized ChatGPT agent prepared the original documentation and checks; this submission was prepared with Codex automation. Exact source packet: https://github.com/woahwhattheheck/commons/tree/069544d00703c0e5fe693d1b084894bb7cdf1474/contributions/rustchain-bounties-100-onboarding.

Related: #100, one documentation improvement rather than a discovery-starter claim. Current upstream main matches the packet base 9ef595b315709cd2c9610a5092b40417288dfa8b. The omnibus bounty tracker remains open; acceptance and payment are not asserted.