### PR TITLE
payout: fail closed when CLAIMANTS.md is unreadable (#16471)

### DIFF
--- a/scripts/bounty_payout.py
+++ b/scripts/bounty_payout.py
@@ -105,13 +105,29 @@ def _find_handle_in_text(text):
         if m:
             return m.group(1)
     return None
+class CanonicalRegistryError(RuntimeError):
+    """docs/CLAIMANTS.md exists but could not be read/parsed.
+
+    Never degrade this into an empty map: a registered contributor would then
+    fall through to an older wallet or bare handle and be paid to the WRONG
+    destination, silently, on a green run.
+    """
+
+
 def _load_canonical_wallets():
     """Parse docs/CLAIMANTS.md into {handle_lower: native_RTC_wallet}.
 
     Canonical registry: a handle listed here is ALWAYS paid to its registered
     native wallet, regardless of what an individual claim body says. Only native
-    `RTC[0-9a-fA-F]{40}` rows are honored. Missing/garbled file -> empty map
-    (resolution falls back to per-claim parsing).
+    `RTC[0-9a-fA-F]{40}` rows are honored.
+
+    Fail-closed contract (reported by @Nish916 under #16471):
+      - File genuinely ABSENT -> empty map is fine; no registry is configured,
+        so resolution falls back to per-claim parsing.
+      - File PRESENT but unreadable/unparseable (encoding, OS, partial read) ->
+        raise CanonicalRegistryError. Returning a partial/empty map here would
+        violate the "canonical registry ALWAYS wins" invariant and misroute a
+        registered contributor's payout while the run still reports success.
     """
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "docs", "CLAIMANTS.md")
     out = {}
@@ -128,9 +144,16 @@ def _load_canonical_wallets():
                 if handle and m and not handle.lower().startswith(("github handle", "---")):
                     out[handle.lower()] = m.group(0)
     except FileNotFoundError:
-        pass
+        # No registry configured for this repo -> per-claim resolution only.
+        return {}
     except Exception as e:
-        print(f"::warning::could not parse CLAIMANTS.md: {e}")
+        # The file exists but could not be read/parsed. Fail closed: abort
+        # before any transfer rather than pay a registered contributor to a
+        # stale wallet or bare handle.
+        raise CanonicalRegistryError(
+            f"docs/CLAIMANTS.md exists but could not be parsed: "
+            f"{e.__class__.__name__}: {e}"
+        ) from e
     return out
 
 

--- a/tests/test_bounty_payout_canonical_fails_closed.py
+++ b/tests/test_bounty_payout_canonical_fails_closed.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""The canonical wallet registry must fail CLOSED when it can't be read.
+
+`_load_canonical_wallets()` used to catch every non-FileNotFoundError, print a
+warning, and return a partial/empty map. `resolve_wallet()` then fell through to
+an older native wallet or bare handle -- so a transient read/parse failure on
+docs/CLAIMANTS.md could pay a REGISTERED contributor to the WRONG destination
+while the run reported success, violating the "canonical registry ALWAYS wins"
+invariant. Reported by @Nish916 under #16471.
+
+Fail-closed contract pinned here:
+  - file genuinely ABSENT  -> {} (no registry; per-claim resolution is fine)
+  - file PRESENT but unreadable/unparseable -> raise CanonicalRegistryError
+    (abort before any transfer)
+"""
+import importlib.util
+import io
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+os.environ.setdefault("GITHUB_TOKEN", "dummy")
+os.environ.setdefault("RTC_ADMIN_KEY", "dummy")
+os.environ.setdefault("RTC_VPS_HOST", "127.0.0.1")
+os.environ.setdefault("GH_REPO", "owner/repo")
+os.environ.setdefault("RATE_RTC", "3")
+os.environ.setdefault("MAX_PER_RUN", "40")
+
+_orig_run = subprocess.run
+
+
+def _stub_run(*a, **kw):
+    class _R:
+        stdout = "[]"
+        stderr = ""
+        returncode = 0
+    return _R()
+
+
+subprocess.run = _stub_run
+try:
+    REPO_ROOT = Path(__file__).resolve().parent.parent
+    SCRIPT = REPO_ROOT / "scripts" / "bounty_payout.py"
+    spec = importlib.util.spec_from_file_location("bounty_payout_canon_test", SCRIPT)
+    bp = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(bp)
+finally:
+    subprocess.run = _orig_run
+
+
+NATIVE_WALLET = "RTC" + "0" * 40
+
+
+def _fake_open_ok(*a, **k):
+    return io.StringIO(
+        "| GitHub Handle | Native RTC Wallet |\n"
+        "|---|---|\n"
+        f"| alice | {NATIVE_WALLET} |\n"
+    )
+
+
+class CanonicalRegistryFailClosedTests(unittest.TestCase):
+    def test_existing_but_unreadable_raises(self):
+        """An OS/read error on an existing file must abort, not return {}."""
+        with patch("builtins.open", side_effect=OSError("disk error")):
+            with self.assertRaises(bp.CanonicalRegistryError):
+                bp._load_canonical_wallets()
+
+    def test_unicode_error_raises(self):
+        """A decode error (corrupt/garbled file) must abort, not return {}."""
+        err = UnicodeDecodeError("utf-8", b"", 0, 1, "bad byte")
+        with patch("builtins.open", side_effect=err):
+            with self.assertRaises(bp.CanonicalRegistryError):
+                bp._load_canonical_wallets()
+
+    def test_missing_file_returns_empty(self):
+        """A genuinely absent registry is fine -> {} (per-claim resolution)."""
+        with patch("builtins.open", side_effect=FileNotFoundError()):
+            self.assertEqual(bp._load_canonical_wallets(), {})
+
+    def test_valid_file_parses(self):
+        """The normal path still maps a registered handle to its wallet."""
+        with patch("builtins.open", _fake_open_ok):
+            out = bp._load_canonical_wallets()
+        self.assertEqual(out.get("alice"), NATIVE_WALLET)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Fail closed when the canonical wallet registry can't be read (#16471)

### Problem
`scripts/bounty_payout.py` `_load_canonical_wallets()` caught **every** non-`FileNotFoundError`, printed a warning, and returned a partial/empty map:

```python
except FileNotFoundError:
    pass
except Exception as e:
    print(f"::warning::could not parse CLAIMANTS.md: {e}")
return out
```

`resolve_wallet()` documents the registry as authoritative ("**canonical registry … ALWAYS wins**"), but with an empty/partial map it silently falls through to a native wallet in the claim body, a `Wallet: <handle>` line, or the bare `claimant_login`. So a transient read/encoding/parse failure on `docs/CLAIMANTS.md` (which **exists**) could pay a **registered** contributor to a **different** destination — real money to the wrong address — while `transfer()` returns success, the issue closes, and the run exits green.

### Fix
- File **genuinely absent** (`FileNotFoundError`) → `{}` as before (no registry configured; per-claim resolution is legitimate).
- File **present but unreadable/unparseable** → raise `CanonicalRegistryError` and abort **before any transfer**, rather than misroute.

### Tests
Adds `tests/test_bounty_payout_canonical_fails_closed.py`: unreadable → raise, decode error → raise, missing → `{}`, valid → parses. All **66** payout tests pass.

### Attribution
Reported by **@Nish916** (Nishant Sinha) via the documented email fallback under bounty **#16471**. Payout is the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
