### PR TITLE
fix(gate): add weekly-cap-reached to early skip filter (closes #16711)

### DIFF
--- a/scripts/docstring_gate.py
+++ b/scripts/docstring_gate.py
@@ -212,7 +212,7 @@ def main():
         print(f"could not read {REPO}#{NUM}", file=sys.stderr)
         return 1
     labels = {l["name"] for l in iss.get("labels", [])}
-    if {"bounty-eligible", "docstring-verified", "gate-processed"} & labels:
+    if {"bounty-eligible", "docstring-verified", "gate-processed", "weekly-cap-reached"} & labels:
         print("already adjudicated; skipping")
         return 0
     title, body = iss.get("title", ""), iss.get("body") or ""

--- a/tests/test_docstring_gate.py
+++ b/tests/test_docstring_gate.py
@@ -139,3 +139,15 @@ class WeeklyCeilingTests(unittest.TestCase):
         the per-claim ceiling, so volume is unbounded without it."""
         typical_batch_rtc = 10 * dg.RATE     # 10 functions
         self.assertLess(typical_batch_rtc, dg.MAX_RTC)
+
+
+class AdjudicationSkipFilterTests(unittest.TestCase):
+    def test_weekly_cap_reached_is_in_skip_filter(self):
+        """Regression test for #16711: weekly-cap-reached must be in the early
+        skip filter alongside bounty-eligible, docstring-verified, and gate-processed
+        to avoid perpetual duplicate comment spam on cron sweeps."""
+        # Inspect main() / labels filter logic
+        import inspect
+        src = inspect.getsource(dg.main)
+        self.assertIn('"weekly-cap-reached"', src)
+        self.assertIn('{"bounty-eligible", "docstring-verified", "gate-processed", "weekly-cap-reached"}', src)


### PR DESCRIPTION
Closes #16711

### Problem
When a contributor's earnings exceed `MAX_RTC_PER_WEEK` (40 RTC), `scripts/docstring_gate.py` labels the issue with `weekly-cap-reached` and posts an explanatory comment. However, the top-level early skip check at line 215 previously only tested:
```python
if {"bounty-eligible", "docstring-verified", "gate-processed"} & labels:
    return 0
```
Because `weekly-cap-reached` was omitted from this set, subsequent scheduled cron sweeps re-adjudicated the claim on every cycle, recalculated `already + amount > MAX_RTC_PER_WEEK`, and posted duplicate comment notifications.

### Solution
- Added `"weekly-cap-reached"" to the early label skip set in `main()`.
- Added unit test in `tests/test_docstring_gate.py` verifying the filter contains the idempotency label.

### Verification
- Ran test suite:
  ```bash
  pytest tests/test_docstring_gate.py
  ```
  Result: `19 passed in 0.02s`

RTC Payout Wallet: `RTC347fc147c3619b5014cfb7815c9b741ecddf0982`